### PR TITLE
Improve the live attendee list

### DIFF
--- a/static/common/js/live-attendee-list.js
+++ b/static/common/js/live-attendee-list.js
@@ -6,21 +6,27 @@ $(function() {
     let socket = new WebSocket(ws_scheme + '://' + window.location.host + '/ws' + window.location.pathname);
 
     socket.onmessage = function(e) {
-        let data = JSON.parse(e.data);
-        data = data.data;
+        const { fields, anonymous } = JSON.parse(e.data).data;
 
-        let list = $('#attendees tbody');
+        const list = $('#attendees tbody');
         $('#attendees-header').css("display", "table-row");
         $('#no-attendee').css("display", "none");
 
-        if(data) {
-            let attendee = '<tr><td>' + list[0].childElementCount + '</td>';
-            for (let key in data) {
-                if (!data.hasOwnProperty(key)) continue;
-                attendee += '<td>' + data[key] + '</td>';
+        if (fields) {
+            // includes header row and is thus equivalent to current amount of attendees + 1
+            const attendeeNumber = list.children().length;
+            const row = $('<tr>');
+            row.append($('<td>').text(attendeeNumber));
+            for (const [field, value] of fields) {
+                const cell = $('<td>');
+                // names of anonymous attendees use <i>
+                if (field === "user" && anonymous)
+                    cell.append($('<i>').text(value))
+                else
+                    cell.text(value);
+                row.append(cell);
             }
-            attendee += '</tr>';
-            list.append(attendee);
+            list.append(row);
         }
     };
     socket.onclose = function(e) {


### PR DESCRIPTION
This PR fixes an XSS vulnerability in the live attendee list caused by lack of input sanitization, and makes the created table row match the event details template more closely. This is done by translating and adding `<i>` elements to the names of anonymous attendees as well as ensuring fields are output in the same order as in the template.