### PR TITLE
Add Jet-dashboard to admin page

### DIFF
--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -1,0 +1,27 @@
+from django.utils.translation import gettext_lazy as _
+from jet.dashboard import modules
+from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
+
+# For more info on Jet dashboard modules: https://django-jet-reboot.readthedocs.io/en/latest/dashboard_modules.html
+# We might want to customize this more!
+#
+# Furhtermore, there is the possibility of introducing google analytics to the website if we so wish.
+# However, a discussion should probably be had if that is even something we need/want.
+
+class CustomIndexDashboard(Dashboard):
+    columns = 2
+
+    def init_with_context(self, context):
+        self.available_children.append(modules.LinkList)
+        self.children.append(modules.AppList(
+            _('Applications'),
+            exclude=('auth.*',),
+            column=0,
+            order=0
+        ))
+        self.children.append(modules.RecentActions(
+            _('Recent Actions'),
+            10,
+            column=1,
+            order=0
+        ))

--- a/core/settings.py
+++ b/core/settings.py
@@ -44,6 +44,8 @@ ALLOWED_HOSTS = json.loads(os.environ['ALLOWED_HOSTS'])
 # Application definition
 
 INSTALLED_APPS = [
+    'jet',
+    'jet.dashboard',
     'date',
     'staticpages',
     'news',
@@ -201,6 +203,42 @@ USE_TZ = True
 DECIMAL_INPUT_FORMATS = ()
 
 DATE_INPUT_FORMATS = ('%d.%m.%Y', '%Y-%m-%d')
+
+JET_INDEX_DASHBOARD = 'core.dashboard.CustomIndexDashboard'
+
+# Custom themes can be added to static/jet/css/themes, can be modeled after, for example, 'light-violet'
+JET_THEMES = [
+    {
+        'theme': 'default', # theme folder name
+        'color': '#47bac1', # color of the theme's button in user menu
+        'title': 'Default' # theme title
+    },
+    {
+        'theme': 'green',
+        'color': '#44b78b',
+        'title': 'Green'
+    },
+    {
+        'theme': 'light-green',
+        'color': '#2faa60',
+        'title': 'Light Green'
+    },
+    {
+        'theme': 'light-violet',
+        'color': '#a464c4',
+        'title': 'Light Violet'
+    },
+    {
+        'theme': 'light-blue',
+        'color': '#5EADDE',
+        'title': 'Light Blue'
+    },
+    {
+        'theme': 'light-gray',
+        'color': '#222',
+        'title': 'Light Gray'
+    }
+]
 
 
 # Static files (CSS, JavaScript, Images)

--- a/core/urls.py
+++ b/core/urls.py
@@ -26,6 +26,8 @@ app_name = 'core'
 
 urlpatterns = [
     path('', date.index, name='index'),
+    path('jet/', include('jet.urls', 'jet')),  # Django JET URLS
+    path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),  # Django JET dashboard URLS
     path('news/', include('news.urls')),
     path('members/', include('django.contrib.auth.urls')),
     path('members/', include('members.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ django-tables2
 django-filter
 django-bootstrap3
 django_cleanup
+django-jet-reboot
+#google-api-python-client==1.4.1


### PR DESCRIPTION
Implemented Jet-dashboard for the `/admin` page, this should probably be tested a bit more thoroughly. Maybe we use Styssen as test-animals?
It is possible to implement Google analytics, but do we even need it?