### PR TITLE
fix: restore login page style to match pre-2FA appearance

### DIFF
--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1108,6 +1108,10 @@ msgstr "Är du säker på att du vill ta bort posten?"
 msgid "Login"
 msgstr "Login"
 
+#: members/two_factor.py
+msgid "Username or email"
+msgstr "Användarnamn eller e-post"
+
 #: templates/common/members/registration/login.html:18
 msgid "Glömt lösenordet?"
 msgstr "Glömt lösenordet?"

--- a/static/common/members/css/two-factor.css
+++ b/static/common/members/css/two-factor.css
@@ -1,6 +1,6 @@
 .two-factor-page {
     min-height: 100vh;
-    padding: 7rem 1rem 4rem;
+    padding: 25vh 1rem 10rem;
 }
 
 .two-factor-shell {
@@ -15,6 +15,7 @@
 .two-factor-card-login {
     width: 360px;
     max-width: 90vw;
+    text-align: center;
 }
 
 .two-factor-card-panel {
@@ -59,29 +60,20 @@
     margin-top: 1.25rem;
 }
 
-.two-factor-card .btn {
+.two-factor-secondary {
+    background-color: var(--primaryColorLight);
+    color: var(--textColorLightish);
     width: auto;
-    padding: 0.65rem 1rem;
-    font-size: 0.95rem;
 }
 
-.two-factor-card .btn-primary {
-    background-color: var(--bs-primary, #0d6efd);
-    border-color: var(--bs-primary, #0d6efd);
-    color: #fff;
+.two-factor-secondary:hover,
+.two-factor-secondary:focus {
+    background-color: var(--primaryColorLighte);
+    color: var(--linkColorLightHover);
 }
 
-.two-factor-card .btn-primary:hover,
-.two-factor-card .btn-primary:focus,
-.two-factor-card .btn-primary:active {
-    background-color: var(--bs-btn-hover-bg, #0b5ed7);
-    border-color: var(--bs-btn-hover-border-color, #0a58ca);
-    color: #fff;
-}
-
-.two-factor-actions .btn,
-.two-factor-inline-form .btn,
-.two-factor-alt-methods .btn {
+.two-factor-actions a.theme-button,
+.two-factor-inline-form a.theme-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -107,18 +99,12 @@
     accent-color: var(--primaryColorLighter);
 }
 
-.two-factor-actions .btn,
-.two-factor-inline-form .btn,
-.two-factor-alt-methods .btn {
-    min-width: 120px;
-}
-
 .two-factor-alt-methods {
     margin-top: 1rem;
 }
 
-.two-factor-alt-methods .btn,
-.two-factor-inline-form .btn {
+.two-factor-alt-methods .two-factor-secondary,
+.two-factor-inline-form .two-factor-secondary {
     margin-top: 0.75rem;
 }
 

--- a/templates/common/two_factor/_wizard_actions.html
+++ b/templates/common/two_factor/_wizard_actions.html
@@ -2,11 +2,11 @@
 
 <div class="two-factor-actions">
     {% if wizard.steps.prev %}
-        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="btn btn-secondary">
+        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="two-factor-secondary">
             {% trans "Back" %}
         </button>
     {% endif %}
-    <button type="submit" class="btn btn-primary">
+    <button type="submit">
         {% trans "Continue" %}
     </button>
 </div>

--- a/templates/common/two_factor/core/login.html
+++ b/templates/common/two_factor/core/login.html
@@ -6,9 +6,7 @@
     <div class="members-form two-factor-card two-factor-card-login">
         <h2>{% trans "Login" %}</h2>
 
-        {% if wizard.steps.current == 'auth' %}
-            <p>{% trans "Enter your username or email address and password." %}</p>
-        {% elif wizard.steps.current == 'token' %}
+        {% if wizard.steps.current == 'token' %}
             <p>{{ device|as_verbose_action }}</p>
         {% elif wizard.steps.current == 'backup' %}
             <p>{% trans "Enter one of your backup tokens to continue." %}</p>
@@ -23,7 +21,7 @@
                 <div class="two-factor-alt-methods">
                     <p>{% trans "Use another authentication method:" %}</p>
                     {% for other in other_devices %}
-                        <button name="challenge_device" value="{{ other.persistent_id }}" class="btn btn-secondary" type="submit">
+                        <button name="challenge_device" value="{{ other.persistent_id }}" class="two-factor-secondary" type="submit">
                             {{ other|as_action }}
                         </button>
                     {% endfor %}
@@ -36,16 +34,16 @@
         {% if backup_tokens %}
             <form action="" method="post" class="two-factor-inline-form">
                 {% csrf_token %}
-                <button name="wizard_goto_step" type="submit" value="backup" class="btn btn-secondary">
+                <button name="wizard_goto_step" type="submit" value="backup" class="two-factor-secondary">
                     {% trans "Use backup token" %}
                 </button>
             </form>
         {% endif %}
 
         {% if wizard.steps.current == 'auth' %}
-            <a href="{% url 'members:password_reset' %}"><p>{% trans 'Forgot your password?' %}</p></a>
+            <a href="{% url 'members:password_reset' %}"><p>{% trans 'Glömt lösenordet?' %}</p></a>
             {% if MEMBERS_SIGNUP_ENABLED %}
-                <a href="{% url 'members:signup' %}"><p>{% trans 'Register' %}</p></a>
+                <a href="{% url 'members:signup' %}"><p>{% trans 'Registrera dig' %}</p></a>
             {% endif %}
         {% endif %}
     </div>


### PR DESCRIPTION
- Center text and correct vertical positioning on login card
- Replace Bootstrap btn classes with project-native two-factor-secondary
- Restore Swedish translation keys for password reset and signup links
- Add Swedish translation for "Username or email" field label