### PR TITLE
Kk/minor fixes (#374)

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -15,7 +15,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.slim.min.js"></script>
-    <script src="https://kit.fontawesome.com/d9427d2408.js" crossorigin="anonymous"></script>
+    <script src="https://kit.fontawesome.com/3d69069a71.js" crossorigin="anonymous"></script>
 </head>
 
 {% include 'header.html' %}

--- a/events/admin.py
+++ b/events/admin.py
@@ -98,6 +98,7 @@ class EventAdmin(admin.ModelAdmin):
         context = self.admin_site.each_context(request)
         event = self.get_object(request, event_id)
         context['event'] = event
+        context["form"] = [x.name for x in event.get_registration_form()][::-1]
         return TemplateResponse(
             request,
             'events/list.html',

--- a/events/static/events/css/event-card.css
+++ b/events/static/events/css/event-card.css
@@ -42,3 +42,7 @@
     background-color: inherit;
     box-shadow: none;
   }
+
+.event-date-txt{
+  white-space: nowrap;
+}

--- a/events/templates/events/index.html
+++ b/events/templates/events/index.html
@@ -23,7 +23,7 @@
                                             <div class="display-4">
                                                 <span class="badge">{{ event.event_date_start|date:"d" }}</span>
                                             </div>
-                                            <div class="display-4">
+                                            <div class="display-4 event-date-txt">
                                                 {{ event.event_date_start|date:"M" }}
                                             </div>
                                         </div>

--- a/events/templates/events/list.html
+++ b/events/templates/events/list.html
@@ -27,7 +27,7 @@
                 <th>E-mail<img class="remove-column" src="/static/admin/img/icon-deletelink.svg" alt="Remove"></th>
                 {# Had to use first attendee as example in order to get correct order for column headers #}
                 {# TODO:Get preferences eg. with a model property #}
-                {% for header, value in event.get_registrations.0.preferences.items %}
+                {% for header in form %}
                     <th>{{ header }}<img class="remove-column" src="/static/admin/img/icon-deletelink.svg" alt="Remove">
                     </th>
                 {% endfor %}
@@ -43,14 +43,14 @@
                     <td>{{ forloop.counter }}</td>
                     <td>{{ attendee.user }}</td>
                     <td>{{ attendee.email }}</td>
-                    {% for key, value in attendee.preferences.items %}
+                    {% for key in form %}
                         <td>
                             {% if value is True %}
                                 <img src="/static/admin/img/icon-yes.svg" alt="True">
                             {% elif value is False %}
                                 <img src="/static/admin/img/icon-no.svg" alt="True">
                             {% else %}
-                                {{ value }}
+                                {{ attendee|get_preference:key }}
                             {% endif %}
                         </td>
                     {% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pillow
 python-dateutil
 icalendar
 django-ical
-django-admin-ordering
+django-admin-ordering==0.16.1
 whitenoise
 channels
 channels_redis


### PR DESCRIPTION
* Stop event month text from wrapping on big screens

Add css rule to stop the responsive font resizing from causing the date start month text (eg. "Oct") from wrapping on larger viewport sizes on events page.

* change fontawesome kit to datedatorer owned

* Lock django-admin-ordering because broken jquery update (#370)

* Fix event detail page

---------