### PR TITLE
Set celery concurrency to 2 to preserve memory

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
   celery:
     restart: always
     image: ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}
-    command: celery -A core worker -l info
+    command: celery -A core worker -l info -c 2
     environment:
       - DEBUG=${DATE_DEBUG}
       - EMAIL_HOST=${EMAIL_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   celery:
     restart: unless-stopped
     build: .
-    command: celery -A core worker -l info
+    command: celery -A core worker -l info -c 2
     volumes:
       - .:/code
     environment:


### PR DESCRIPTION
Currently celery starts as many tasks as there is CPU cores, each task uses memory so we can save quite a lot by starting less tasks. 

Celery currently has almost no traffic and none of it is long running or time-critical. May need to be looked at in the future, but for now 2 should be adequate. 