### PR TITLE
Ignore past events in resending script & template fix

### DIFF
--- a/scripts/resend_signup_emails.py
+++ b/scripts/resend_signup_emails.py
@@ -1,17 +1,18 @@
 import time
-from billing.models import EventInvoice
+import datetime
 import sys
 import os
 import django
 
-from billing.util import send_event_invoice
 import csv
 
 
 sys.path.append("/code")
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings.date")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings.on")
 django.setup()
 
+from billing.models import EventInvoice
+from billing.util import send_event_invoice
 
 emails_filename = sys.argv[1]
 
@@ -20,7 +21,7 @@ with open(emails_filename, 'r') as file:
     emails = [row['email_address'] for row in reader]
 
     invoices = EventInvoice.objects.filter(
-        participant__email__in=emails).prefetch_related("participant")
+        participant__email__in=emails, due_date=datetime.datetime.now()).prefetch_related("participant")
     for invoice in invoices:
         send_event_invoice(invoice.participant, invoice)
         time.sleep(1.1)

--- a/templates/on/events/arsfest.html
+++ b/templates/on/events/arsfest.html
@@ -104,7 +104,7 @@
                                     {% endfor %}
                             </tr>
                             {% for attendee in event.get_registrations %}
-                                <tr {% if forloop.counter > event.sign_up_max_participants and event.sign_up_max_participants != 0 %} class="event-full" {% endif %} >
+                                <tr {% if forloop.counter > event.sign_up_max_participants and event.sign_up_max_participants != 0 and not event.parent %} class="event-full" {% endif %} >
                                     <td>{{ forloop.counter }}</td>
                                     <td>{% if not attendee.anonymous %}{{ attendee.user }}{% else %}
                                         <i>{% trans "Anonymt" %}</i>{% endif %}</td>


### PR DESCRIPTION
Change import order so django models are imported after django.setup

Make sure ÖN/events also ignores marking names for signups past the limit