### PR TITLE
Flag remains as unsolved forever if ctf ends before it gets solved

### DIFF
--- a/ctf/views.py
+++ b/ctf/views.py
@@ -70,8 +70,8 @@ def flag(request, ctf_slug, flag_slug):
                     if flag_query.exists():
                         flag_instance = flag_query.first()
                         request.session['flag_valid'] = True
-                        if user_solved or flag_instance.solver:
-                            # User has already solved a flag or flag is already solved
+                        if user_solved or flag_instance.solver or ctf.ctf_ended():
+                            # User has already solved a flag or flag is already solved or ctf has ended
                             Guess.objects.create(ctf=ctf, flag=flag_instance, user=request.user, guess=flag_input,
                                                  correct=True)
                             return redirect(request.path)


### PR DESCRIPTION
Currently there is no check that the ctf is still open when submitting a guess. This change makes it so that users can't be added as a solvers to unsolved flags after the ctf ends even though the input is correct. Important as the correct solutions eventually get revealed after the ctf ends.