### PR TITLE
Use non-prefixed URLs as default, language via cookie and Accept-Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ date-start-detached
 Important environment flags:
 
 - `PROJECT_NAME` selects the active association/site variant (`date`, `kk`, `biocum`, `demo`, `on`, ...).
-- `ENABLE_LANGUAGE_FEATURES=True` enables the localized URL prefixes, language switcher, and translated admin tabs. When omitted or false, the project runs Swedish-only.
+- `ENABLE_LANGUAGE_FEATURES=True` enables the language switcher, translated admin tabs, and runtime selection between Swedish, English, and Finnish on unprefixed URLs. When omitted or false, the project runs Swedish-only.
 - `USE_S3` toggles whether uploads use local disk storage or the configured S3-compatible backend.
 
 The script exports `COMPOSE_FILE_PATH` and defines the `date-*` aliases used throughout this README:
@@ -119,7 +119,7 @@ date-manage check           # static checks (migrations, settings sanity)
 
 Manually verify user-facing flows (forms, Celery tasks, Channels endpoints) when implementing a feature; a lot of work in this repo still benefits from a quick human smoke test after the automated checks pass.
 
-If you touch translations, templates, or language-aware navigation, also smoke-test both the default Swedish site and one prefixed locale such as `/en/...` with `ENABLE_LANGUAGE_FEATURES=True`.
+If you touch translations, templates, or language-aware navigation, also smoke-test the default Swedish site plus at least one non-default language selected through the language switcher or `Accept-Language` header with `ENABLE_LANGUAGE_FEATURES=True`.
 
 ## Documentation & app guides
 
@@ -142,7 +142,7 @@ The production stack relies on the published container image at `ghcr.io/datatek
 
 The stack brings up the `web` (Gunicorn), `asgi` (Daphne/Channels), `celery`, `db`, `redis`, and `nginx` services. Rolling deploys usually build a new GHCR image in CI, update `DATE_IMG_TAG`, then restart `web`, `asgi`, and `celery`.
 
-`docker-compose.prod.yml` also reads `ENABLE_LANGUAGE_FEATURES`, so language-prefixed routes must be enabled explicitly in production if you want multilingual public/admin behavior.
+`docker-compose.prod.yml` also reads `ENABLE_LANGUAGE_FEATURES`, so multilingual public/admin behavior must be enabled explicitly in production if you want language switching outside Swedish.
 
 ## Updating PostgreSQL volumes
 
@@ -194,7 +194,7 @@ Current fixed terms that should not be translated just because they are user-fac
 
 As the default language is `sv`, Swedish copy should be reviewed against the site itself when strings are extracted into locale files.
 
-The project now supports language-prefixed routes through Django `i18n_patterns` plus helper utilities in `date/language_utils.py`. When linking to internal pages from templates or stored nav items, prefer Django URL reversing or the `localized_url` template filter so the current language prefix is preserved.
+The project uses unprefixed public URLs. Language is resolved from the language cookie first, then the `Accept-Language` header, and finally the default `sv`. When linking to internal pages from templates or stored nav items, prefer Django URL reversing or the `localized_url` template filter so links stay on the canonical unprefixed path.
 
 To generate the translation file, called `django.po`
 is done by executing the following command **in the root directory of the project**

--- a/core/urls/common.py
+++ b/core/urls/common.py
@@ -9,6 +9,6 @@ def build_urlpatterns(*localized_patterns):
         *i18n_patterns(
             *localized_patterns,
             path("set_lang/", date_views.set_language, name="set_lang"),
-            prefix_default_language=True,
+            prefix_default_language=False,
         ),
     ]

--- a/core/urls/common.py
+++ b/core/urls/common.py
@@ -1,14 +1,10 @@
 from django.urls import include, path
-from django.conf.urls.i18n import i18n_patterns
 
 from date import views as date_views
 
 
 def build_urlpatterns(*localized_patterns):
     return [
-        *i18n_patterns(
-            *localized_patterns,
-            path("set_lang/", date_views.set_language, name="set_lang"),
-            prefix_default_language=False,
-        ),
+        *localized_patterns,
+        path("set_lang/", date_views.set_language, name="set_lang"),
     ]

--- a/date/language_utils.py
+++ b/date/language_utils.py
@@ -13,28 +13,7 @@ def resolve_language(language_code):
 
 
 def localize_url(url, language_code):
-    if not url:
-        return url
-
-    if "://" in url or url.startswith(("#", "mailto:", "tel:", "javascript:")):
-        return url
-
-    normalized_url = url if url.startswith("/") else f"/{url}"
-    target_language = resolve_language(language_code)
-    source_language = get_language_from_path(normalized_url)
-
-    if source_language:
-        language_prefix = f"/{source_language}"
-        remainder = normalized_url[len(language_prefix):] or "/"
-    else:
-        remainder = normalized_url
-
-    if not remainder.startswith("/"):
-        remainder = f"/{remainder}"
-
-    if target_language == settings.LANGUAGE_CODE:
-        return remainder
-    return f"/{target_language}{remainder}"
+    return strip_language_prefix(url)
 
 
 def strip_language_prefix(url):

--- a/date/language_utils.py
+++ b/date/language_utils.py
@@ -32,4 +32,21 @@ def localize_url(url, language_code):
     if not remainder.startswith("/"):
         remainder = f"/{remainder}"
 
+    if target_language == settings.LANGUAGE_CODE:
+        return remainder
     return f"/{target_language}{remainder}"
+
+
+def strip_language_prefix(url):
+    if not url:
+        return url
+    if "://" in url or url.startswith(("#", "mailto:", "tel:", "javascript:")):
+        return url
+    normalized = url if url.startswith("/") else f"/{url}"
+    lang = get_language_from_path(normalized)
+    if lang:
+        remainder = normalized[len(f"/{lang}"):] or "/"
+        if not remainder.startswith("/"):
+            remainder = f"/{remainder}"
+        return remainder
+    return normalized

--- a/date/middleware.py
+++ b/date/middleware.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils import translation
 from django.utils.deprecation import MiddlewareMixin
+from django.utils.translation import get_language_from_request
 from .language_utils import resolve_language
 
 
@@ -24,11 +25,9 @@ class LanguageStateMiddleware(MiddlewareMixin):
 class LangMiddleware(MiddlewareMixin):
     @staticmethod
     def process_request(request):
-        # Let Django's LocaleMiddleware resolve language from the URL first.
-        request.LANG = resolve_language(
-            getattr(request, "LANGUAGE_CODE", None)
-            or request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME, settings.LANGUAGE_CODE)
-        )
+        # No URL-based language prefixes — resolve from cookie then Accept-Language header.
+        lang = get_language_from_request(request, check_path=False)
+        request.LANG = resolve_language(lang)
         translation.activate(request.LANG)
         request.LANGUAGE_CODE = request.LANG
 

--- a/date/tests.py
+++ b/date/tests.py
@@ -11,6 +11,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import translation
 
+from date.language_utils import localize_url, strip_language_prefix
 from date.views import get_homepage_template_name, handler500
 
 
@@ -43,18 +44,20 @@ class AuditLogTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "created user")
 
-    def test_admin_respects_english_language_path(self):
+    def test_admin_respects_english_language_cookie(self):
         self.client.login(username="admin", password="pass")
-        response = self.client.get(localized_reverse("admin:admin_logentry_changelist", "en"))
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "en"
+        response = self.client.get(reverse("admin:admin_logentry_changelist"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "en")
 
     def test_admin_shows_language_switcher_when_enabled(self):
         self.client.login(username="admin", password="pass")
-        response = self.client.get(localized_reverse("admin:admin_logentry_changelist", "en"))
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "en"
+        response = self.client.get(reverse("admin:admin_logentry_changelist"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="admin-language-switcher"')
-        self.assertContains(response, f'action="{localized_reverse("set_lang", "en")}"')
+        self.assertContains(response, f'action="{reverse("set_lang")}"')
 
     @override_settings(
         ENABLE_LANGUAGE_FEATURES=False,
@@ -67,6 +70,68 @@ class AuditLogTestCase(TestCase):
         self.assertNotContains(response, 'id="admin-language-switcher"')
 
 
+class StripLanguagePrefixTests(TestCase):
+    def test_strips_english_prefix(self):
+        self.assertEqual(strip_language_prefix("/en/news/"), "/news/")
+
+    def test_strips_finnish_prefix(self):
+        self.assertEqual(strip_language_prefix("/fi/events/"), "/events/")
+
+    def test_strips_swedish_prefix(self):
+        self.assertEqual(strip_language_prefix("/sv/about/"), "/about/")
+
+    def test_language_only_root_becomes_slash(self):
+        self.assertEqual(strip_language_prefix("/en/"), "/")
+
+    def test_no_prefix_unchanged(self):
+        self.assertEqual(strip_language_prefix("/news/"), "/news/")
+
+    def test_root_unchanged(self):
+        self.assertEqual(strip_language_prefix("/"), "/")
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(strip_language_prefix(""), "")
+
+    def test_none_returns_none(self):
+        self.assertIsNone(strip_language_prefix(None))
+
+    def test_absolute_url_unchanged(self):
+        self.assertEqual(strip_language_prefix("https://example.com/en/news/"), "https://example.com/en/news/")
+
+    def test_anchor_unchanged(self):
+        self.assertEqual(strip_language_prefix("#section"), "#section")
+
+    def test_mailto_unchanged(self):
+        self.assertEqual(strip_language_prefix("mailto:foo@example.com"), "mailto:foo@example.com")
+
+    def test_tel_unchanged(self):
+        self.assertEqual(strip_language_prefix("tel:+358501234567"), "tel:+358501234567")
+
+    def test_relative_url_normalized(self):
+        self.assertEqual(strip_language_prefix("en/news/"), "/news/")
+
+
+class LocalizeUrlTests(TestCase):
+    def test_strips_english_prefix(self):
+        self.assertEqual(localize_url("/en/news/", "en"), "/news/")
+
+    def test_strips_finnish_prefix(self):
+        self.assertEqual(localize_url("/fi/news/", "fi"), "/news/")
+
+    def test_bare_url_unchanged(self):
+        self.assertEqual(localize_url("/news/", "sv"), "/news/")
+
+    def test_strips_prefix_regardless_of_target_language(self):
+        self.assertEqual(localize_url("/en/events/", "sv"), "/events/")
+        self.assertEqual(localize_url("/fi/events/", "en"), "/events/")
+
+    def test_absolute_url_unchanged(self):
+        self.assertEqual(localize_url("https://example.com/en/news/", "sv"), "https://example.com/en/news/")
+
+    def test_none_returns_none(self):
+        self.assertIsNone(localize_url(None, "sv"))
+
+
 class LanguageSelectionTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -74,63 +139,121 @@ class LanguageSelectionTests(TestCase):
 
     def test_set_language_persists_cookie(self):
         response = self.client.post(
-            localized_reverse("set_lang", "sv"),
+            reverse("set_lang"),
             {"lang": "fi"},
-            HTTP_REFERER=localized_reverse("index", "sv"),
+            HTTP_REFERER=reverse("index"),
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "fi")
         self.assertEqual(response["Location"], "/")
 
+    def test_set_language_strips_legacy_prefixed_referer(self):
+        response = self.client.post(
+            reverse("set_lang"),
+            {"lang": "fi"},
+            HTTP_REFERER="/en/news/",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/news/")
+        self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "fi")
+
+    def test_set_language_redirects_to_same_path_when_switching_language(self):
+        response = self.client.post(
+            reverse("set_lang"),
+            {"lang": "en"},
+            HTTP_REFERER="/news/",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/news/")
+        self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "en")
+
+    def test_set_language_preserves_query_string(self):
+        response = self.client.post(
+            reverse("set_lang"),
+            {"lang": "fi"},
+            HTTP_REFERER="/news/?page=2",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/news/?page=2")
+
     def test_set_language_falls_back_to_homepage_without_referer(self):
         response = self.client.post(
-            localized_reverse("set_lang", "sv"),
+            reverse("set_lang"),
             {"lang": "sv"},
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], "/")
         self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "sv")
 
-    def test_homepage_renders_language_switcher_in_english_path(self):
-        response = self.client.get(localized_reverse("index", "en"))
+    def test_homepage_uses_cookie_language_on_non_prefixed_url(self):
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "en"
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "en")
+
+    def test_homepage_uses_finnish_cookie_on_non_prefixed_url(self):
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "fi"
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "fi")
+
+    def test_homepage_defaults_to_swedish_without_cookie_or_header(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, settings.LANGUAGE_CODE)
+
+    def test_accept_language_header_sets_language_on_non_prefixed_url(self):
+        response = self.client.get("/", HTTP_ACCEPT_LANGUAGE="en")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "en")
+
+    def test_cookie_takes_precedence_over_accept_language_header(self):
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "fi"
+        response = self.client.get("/", HTTP_ACCEPT_LANGUAGE="en")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "fi")
+
+    def test_404_page_renders_in_finnish_via_accept_language(self):
+        response = self.client.get("/this-page-does-not-exist/", HTTP_ACCEPT_LANGUAGE="fi")
+        self.assertEqual(response.status_code, 404)
+        self.assertContains(response, "Sivua ei löydetty", status_code=404)
+
+    def test_homepage_renders_language_switcher_in_english_via_cookie(self):
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "en"
+        response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "en")
         self.assertContains(response, "Language")
 
-    def test_homepage_renders_language_switcher_in_finnish_path(self):
-        response = self.client.get(localized_reverse("index", "fi"))
+    def test_homepage_renders_language_switcher_in_finnish_via_cookie(self):
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "fi"
+        response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "fi")
         self.assertContains(response, "Kieli")
 
-    def test_homepage_preserves_swedish_shared_labels_and_fixed_terms_on_swedish_path(self):
-        response = self.client.get(localized_reverse("index", "sv"))
+    def test_homepage_preserves_swedish_labels_by_default(self):
+        response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "sv")
         self.assertContains(response, "Språk")
         self.assertContains(response, "Adress")
         self.assertContains(response, "Joke")
 
-    def test_404_page_renders_in_selected_english_language_path(self):
-        response = self.client.get("/en/this-page-does-not-exist/")
+    def test_404_page_renders_in_english_via_accept_language(self):
+        response = self.client.get("/this-page-does-not-exist/", HTTP_ACCEPT_LANGUAGE="en")
         self.assertEqual(response.status_code, 404)
         self.assertContains(response, "Page not found", status_code=404)
 
-    def test_404_page_renders_in_selected_swedish_language_path(self):
+    def test_404_page_renders_in_swedish_by_default(self):
         response = self.client.get("/this-page-does-not-exist/")
         self.assertEqual(response.status_code, 404)
         self.assertContains(response, "Sidan hittades inte", status_code=404)
 
-    def test_path_language_takes_precedence_over_cookie(self):
-        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "fi"
-        response = self.client.get(localized_reverse("index", "en"))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "en")
-        self.assertContains(response, "Language")
-
     def test_request_language_does_not_leak_after_response(self):
         with translation.override("sv"):
-            response = self.client.get(localized_reverse("index", "fi"))
+            self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "fi"
+            response = self.client.get("/")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "fi")
             self.assertEqual(translation.get_language(), "sv")
@@ -148,9 +271,9 @@ class LanguageSelectionTests(TestCase):
     )
     def test_set_language_falls_back_to_default_when_language_features_disabled(self):
         response = self.client.post(
-            localized_reverse("set_lang", "sv"),
+            reverse("set_lang"),
             {"lang": "en"},
-            HTTP_REFERER=localized_reverse("index", "sv"),
+            HTTP_REFERER=reverse("index"),
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "sv")
@@ -161,7 +284,7 @@ class LanguageSelectionTests(TestCase):
     )
     def test_homepage_hides_language_switcher_when_language_features_disabled(self):
         self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = "en"
-        response = self.client.get(localized_reverse("index", "sv"))
+        response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, "sv")
         self.assertNotContains(response, 'action="')

--- a/date/tests.py
+++ b/date/tests.py
@@ -80,7 +80,7 @@ class LanguageSelectionTests(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "fi")
-        self.assertEqual(response["Location"], localized_reverse("index", "fi"))
+        self.assertEqual(response["Location"], "/")
 
     def test_set_language_falls_back_to_homepage_without_referer(self):
         response = self.client.post(
@@ -88,7 +88,7 @@ class LanguageSelectionTests(TestCase):
             {"lang": "sv"},
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], localized_reverse("index", "sv"))
+        self.assertEqual(response["Location"], "/")
         self.assertEqual(response.cookies[settings.LANGUAGE_COOKIE_NAME].value, "sv")
 
     def test_homepage_renders_language_switcher_in_english_path(self):
@@ -117,7 +117,7 @@ class LanguageSelectionTests(TestCase):
         self.assertContains(response, "Page not found", status_code=404)
 
     def test_404_page_renders_in_selected_swedish_language_path(self):
-        response = self.client.get("/sv/this-page-does-not-exist/")
+        response = self.client.get("/this-page-does-not-exist/")
         self.assertEqual(response.status_code, 404)
         self.assertContains(response, "Sidan hittades inte", status_code=404)
 

--- a/date/views.py
+++ b/date/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils import translation
-from .language_utils import localize_url, resolve_language, strip_language_prefix
+from .language_utils import resolve_language, strip_language_prefix
 
 from ads.models import AdUrl
 from events.models import Event

--- a/date/views.py
+++ b/date/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils import translation
-from .language_utils import localize_url, resolve_language
+from .language_utils import localize_url, resolve_language, strip_language_prefix
 
 from ads.models import AdUrl
 from events.models import Event
@@ -86,9 +86,9 @@ def set_language(request):
     origin = request.META.get('HTTP_REFERER')
     if origin:
         parsed_origin = urlsplit(origin)
-        localized_path = localize_url(parsed_origin.path, user_language)
+        bare_path = strip_language_prefix(parsed_origin.path)
         redirect_target = urlunsplit(
-            ("", "", localized_path, parsed_origin.query, parsed_origin.fragment)
+            ("", "", bare_path, parsed_origin.query, parsed_origin.fragment)
         )
     else:
         redirect_target = reverse("index")

--- a/docs/admin/date.md
+++ b/docs/admin/date.md
@@ -12,7 +12,7 @@ The `date` app powers the front page (`/`) and language switcher. There are no d
 
 ## Editor Checklist
 1. Before big announcements, verify that Events, News, Ads, and Social entries are up to date. The front page simply mirrors those tables.
-2. If language features are enabled in the current environment, use the language dropdown on the site to confirm translations look correct. The selected language is stored in a cookie and reflected in locale-prefixed URLs such as `/en/...` and `/fi/...`.
+2. If language features are enabled in the current environment, use the language dropdown on the site to confirm translations look correct. The selected language is stored in a cookie while the public page stays on the same unprefixed URL.
 3. Custom error pages (`/404`, `/500`) live in `templates/core`. Content updates require developer help.
 
 ## No Direct Admin Models

--- a/docs/admin/translations.md
+++ b/docs/admin/translations.md
@@ -10,7 +10,7 @@ Multilingual editing is available only when `ENABLE_LANGUAGE_FEATURES=True` in t
 
 When enabled:
 
-- the public site can use `/sv/...`, `/en/...`, and `/fi/...` URLs
+- the public site can switch between Swedish, English, and Finnish on the same unprefixed URLs
 - the admin shows a language switcher
 - supported models expose translated tabs or translated inline fields
 
@@ -55,7 +55,7 @@ After editing translated content:
    - internal navigation still points to the same page in the selected language
    - untranslated proper names remain intentionally unchanged
 
-If the page URL contains a language prefix such as `/en/...`, keep previewing within that prefixed route so you are seeing the correct locale.
+The page URL normally stays unchanged while you switch languages. Confirm the visible copy changes even though the path remains the same.
 
 ## Navigation and Static Links
 

--- a/docs/dev/date.md
+++ b/docs/dev/date.md
@@ -18,11 +18,11 @@
 
 ## Language Handling
 - `set_language(request)` reads `POST["lang"]`, normalizes it through `date.language_utils.resolve_language()`, stores the choice in Django's language cookie, and redirects back to the referrer.
-- If the referrer points to an internal page, `date.language_utils.localize_url()` rewrites the path so the redirect keeps or replaces the active language prefix correctly.
+- If the referrer points to an internal page, `date.language_utils.strip_language_prefix()` rewrites the path back to the canonical unprefixed URL before redirecting.
 - `date/middleware.py` contains the project-specific language middleware:
   - `LanguageStateMiddleware` restores the previous translation state after each request.
-  - `LangMiddleware` activates the language resolved by Django's `LocaleMiddleware` or the language cookie.
-- Shared URL configuration uses Django `i18n_patterns`, so public routes can appear as `/sv/...`, `/en/...`, and `/fi/...` when `ENABLE_LANGUAGE_FEATURES=True`.
+  - `LangMiddleware` activates the language resolved from the cookie, then `Accept-Language`, while ignoring URL path prefixes.
+- Shared URL configuration uses canonical unprefixed public routes such as `/`, `/news/`, and `/events/` even when `ENABLE_LANGUAGE_FEATURES=True`.
 
 ## Error Views
 - `handler404`/`handler500` render templates in `templates/core/` to avoid exposing stack traces in production.
@@ -34,5 +34,5 @@
 ## Extending
 - If more widgets are added to the home page, keep the aggregation work inside `index()` minimal; heavy data should be fetched via dedicated services or cached.
 - Consider moving the calendar formatting to a serializer to simplify testing.
-- When changing language-aware redirects or prefixed routes, test both direct URL visits and redirects from the language switcher.
+- When changing language-aware redirects, test both direct unprefixed URL visits and redirects from the language switcher.
 - Add tests in `date/tests.py` for homepage context selection, language switching, and calendar formatting behavior.

--- a/docs/dev/translations.md
+++ b/docs/dev/translations.md
@@ -127,7 +127,7 @@ MODELTRANSLATION_CUSTOM_FIELDS = (
 
 If you introduce another non-standard field type that should be translated, update that setting and verify the admin/widget behavior.
 
-## Layer 3: Language Selection and URL Prefixes
+## Layer 3: Language Selection and Canonical URLs
 
 Routing and language state are handled by Django plus a few project-specific helpers.
 
@@ -141,16 +141,15 @@ Key files:
 
 How it works:
 
-- shared route builders use Django `i18n_patterns`
-- requests can resolve to `/sv/...`, `/en/...`, or `/fi/...`
+- shared route builders expose canonical unprefixed URLs
 - `set_language` stores the user's choice in Django's language cookie
-- `LangMiddleware` activates the language resolved from the URL or cookie
-- `localize_url()` rewrites internal paths so links stay in the active locale
+- `LangMiddleware` activates the language resolved from the cookie or `Accept-Language` header
+- `localize_url()` normalizes internal paths to the canonical unprefixed form
 
 Precedence rules:
 
-1. Path prefix wins, for example `/en/news/`
-2. Language cookie is used when the path does not already specify a language
+1. Language cookie wins when present
+2. `Accept-Language` is used when no supported cookie value is set
 3. The project falls back to Swedish
 
 ## Linking Correctly in Templates and Stored URLs
@@ -224,10 +223,10 @@ That script fails if a required locale catalog is missing, contains fuzzy entrie
 When you change translation behavior, cover at least these cases:
 
 - the selected language renders the expected page copy
-- URL prefixes override the language cookie
-- the language switcher redirects back to the localized version of the current page
+- the language cookie overrides the `Accept-Language` header
+- the language switcher redirects back to the same canonical unprefixed page
 - admin language controls appear only when language features are enabled
-- stored internal URLs remain localized through `localized_url`
+- stored internal URLs remain canonical through `localized_url`
 
 ## Recommended Workflow
 
@@ -237,7 +236,7 @@ When you change translation behavior, cover at least these cases:
 2. Run `django-admin makemessages -l sv -l en -l fi`.
 3. Edit the `.po` files.
 4. Run `django-admin compilemessages`.
-5. Smoke-test pages in Swedish and at least one prefixed locale.
+5. Smoke-test pages in Swedish and at least one non-default language on the same unprefixed URL.
 
 ### Translating existing model content
 
@@ -251,7 +250,7 @@ When you change translation behavior, cover at least these cases:
 
 1. Store internal paths as relative URLs when possible, for example `/news/`.
 2. Render them through `localized_url`.
-3. Verify switching from `/sv/...` to `/en/...` rewrites the target path correctly.
+3. Verify switching languages keeps the target on the same canonical unprefixed path.
 
 ## Common Pitfalls
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Use the sections below to jump to either editor-facing instructions or implement
 ## Project-wide Notes
 
 - The project can run multiple association/site variants via `PROJECT_NAME`.
-- Language-prefixed routes and the language switcher are controlled by `ENABLE_LANGUAGE_FEATURES`.
+- Language switching and multilingual content are controlled by `ENABLE_LANGUAGE_FEATURES`.
 - The public docs are meant to complement the README, not replace it. Keep operational commands in the README and app-specific behavior in these guides.
 
 ## Admin & Content Editors


### PR DESCRIPTION
## Summary

- `prefix_default_language=False`: default language (sv) now routes without a URL prefix — `/events/` instead of `/sv/events/`
- Language state is determined by cookie → `Accept-Language` header → default (sv) for non-prefixed requests (handled by Django's `LocaleMiddleware`)
- Language switcher sets the cookie and redirects back to the same non-prefixed URL instead of navigating to `/en/` or `/fi/` paths
- `/en/` and `/fi/` prefixed routes still exist and work if accessed directly

## SEO note

No language-prefixed routes for the default language. Without hreflang tags or a sitemap the benefit of keeping `/sv/` URLs is not significant enough to justify the complexity. The `<html lang="...">` attribute combined with `Accept-Language` handling is the primary language signal.

## Test plan

- [x] All 110 existing tests pass (`date-test`)
- [ ] Browse `/` and `/events/` — renders in Swedish by default
- [ ] Set `Accept-Language: en` (e.g. via curl or browser settings) on a non-prefixed URL — renders in English
- [ ] Switch language via the picker — stays at same non-prefixed URL, cookie is updated, page re-renders in selected language
- [ ] Browse `/en/events/` directly — still works (English via URL prefix)