### PR TITLE
Stop event month text from wrapping on big screens

### DIFF
--- a/events/static/events/css/event-card.css
+++ b/events/static/events/css/event-card.css
@@ -42,3 +42,7 @@
     background-color: inherit;
     box-shadow: none;
   }
+
+.event-date-txt{
+  white-space: nowrap;
+}

--- a/events/templates/events/index.html
+++ b/events/templates/events/index.html
@@ -23,7 +23,7 @@
                                             <div class="display-4">
                                                 <span class="badge">{{ event.event_date_start|date:"d" }}</span>
                                             </div>
-                                            <div class="display-4">
+                                            <div class="display-4 event-date-txt">
                                                 {{ event.event_date_start|date:"M" }}
                                             </div>
                                         </div>


### PR DESCRIPTION
Add css rule to stop the responsive font resizing from causing the date start month text (eg. "Oct") from wrapping on larger viewport sizes on events page.