### PR TITLE
Fix #720

### DIFF
--- a/archive/migrations/0007_collection_slug.py
+++ b/archive/migrations/0007_collection_slug.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('archive', '0006_auto_20221004_1958'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='collection',
+            name='slug',
+            field=models.SlugField(blank=True, max_length=50, unique=True, allow_unicode=False, verbose_name='Slug'),
+        ),
+    ]

--- a/archive/urls.py
+++ b/archive/urls.py
@@ -12,8 +12,8 @@ urlpatterns = [
     path('pictures/', login_required(views.year_index), name='years'),
     # /archive/pictures/<year>/
     path('pictures/<int:year>/', login_required(views.picture_index), name='pictures'),
-    # /archive/pictures/<year>/<Collection_id>/
-    path('pictures/<int:year>/<str:album>/', login_required(views.picture_detail), name='detail'),
+    # /archive/pictures/<year>/<slug>/
+    path('pictures/<int:year>/<slug:slug>/', login_required(views.picture_detail), name='detail'),
     # /documents/
     path('documents/', login_required(views.FilteredDocumentsListView.as_view()), name='documents'),
     path('exams/', login_required(views.exams_index), name='exams'),

--- a/templates/common/archive/picture_index.html
+++ b/templates/common/archive/picture_index.html
@@ -20,7 +20,7 @@
                     {% for collection in collections %}
                         <div class="grid-sizer"></div>
                         <div class="grid-item">
-                            <a href="{% url 'archive:detail' year collection.title %}">
+                            <a href="{% url 'archive:detail' year collection.slug %}">
                                 <div class="card" style="width: 18rem;">
                                     <img class="card-img-top gallery-image" src={{ collection.get_first_picture.image.url }}>
                                     <div class="card-body">


### PR DESCRIPTION
## Summary
- allow slashes in picture collection titles by generating slugs like events
- auto-generate unique slug on save using the same logic as events
- enforce slug generation in admin forms
- return HTTP 400 on invalid album names
- update migration and tests for new slug behaviour

## Testing
- `PROJECT_NAME=date python manage.py test archive.tests.PictureFormTestCase.test_slug_generated_from_album -v 2` *(fails: could not translate host name "db" to address)*
- `PROJECT_NAME=date python manage.py test archive.tests.PictureFormTestCase.test_upload_invalid_album_returns_400 -v 2` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_684c6ecde7b483249a358d7958520f40