### PR TITLE
Issue-441: Add audit log to admin

### DIFF
--- a/date/admin.py
+++ b/date/admin.py
@@ -1,0 +1,30 @@
+from django.contrib import admin
+from django.contrib.admin.models import LogEntry
+
+
+@admin.register(LogEntry)
+class LogEntryAdmin(admin.ModelAdmin):
+    """Read-only display of admin actions for audit logging."""
+
+    date_hierarchy = "action_time"
+    list_display = (
+        "action_time",
+        "user",
+        "content_type",
+        "object_repr",
+        "action_flag",
+        "change_message",
+    )
+    list_filter = ("user", "content_type", "action_flag")
+    search_fields = ("object_repr", "change_message")
+    ordering = ("-action_time",)
+    readonly_fields = list_display
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/date/tests.py
+++ b/date/tests.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.admin.models import LogEntry, ADDITION
+
+
+class AuditLogTestCase(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_superuser(
+            username="admin",
+            password="pass",
+            email="admin@example.com",
+        )
+        ct = ContentType.objects.get_for_model(get_user_model())
+        LogEntry.objects.log_action(
+            user_id=self.user.pk,
+            content_type_id=ct.pk,
+            object_id=self.user.pk,
+            object_repr=str(self.user),
+            action_flag=ADDITION,
+            change_message="created user",
+        )
+
+    def test_audit_log_accessible(self):
+        self.client.login(username="admin", password="pass")
+        url = reverse("admin:admin_logentry_changelist")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "created user")


### PR DESCRIPTION
## Summary
- register `LogEntry` in admin as read-only audit log
- add regression test ensuring audit log page works
- fix flake8 style warning

## Testing
- `date-test` *(fails: docker not available)*
- `python manage.py test date.tests.AuditLogTestCase.test_audit_log_accessible` *(fails: could not translate host name "db" to address)*


------
https://chatgpt.com/codex/tasks/task_e_6848a5b4633083248a937962c2e3d7f6