### PR TITLE
Improve polls test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ Commit messages need to be short and descriptive. If the commit is a fix to an i
 
 Unittests are done accordingly to Django documentation: [Testing in Django](https://docs.djangoproject.com/en/2.1/topics/testing/)
 
+Running `python manage.py test` automatically uses the `core.settings.test` configuration so that the suite works without external services like Redis or PostgreSQL.
+
 ## Other tests
 
 While developing a feature, make sure it works as intended by testing it manually as well. 

--- a/core/settings/test.py
+++ b/core/settings/test.py
@@ -1,0 +1,24 @@
+from .date import *  # noqa
+
+# Use in-memory sqlite database for tests
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    }
+}
+
+# Use local memory cache to avoid Redis dependency during tests
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+
+PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']

--- a/manage.py
+++ b/manage.py
@@ -2,10 +2,12 @@
 import os
 import sys
 
-proj_name = os.environ.get("PROJECT_NAME")
-if proj_name == "":
-    proj_name = "date"
-    print("PROJECT_NAME not set, defaulting to 'date'")
+proj_name = os.environ.get("PROJECT_NAME") or "date"
+
+# When running the Django test suite we default to the test settings module.
+if "test" in sys.argv and "DJANGO_SETTINGS_MODULE" not in os.environ:
+    proj_name = "test"
+    print("Running tests with core.settings.test")
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', f'core.settings.{proj_name}')

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -1,3 +1,54 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
+from django.http import HttpResponse
+from unittest.mock import patch
 
-# Create your tests here.
+from members.models import Member, MembershipType, ORDINARY_MEMBER
+from .models import Question, Choice
+from . import views
+
+
+class QuestionModelTests(TestCase):
+    def test_get_total_votes(self):
+        question = Question.objects.create(question_text="Favourite colour?")
+        Choice.objects.create(question=question, choice_text="red", votes=3)
+        Choice.objects.create(question=question, choice_text="blue", votes=1)
+        self.assertEqual(question.get_total_votes(), 4)
+
+    def test_choice_vote_percentage(self):
+        question = Question.objects.create(question_text="Favourite colour?")
+        red = Choice.objects.create(question=question, choice_text="red", votes=3)
+        blue = Choice.objects.create(question=question, choice_text="blue", votes=1)
+        self.assertEqual(red.get_vote_percentage(), 75)
+        self.assertEqual(blue.get_vote_percentage(), 25)
+
+
+class VoteViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        membership = MembershipType.objects.get(pk=ORDINARY_MEMBER)
+        self.member = Member.objects.create_user(username="test", password="pwd", membership_type=membership)
+        self.question = Question.objects.create(question_text="Favourite colour?")
+        self.choice1 = Choice.objects.create(question=self.question, choice_text="red")
+        self.choice2 = Choice.objects.create(question=self.question, choice_text="blue")
+
+    @patch("polls.views.handle_vote")
+    def test_vote_calls_handle_vote_authenticated(self, mock_handle_vote):
+        mock_handle_vote.return_value = HttpResponse("ok")
+        request = self.factory.post(reverse("polls:vote", args=[self.question.id]), {"choice": [str(self.choice1.id), str(self.choice2.id), str(self.choice1.id)]})
+        request.user = self.member
+        response = views.vote(request, self.question.id)
+        selected = mock_handle_vote.call_args.args[3]
+        self.assertCountEqual(selected, [str(self.choice1.id), str(self.choice2.id)])
+        self.assertEqual(response.content, b"ok")
+
+    @patch("polls.views.handle_vote")
+    def test_vote_calls_handle_vote_anonymous(self, mock_handle_vote):
+        mock_handle_vote.return_value = HttpResponse("ok")
+        request = self.factory.post(reverse("polls:vote", args=[self.question.id]), {"choice": [str(self.choice1.id)]})
+        from django.contrib.auth.models import AnonymousUser
+        request.user = AnonymousUser()
+        response = views.vote(request, self.question.id)
+        selected = mock_handle_vote.call_args.args[3]
+        self.assertEqual(selected, [str(self.choice1.id)])
+        self.assertEqual(response.content, b"ok")


### PR DESCRIPTION
## Summary
- add dedicated Django test settings using in-memory DB/cache
- expand polls test suite with model and view tests
- use test settings automatically when running tests
- document test settings usage in contributing guide

## Testing
- `python manage.py test polls`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684b43b4a4048324b20db861b15cf662