### PR TITLE
Implement event signup editing

### DIFF
--- a/events/migrations/0015_member_and_edit_token.py
+++ b/events/migrations/0015_member_and_edit_token.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import uuid
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0014_alter_event_sign_up_max_participants'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='eventattendees',
+            name='member',
+            field=models.ForeignKey(
+                to=settings.AUTH_USER_MODEL,
+                on_delete=django.db.models.deletion.SET_NULL,
+                null=True,
+                blank=True,
+                verbose_name='Medlem',
+            ),
+        ),
+        migrations.AddField(
+            model_name='eventattendees',
+            name='edit_token',
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+    ]

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -1,0 +1,19 @@
+from celery import shared_task
+from django.conf import settings
+from django.template.loader import render_to_string
+
+from core.utils import send_email_task
+from .models import EventAttendees
+
+
+@shared_task
+def send_edit_token_email(attendee_id: int) -> None:
+    attendee = EventAttendees.objects.get(id=attendee_id)
+    context = {
+        'TOKEN': attendee.edit_token,
+        'SITE_URL': settings.CONTENT_VARIABLES.get('SITE_URL', 'https://datateknologerna.org'),
+        'EVENT_TITLE': attendee.event.title,
+    }
+    message = render_to_string('events/edit_signup_email.txt', context)
+    subject = f"Uppdatera din anm\xe4lan till {attendee.event.title}"
+    send_email_task.delay(subject, message, settings.DEFAULT_FROM_EMAIL, [attendee.email])

--- a/events/urls.py
+++ b/events/urls.py
@@ -6,6 +6,8 @@ app_name = 'events'
 
 urlpatterns = [
     re_path(r'^$', views.IndexView.as_view(), name='index'),
+    re_path(r'^my/$', views.MySignupsView.as_view(), name='my-signups'),
+    re_path(r'^edit/(?P<token>[0-9a-f-]+)/$', views.EventEditSignupView.as_view(), name='edit-signup'),
     re_path(r'^(?P<slug>[-\w]+)/$', views.EventDetailView.as_view(), name='detail'),
     re_path(r'^feed$', feed.EventFeed(), name='feed'),
 ]

--- a/scripts/merge_events.py
+++ b/scripts/merge_events.py
@@ -22,18 +22,20 @@ source_participants = EventAttendees.objects.filter(event=source_event.id).all()
 for participant in source_participants:
     if participant.avec_for:
         target_event.add_event_attendance(
-            user= participant.user,
+            user=participant.user,
             email=participant.email,
             anonymous=participant.anonymous,
             preferences=participant.preferences,
-            avec_for=EventAttendees.objects.filter(event=target_event.id, email=participant.avec_for.email).first()
+            member=participant.member,
+            avec_for=EventAttendees.objects.filter(event=target_event.id, email=participant.avec_for.email).first(),
         )
         continue
     target_event.add_event_attendance(
-        user= participant.user,
+        user=participant.user,
         email=participant.email,
         anonymous=participant.anonymous,
-        preferences=participant.preferences
+        preferences=participant.preferences,
+        member=participant.member,
     )
     
 

--- a/templates/common/events/edit_cancelled.html
+++ b/templates/common/events/edit_cancelled.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Anm\u00e4lan borttagen' %}{% endblock %}
+{% block content %}
+<div class="container-md container-margin-top">
+  <p>{% trans 'Din anm\u00e4lan har tagits bort.' %}</p>
+</div>
+{% endblock %}

--- a/templates/common/events/edit_complete.html
+++ b/templates/common/events/edit_complete.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Anm\u00e4lan uppdaterad' %}{% endblock %}
+{% block content %}
+<div class="container-md container-margin-top">
+  <p>{% trans 'Din anm\u00e4lan har uppdaterats.' %}</p>
+</div>
+{% endblock %}

--- a/templates/common/events/edit_signup.html
+++ b/templates/common/events/edit_signup.html
@@ -1,0 +1,14 @@
+{% extends 'core/base.html' %}
+{% load i18n %}
+{% block title %}{{ attendee.event.title }}{% endblock %}
+{% block content %}
+<div class="container-md container-margin-top">
+  <h2>{% trans 'Uppdatera anm\u00e4lan' %}</h2>
+  <form method="post">
+    {{ form.as_p }}
+    <button class="button" type="submit">{% trans 'Uppdatera' %}</button>
+    <button class="button" type="submit" name="cancel" value="1">{% trans 'Avanm\u00e4l' %}</button>
+    {% csrf_token %}
+  </form>
+</div>
+{% endblock %}

--- a/templates/common/events/edit_signup_email.txt
+++ b/templates/common/events/edit_signup_email.txt
@@ -1,0 +1,10 @@
+Hej,
+
+Du kan uppdatera eller avanm\xe4la dig fr\xe5n {{ EVENT_TITLE }} genom l\xe4nken nedan:
+
+{{ SITE_URL }}/events/edit/{{ TOKEN }}/
+
+Länken fungerar fram tills avanmälningen stänger.
+
+Om du har ett konto kan du också hantera dina anmälningar här:
+{{ SITE_URL }}/events/my/

--- a/templates/common/events/my_signups.html
+++ b/templates/common/events/my_signups.html
@@ -1,0 +1,21 @@
+{% extends 'core/base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Mina anm\u00e4lningar' %}{% endblock %}
+{% block content %}
+<div class="container-md container-margin-top">
+  <h2>{% trans 'Mina anm\u00e4lningar' %}</h2>
+  {% if object_list %}
+  <ul>
+    {% for attendee in object_list %}
+      <li>
+        {{ attendee.event.title }} -
+        <a href="{% url 'events:edit-signup' attendee.edit_token %}">{% trans 'Uppdatera' %}</a>
+      </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>{% trans 'Du har inga anm\u00e4lningar.' %}</p>
+  {% endif %}
+  <a href="{% url 'members:info' %}" class="theme-button mt-3">{% trans 'Till kontot' %}</a>
+</div>
+{% endblock %}

--- a/templates/common/members/userinfo.html
+++ b/templates/common/members/userinfo.html
@@ -113,6 +113,7 @@
 
                 <a href="{% url 'members:password_change' %}" class="theme-button">{% trans 'Password change' %}<i class="fas fa-chevron-right"></i></a>
                 <a href="{% url 'members:functionary' %}" class="theme-button" style="margin-top: 5px;">Funktionärsposter <i class="fas fa-chevron-right"></i></a>
+                <a href="{% url 'events:my-signups' %}" class="theme-button" style="margin-top: 5px;">Mina evenemang <i class="fas fa-chevron-right"></i></a>
                 <p style="margin-top: 5px">För att ändra ditt användarnamn eller e-post, kontakta styrelsen på {{ ASSOCIATION_EMAIL }}</p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- allow editing/canceling of event signups
- email participants a link to edit their signup via new token
- add templates for editing forms
- add tests
- add user signup management page and link from account
- link event signups directly to Member for safety
- combine migrations for new fields

## Testing
- `DJANGO_SETTINGS_MODULE=core.settings.demo python manage.py test events.tests.EventTestCase.test_my_signups_view` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6269db48324b376964d85a588b0