### PR TITLE
Change supporting memeber color on cert page

### DIFF
--- a/members/static/members/css/certificate.css
+++ b/members/static/members/css/certificate.css
@@ -21,6 +21,10 @@
     background-color: rgb(141, 31, 31);
 }
 
+.supporting {
+    background-color: orange;
+}
+
 
 .checkmark {
     position: absolute;

--- a/members/templates/certificate.html
+++ b/members/templates/certificate.html
@@ -18,7 +18,7 @@
                         {% if user.membership_type != 3 %}
                             <div class="validation valid">
                         {% else %}
-                            <div class="validation invalid">
+                            <div class="validation supporting">
                         {% endif %}
                                 <h3 style="margin: 0;">Datateknologerna</h3>
                                 <div id="clock-wrapper"></div>


### PR DESCRIPTION
Title says it all, changed supporting memebers color to 
![image](https://user-images.githubusercontent.com/55868268/225711505-29a7ad7f-aafb-4c45-a66e-7efaa7283b6e.png)

Closes https://github.com/Datateknologerna-vid-Abo-Akademi/date-website/issues/303