### PR TITLE
corrected bug where attendee order increments with 10. 

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -33,8 +33,8 @@ class EventAttendeesFormInline(OrderableAdmin, admin.TabularInline):
     model = EventAttendees
     fk_name = 'event'
     extra = 0
-    list_editable = ('attendee_nr',)
-    readonly_fields = ('user', 'email', 'time_registered')
+    list_editable = ('user', 'email', 'preferences')
+    readonly_fields = ('time_registered',)
     fields = ('attendee_nr', 'user', 'email', 'anonymous', 'preferences', 'time_registered')
     formfield_overrides = {
         JSONField: {'widget': PrettyJSONWidget()}

--- a/events/models.py
+++ b/events/models.py
@@ -172,7 +172,9 @@ class EventAttendees(models.Model):
 
     def save(self, *args, **kwargs):
         if self.attendee_nr is None:
-            self.attendee_nr = self.event.get_registrations().count()
+            # attendee_nr increments by 10, e.g 10,20,30,40...
+            # this is needed so the admin sorting library will work.
+            self.attendee_nr = (self.event.get_registrations().count()+1) * 10
         if self.time_registered is None:
             self.time_registered = timezone.now()
         super(EventAttendees, self).save(*args, **kwargs)


### PR DESCRIPTION
By using an external Django module to sort elements in the admin panel we are forced to increments the attendee order by 10.

This should be noted in the documentation for future use.