### PR TITLE
Fix issue 722

### DIFF
--- a/templates/common/events/arsfest.html
+++ b/templates/common/events/arsfest.html
@@ -90,9 +90,9 @@
                     {% elif event.registation_past_due %}
                         <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                     {% elif not event.registation_past_due and user.is_authenticated %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                     {% else %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                     {% endif %}
                 </div>
                 <div id="anmalda" class="content ball-content anmalda hidden">

--- a/templates/common/events/baal_anmalan.html
+++ b/templates/common/events/baal_anmalan.html
@@ -23,9 +23,9 @@
                 {% elif event.registation_past_due %}
                     <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                 {% elif not event.registation_past_due and user.is_authenticated %}
-                    <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                    <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                 {% else %}
-                    <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                    <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/common/events/baal_detail.html
+++ b/templates/common/events/baal_detail.html
@@ -57,9 +57,9 @@
                     {% elif event.registation_past_due %}
                         <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                     {% elif not event.registation_past_due and user.is_authenticated %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                     {% else %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                     {% endif %}
                 </div>
                 <div id="anmalda" class="content baal-content anmalda hidden">

--- a/templates/common/events/detail.html
+++ b/templates/common/events/detail.html
@@ -41,9 +41,9 @@
                         {% elif event.registation_past_due %}
                             <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                         {% elif not event.registation_past_due and user.is_authenticated %}
-                            <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                            <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                         {% else %}
-                            <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                            <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                         {% endif %}
                     </div>
                     <div class="content overflow-auto">

--- a/templates/common/events/kk100_detail.html
+++ b/templates/common/events/kk100_detail.html
@@ -58,9 +58,9 @@
                     {% elif event.registation_past_due %}
                         <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                     {% elif not event.registation_past_due and user.is_authenticated %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                     {% else %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                     {% endif %}
                 </div>
                 <div id="anmalda" class="content baal-content anmalda hidden">

--- a/templates/common/events/registering.html
+++ b/templates/common/events/registering.html
@@ -6,7 +6,7 @@
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 </head>
 
-<p>{% trans "Anmälan stängs om " %}{{ event.sign_up_deadline | timeuntil }}</p>
+<p>{% trans "Anmälan stängs" %} {{ event.sign_up_deadline|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_deadline | timeuntil }}</p>
 <small>{% trans "OBS!" %} {% trans "Anmälningen är bindande om inget annat meddelas." %} <br>
     {% trans "Kom ihåg att avanmäla dig så snabbt som möjligt i fall du stöter på förhinder." %}</small>
 {% if form.errors %}

--- a/templates/common/events/tomtejakt.html
+++ b/templates/common/events/tomtejakt.html
@@ -302,9 +302,9 @@
                     {% elif event.registation_past_due %}
                         <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                     {% elif not event.registation_past_due and user.is_authenticated %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                     {% else %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                     {% endif %}
                 </div>
                 <div class="content overflow-auto">

--- a/templates/common/events/wappmiddag.html
+++ b/templates/common/events/wappmiddag.html
@@ -58,9 +58,9 @@
                     {% elif event.registation_past_due %}
                         <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                     {% elif not event.registation_past_due and user.is_authenticated %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                     {% else %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                     {% endif %}
                 </div>
                 <div id="anmalda" class="content baal-content anmalda hidden">

--- a/templates/on/events/arsfest.html
+++ b/templates/on/events/arsfest.html
@@ -82,9 +82,9 @@
                     {% elif event.registation_past_due %}
                         <h4 id="no-registration">{% trans "Anmälningstiden gick ut för" %} {{ event.sign_up_deadline | timesince }} {% trans 'sedan' %}</h4>
                     {% elif not event.registation_past_due and user.is_authenticated %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_members | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_members|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_members | timeuntil }}</p>
                     {% else %}
-                        <p>{% trans "Anmälan öppnas om " %}{{ event.sign_up_others | timeuntil }}</p>
+                        <p>{% trans "Anmälan öppnas" %} {{ event.sign_up_others|date:"j.n H:i" }}, {% trans "om" %} {{ event.sign_up_others | timeuntil }}</p>
                     {% endif %}
                 </div>
                 <div id="anmalda" class="content baal-content anmalda hidden">


### PR DESCRIPTION
## Summary
- show the exact date in event sign-up countdown messages
- keep the remaining time after the date
- fix ÖN arsfest template

## Testing
- `pip install -r requirements.txt`
- `date-test` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489ed411988324a871c11a4690aa42