### PR TITLE
Fix/280 fix clean up the spaghetti in eventsviewspy

### DIFF
--- a/events/tests.py
+++ b/events/tests.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -10,23 +11,28 @@ class EventTestCase(TestCase):
     def setUp(self):
         self.member = Member.objects.create(username='Test', password='test', is_superuser=True)
 
+        now = timezone.now()
+        yesterday = now - timezone.timedelta(days=1)
+        two_days_ago = now - timezone.timedelta(days=2)
+        tomorrow = now + timezone.timedelta(days=1)
+
         # Create past and future events for testing
         self.past_event1 = Event.objects.create(
             title='Past Event 1',
             slug='past-event-1',
-            event_date_end=timezone.now() - timezone.timedelta(days=2),
+            event_date_end=two_days_ago,
             author_id=self.member.id
         )
         self.past_event2 = Event.objects.create(
             title='Past Event 2',
             slug='past-event-2',
-            event_date_end=timezone.now() - timezone.timedelta(days=1),
+            event_date_end=yesterday,
             author_id=self.member.id
         )
         self.future_event = Event.objects.create(
             title='Future Event',
             slug='future-event',
-            event_date_end=timezone.now() + timezone.timedelta(days=1),
+            event_date_end=tomorrow,
             author_id=self.member.id
         )
         self.event = Event.objects.create(title='Test event',

--- a/events/tests.py
+++ b/events/tests.py
@@ -1,14 +1,12 @@
-import datetime
-from django.contrib import auth
-from django.test import Client, TestCase, RequestFactory
+import logging
+from unittest.mock import patch
+
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from events.forms import PasscodeForm
-from events.models import Event
-from events.views import EventDetailView
+from events.models import Event, EventRegistrationForm
 from members.models import Member, ORDINARY_MEMBER, Subscription, SubscriptionPayment
-import logging
 
 logger = logging.getLogger('date')
 
@@ -31,8 +29,6 @@ class EventTestCase(TestCase):
             is_active=True,
         )
 
-
-
         subscription = Subscription.objects.create(
             name="Basic Subscription",
             does_expire=True,
@@ -52,15 +48,15 @@ class EventTestCase(TestCase):
         self.event = Event.objects.create(title='Test event',
                                           slug='test',
                                           author_id=self.member.id,
-                                          sign_up_deadline=(timezone.now() + timezone.timedelta(1))
+                                          sign_up_deadline=(timezone.now() + timezone.timedelta(days=7))
                                           )
+        self.content = {'user': 'person', 'email': 'person@test.com'}
         self.assertIsNotNone(self.event)
         self.assertTrue(self.event.published)
 
     def test_attending_event(self):
         c = Client()
-        response = c.post(reverse('events:detail', args=[self.event.slug]),
-                          {'user': 'person', 'email': 'person@test.com'}, follow=True)
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
         self.assertEqual(response.redirect_chain[0][1], 302)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event.get_registrations().count(), 1)
@@ -68,13 +64,11 @@ class EventTestCase(TestCase):
     def test_duplicate_attendance(self):
         self.assertEqual(self.event.get_registrations().count(), 0)
         c = Client()
-        response = c.post(reverse('events:detail', args=[self.event.slug]),
-                          {'user': 'person', 'email': 'person@test.com'}, follow=True)
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
         self.assertEqual(response.redirect_chain[0][1], 302)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event.get_registrations().count(), 1)
-        response = c.post(reverse('events:detail', args=[self.event.slug]),
-                          {'user': 'person', 'email': 'person@test.com'})
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
         # Expect bad request status 400 since duplicate attendance not allowed
         self.assertEqual(response.status_code, 400)
         self.assertEqual(self.event.get_registrations().count(), 1)
@@ -84,7 +78,7 @@ class EventTestCase(TestCase):
         self.assertEqual(self.event.get_registrations().count(), 0)
         c = Client()
         response = c.post(reverse('events:detail', args=[self.event.slug]),
-                          {'user': 'person2', 'email': 'person2@test.com'}, follow=True)
+                          {'user': 'person', 'email': 'person@test.com'}, follow=True)
         self.assertEqual(response.redirect_chain[0][1], 302)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event.get_registrations().count(), 1)
@@ -92,22 +86,36 @@ class EventTestCase(TestCase):
     def test_form_validation(self):
         self.assertEqual(self.event.get_registrations().count(), 0)
         c = Client()
-        response = c.post(reverse('events:detail', args=[self.event.slug]),
-                          {'user': 'person3', 'email': 'no-email-provided'})
+        self.content['email'] = 'no-email-provided'
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(self.event.get_registrations().count(), 0)
 
     def test_member_registration(self):
-        event = Event.objects.create(title='Test event number 2', slug='test_member_registration',
-                                     sign_up_members=timezone.now(),
-                                     sign_up_others=timezone.now() + timezone.timedelta(days=7),
-                                     author_id=self.member.id)
-        self.assertIsNotNone(event)
+        self.event.sign_up_members = timezone.now()
+        self.event.sign_up_others = timezone.now() + timezone.timedelta(days=5)
+        self.event.save()
+        self.assertIsNotNone(self.event)
         c = Client()
-        response = c.post(reverse('events:detail', args=[event.slug]), {'user': 'person4', 'email': 'person4@test.com'})
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(event.get_registrations().count(), 0)
-        # Can not test registration with testuser because auth backend is linked with an external source
+        self.assertEqual(self.event.get_registrations().count(), 0)
+
+    def test_member_registration_with_subscription(self):
+        self.event.sign_up_members = timezone.now() - timezone.timedelta(days=1)
+        self.event.sign_up_others = timezone.now() + timezone.timedelta(days=1)
+        self.event.save()
+        c = Client()
+        c.login(username=self.member.username, password='test')
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
+        self.assertIsNotNone(self.event.sign_up_members)
+        self.assertEqual(response.status_code, 200)
+
+        self.event.sign_up_members = timezone.now() + timezone.timedelta(days=1)
+        self.event.save()
+        self.content['email'] = 'person2@test.com'
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
+        self.assertEqual(response.status_code, 403)
 
     def test_get_event_feed(self):
         c = Client()
@@ -127,81 +135,134 @@ class EventTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_past_deadline(self):
-        event = Event.objects.create(title='Test event number 4', slug='test_past_deadline',
-                                     sign_up_deadline=timezone.now(),
-                                     author_id=self.member.id)
-        self.assertIsNotNone(event)
-        c = Client(enforce_csrf_checks=False)
-        response = c.post(reverse('events:detail', args=[event.slug]), {'user': 'person6', 'email': 'person6@test.com'})
+        self.event.sign_up_deadline = timezone.now()
+        self.event.save()
+        self.assertIsNotNone(self.event)
+        c = Client()
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(event.get_registrations().count(), 0)
+        self.assertEqual(self.event.get_registrations().count(), 0)
 
     def test_event_detail_view_with_and_without_passcode(self):
         self.event.passcode = 'secret'
         self.event.save()
-
-        response = self.client.post(reverse('events:detail', args=[self.event.slug]), {'passcode': 'wrong'})
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "invalid passcode")
-
-        response_with_passcode = self.client.post(reverse('events:detail', args=[self.event.slug]),
-                                                  {'passcode': 'secret'})
-        self.assertEqual(response_with_passcode.status_code, 200)
-        self.assertNotContains(response_with_passcode, "invalid passcode")
-
-    def test_sign_up_members_with_subscription(self):
-        event = Event.objects.create(
-            title='Test event members with subscription',
-            slug='test_members',
-            author_id=self.member.id,
-            sign_up_members=timezone.now() - timezone.timedelta(days=1),
-            sign_up_others=timezone.now() + timezone.timedelta(days=1),
-            sign_up_deadline=timezone.now() + timezone.timedelta(days=1)
-        )
         c = Client()
-        c.login(username=self.member.username, password='test')
-        response = c.post(reverse('events:detail', args=[event.slug]),
-                          {'user': 'person', 'email': 'person@test.com'}, follow=True)
-        self.assertIsNotNone(event.sign_up_members)
-        self.assertEqual(response.status_code, 200)
-
-        # Change the sign_up_members to a date in the past
-        event.sign_up_members = timezone.now() + timezone.timedelta(days=1)
-        event.save()
-
-        response = c.post(reverse('events:detail', args=[event.slug]),
-                          {'user': 'person', 'email': 'person2@test.com'}, follow=True)
-        # The sign up should fail
-        self.assertEqual(response.status_code, 403)
+        wrong, right = {'passcode': 'wrong'}, {'passcode': 'secret'}
+        incorrect = c.post(reverse('events:detail', args=[self.event.slug]), wrong)
+        self.assertEqual(incorrect.status_code, 200)
+        self.assertContains(incorrect, "invalid passcode")
+        correct = c.post(reverse('events:detail', args=[self.event.slug]), right)
+        self.assertEqual(correct.status_code, 200)
+        self.assertNotContains(correct, "invalid passcode")
 
     def test_sign_up_members_before_sign_up_open(self):
-        event = Event.objects.create(
-            title='Test event members before sign up open',
-            slug='test_members_before',
-            author_id=self.member.id,
-            sign_up_members=timezone.now() + timezone.timedelta(days=1),
-            sign_up_others=timezone.now() + timezone.timedelta(days=1),
-            sign_up_deadline=timezone.now() + timezone.timedelta(days=1)
-        )
+        self.event.sign_up_members = timezone.now() + timezone.timedelta(days=1)
+        self.event.sign_up_others = timezone.now() + timezone.timedelta(days=1)
+        self.event.save()
         c = Client()
         c.login(username=self.member.username, password='test')
-        response = c.post(reverse('events:detail', args=[event.slug]),
-                          {'user': 'person', 'email': 'person@test.com'})
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
         self.assertEqual(response.status_code, 403)
 
     def test_sign_up_members_without_subscription(self):
-        event = Event.objects.create(
-            title='Test event members without subscription',
-            slug='test_members_without',
-            author_id=self.member.id,
-            sign_up_members=timezone.now() - timezone.timedelta(days=1),
-            sign_up_others=timezone.now() + timezone.timedelta(days=1),
-            sign_up_deadline=timezone.now() + timezone.timedelta(days=1)
-        )
+        self.event.sign_up_members = timezone.now() - timezone.timedelta(days=1)
+        self.event.sign_up_others = timezone.now() + timezone.timedelta(days=1)
+        self.event.save()
         self.subpay.delete()
-        self.assertIsNotNone(event.sign_up_members)
         c = Client()
         c.login(username=self.member.username, password='test')
-        response = c.post(reverse('events:detail', args=[event.slug]),
-                          {'user': 'person', 'email': 'person@test.com'}, follow=True)
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
         self.assertEqual(response.status_code, 403)
+
+    def test_avec_data_posting(self):
+        self.event.sign_up_avec = True
+        self.event.save()
+        c = Client()
+        avec_data = {'avec': 'on', 'avec_user': 'Avec Person', 'avec_email': 'avec@test.com'}
+        self.content.update(avec_data)
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
+        self.assertEqual(response.status_code, 200)
+        person_registration = self.event.get_registrations().first()
+        self.assertEqual(person_registration.user, 'person')
+        self.assertEqual(person_registration.email, 'person@test.com')
+        avec_registration = self.event.get_registrations().last()
+        self.assertIsNotNone(avec_registration)
+        self.assertEqual(avec_registration.user, 'Avec Person')
+        self.assertEqual(avec_registration.email, 'avec@test.com')
+
+    def test_redirect_link(self):
+        self.event.redirect_link = 'https://www.google.com'
+        self.event.save()
+        c = Client()
+        response = c.get(reverse('events:detail', args=[self.event.slug]))
+        logger.debug(response.status_code)
+        logger.debug(response.content)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers['Location'], 'https://www.google.com')
+
+    def test_anonymous_attendance(self):
+        c = Client()
+        self.content['anonymous'] = 'on'
+        c.post(reverse('events:detail', args=[self.event.slug]), self.content)
+        details = c.get(reverse('events:detail', args=[self.event.slug]))
+        self.assertEqual(self.event.get_registrations().last().anonymous, True)
+        self.assertContains(details, '<i>Anonymt</i>', count=1)
+
+    def test_custom_fields(self):
+        EventRegistrationForm(event=self.event, choice_number=1, name='field1',
+                              type='text', required=False, public_info=True).save()
+        EventRegistrationForm(event=self.event, choice_number=2, name='field2',
+                              type='select', required=False, public_info=True,
+                              choice_list='choice 1,choice 2,choice 3').save()
+        EventRegistrationForm(event=self.event, choice_number=3, name='field3',
+                              type='checkbox', required=False, public_info=True).save()
+
+        c = Client()
+        response = c.get(reverse('events:detail', args=[self.event.slug]))
+        self.assertNotContains(response, 'Test value')
+        self.assertContains(response, 'choice 2', count=2)
+        self.assertNotContains(response, '<td>True</td>')
+
+        choices = {'field1': 'Test value', 'field2': 'choice 2', 'field3': 'on'}
+        self.content.update(choices)
+        c.post(reverse('events:detail', args=[self.event.slug]), self.content)
+        response = c.get(reverse('events:detail', args=[self.event.slug]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test value', count=1)
+        self.assertContains(response, 'choice 2', count=3)
+        self.assertContains(response, '<td>True</td>', count=1)
+
+    def test_max_participants(self):
+        self.event.sign_up_max_participants = 1
+        self.event.save()
+        c = Client()
+
+        c.post(reverse('events:detail', args=[self.event.slug]), self.content)
+        self.content['email'] = 'person2@test.com'
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.event.get_registrations().count(), 2)
+
+    @patch('events.views.validate_captcha')
+    @override_settings(CAPTCHA_SITE_KEY='test', TURNSTILE_SECRET_KEY='test')
+    def test_captcha(self, mock_validate_captcha):
+        mock_validate_captcha.return_value = False
+        self.event.captcha = True
+        self.event.save()
+
+        c = Client()
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.event.get_registrations().count(), 0)
+
+        mock_validate_captcha.return_value = True
+        content = {'user': 'person', 'email': 'person@test.com', 'cf-turnstile-response': 'test'}
+        response = c.post(reverse('events:detail', args=[self.event.slug]), content, follow=True)
+        mock_validate_captcha.assert_called()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.event.get_registrations().count(), 1)
+

--- a/events/tests.py
+++ b/events/tests.py
@@ -3,12 +3,41 @@ from django.urls import reverse
 from django.utils import timezone
 
 from events.models import Event
-from members.models import Member
+from members.models import Member, ORDINARY_MEMBER, Subscription, SubscriptionPayment
 
 
 class EventTestCase(TestCase):
     def setUp(self):
-        self.member = Member.objects.create(username='Test', password='test', is_superuser=True)
+        self.member = Member.objects.create(
+            username="testuser",
+            email="testuser@example.com",
+            first_name="Test",
+            last_name="User",
+            phone="123456789",
+            address="123 Test Street",
+            zip_code="00000",
+            city="Test City",
+            country="Finland",
+            membership_type=ORDINARY_MEMBER,  # Using one of your defined membership types
+            is_superuser=True
+        )
+
+        subscription = Subscription.objects.create(
+            name="Basic Subscription",
+            does_expire=True,
+            renewal_scale="year",
+            renewal_period=1,
+            price=100.00
+        )
+
+        SubscriptionPayment.objects.create(
+            member=self.member,
+            subscription=subscription,
+            date_paid=timezone.now(),
+            date_expires=timezone.now() + timezone.timedelta(days=365),
+            amount_paid=100.00
+        )
+
         self.event = Event.objects.create(title='Test event',
                                           slug='test',
                                           author_id=self.member.id,

--- a/events/tests.py
+++ b/events/tests.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -10,31 +9,6 @@ from members.models import Member
 class EventTestCase(TestCase):
     def setUp(self):
         self.member = Member.objects.create(username='Test', password='test', is_superuser=True)
-
-        now = timezone.now()
-        yesterday = now - timezone.timedelta(days=1)
-        two_days_ago = now - timezone.timedelta(days=2)
-        tomorrow = now + timezone.timedelta(days=1)
-
-        # Create past and future events for testing
-        self.past_event1 = Event.objects.create(
-            title='Past Event 1',
-            slug='past-event-1',
-            event_date_end=two_days_ago,
-            author_id=self.member.id
-        )
-        self.past_event2 = Event.objects.create(
-            title='Past Event 2',
-            slug='past-event-2',
-            event_date_end=yesterday,
-            author_id=self.member.id
-        )
-        self.future_event = Event.objects.create(
-            title='Future Event',
-            slug='future-event',
-            event_date_end=tomorrow,
-            author_id=self.member.id
-        )
         self.event = Event.objects.create(title='Test event',
                                           slug='test',
                                           author_id=self.member.id,
@@ -121,10 +95,3 @@ class EventTestCase(TestCase):
         response = c.post(reverse('events:detail', args=[event.slug]), {'user': 'person6', 'email': 'person6@test.com'})
         self.assertEqual(response.status_code, 403)
         self.assertEqual(event.get_registrations().count(), 0)
-
-    def test_past_events_order(self):
-        today = timezone.now().date()
-        past_events = Event.objects.filter(event_date_end__lte=today).order_by('-event_date_end')
-        self.assertEqual(len(past_events), 2)
-        self.assertEqual(past_events[0], self.past_event2)
-        self.assertEqual(past_events[1], self.past_event1)

--- a/events/views.py
+++ b/events/views.py
@@ -133,6 +133,7 @@ class EventDetailView(DetailView):
                 return self.process_signup_form(form, request)
 
             return self.form_invalid(form)
+        return HttpResponseForbidden()
 
     def process_signup_form(self, form, request):
         public_info = self.object.get_registration_form_public_info()

--- a/events/views.py
+++ b/events/views.py
@@ -154,8 +154,23 @@ class EventDetailView(DetailView):
         avec_data.update({key.split('avec_')[1]: cleaned_data[key] for key in avec_keys})
         self.add_attendance(avec_data)
 
-    def add_attendance(self, data):
-        return self.get_object().add_event_attendance(**data)
+    def add_attendance(self, form_data):
+        # Extract necessary data from form_data
+        user = form_data.get('user')
+        email = form_data.get('email')
+        anonymous = form_data.get('anonymous', False)
+
+        # Extract avec_for if it's present in form_data
+        avec_for = form_data.get('avec_for')
+
+        # The rest of the form_data can be considered as preferences
+        # Exclude the already extracted keys
+        preferences = {key: value for key, value in form_data.items() if
+                       key not in ['user', 'email', 'anonymous', 'avec_for']}
+
+        # Call add_event_attendance with the extracted data
+        return self.get_object().add_event_attendance(user=user, email=email, anonymous=anonymous,
+                                                      preferences=preferences, avec_for=avec_for)
 
 
 def date_25(request):

--- a/events/views.py
+++ b/events/views.py
@@ -1,10 +1,8 @@
 import datetime
 import logging
 
-from asgiref.sync import async_to_sync
-from channels.layers import get_channel_layer
 from django.conf import settings
-from django.http import HttpResponseForbidden, HttpResponse
+from django.http import HttpResponseForbidden
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.views.generic import DetailView, ListView

--- a/events/websocket_utils.py
+++ b/events/websocket_utils.py
@@ -1,0 +1,39 @@
+import json
+import logging
+from websocket._exceptions import WebSocketBadStatusException
+from websocket import create_connection
+from core import settings
+
+logger = logging.getLogger('date')
+
+
+def ws_send(request, form, public_info):
+    ws_schema = 'ws' if settings.DEVELOP else 'wss'
+    url = request.META.get('HTTP_HOST')
+    path = f'{ws_schema}://{url}/ws{request.path}'
+    ws = None
+    try:
+        ws = create_connection(path)
+        ws.send(json.dumps(ws_data(form.cleaned_data, public_info)))
+        if 'avec' in form.cleaned_data:
+            avec_data = form.cleaned_data.copy()
+            avec_user = form.cleaned_data.get('avec_user')
+            if avec_user:
+                avec_data['user'] = avec_user
+                ws.send(json.dumps(ws_data(avec_data, '')))
+    except WebSocketBadStatusException as e:
+        logger.error(f"WebSocket connection error: {e}")
+    finally:
+        if ws:
+            ws.close()
+
+
+def ws_data(cleaned_data, public_info):
+    data = {'user': "Anonymous" if cleaned_data['anonymous'] else cleaned_data['user']}
+
+    # Parse the public info and only send that through websockets.
+    for info in public_info:
+        if info in cleaned_data:
+            data[info] = cleaned_data[info]
+
+    return {"data": data}

--- a/events/websocket_utils.py
+++ b/events/websocket_utils.py
@@ -1,5 +1,5 @@
 import logging
-from copy import copy
+from copy import deepcopy
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -13,7 +13,7 @@ def ws_send(request, form, public_info):
                                             {"type": "event_message", **ws_data(form, public_info)})
     # Send ws again if avec
     if dict(form.cleaned_data).get('avec'):
-        newform = copy(form)
+        newform = deepcopy(form)
         newform.cleaned_data['user'] = dict(newform.cleaned_data).get('avec_user')
         public_info = ''
         async_to_sync(channel_layer.group_send)(f"event_{request.path.split('/')[-2]}",


### PR DESCRIPTION
Check `avec_data = form.cleaned_data.copy()` and if it needs deepcopy or not. The functionality should basically be the same otherwise.

Closes #280 