### PR TITLE
Upgrade S3 to s3v4, make CDN and ACL provider-agnostic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,11 +93,23 @@ S3_SECRET_KEY="password"
 # S3 bucket name
 S3_BUCKET_NAME="date-images"
 
+# Set to False for providers that don't support per-object ACLs (e.g. Backblaze B2).
+# Leave True (or unset) for DigitalOcean Spaces, AWS S3, and MinIO.
+# When False, configure bucket-level access control in your provider's console instead.
+S3_USE_ACL=True
+
 # Private media location (example: date/media or kk/media)
 PRIVATE_MEDIA_LOCATION="date/media"
 
 # Public media location  (example: date/public or kk/public)
 PUBLIC_MEDIA_LOCATION="date/public"
+
+# CDN rewrite: origin path as it appears in S3 URLs, and the CDN domain to replace it with.
+# DigitalOcean example: S3_CDN_ORIGIN="fra1.digitaloceanspaces.com/my-bucket/"
+# Backblaze B2 example: S3_CDN_ORIGIN="s3.us-west-004.backblazeb2.com/my-bucket/"
+# Leave both empty to disable CDN rewriting.
+S3_CDN_ORIGIN=""
+S3_CDN_DOMAIN=""
 
 # Cloudflare captcha keys, set to '' to disable captcha
 CF_TURNSTILE_SITE_KEY=""

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -269,6 +269,15 @@ if USE_S3:
     AWS_STORAGE_BUCKET_NAME = env('AWS_STORAGE_BUCKET_NAME')
     AWS_QUERYSTRING_AUTH = True
     AWS_QUERYSTRING_EXPIRE = 3600
+    AWS_S3_SIGNATURE_VERSION = 's3v4'
+    # Force path-style addressing so presigned URLs use the same host as the endpoint URL.
+    # Without this, boto3 generates virtual-hosted URLs (bucket.endpoint/key) which produce
+    # SignatureDoesNotMatch errors on DigitalOcean Spaces because the signed host differs
+    # from the path-style endpoint URL used everywhere else.
+    AWS_S3_ADDRESSING_STYLE = 'path'
+    # Set to False for providers that don't support per-object ACLs (e.g. Backblaze B2).
+    # DigitalOcean Spaces supports ACLs so this can remain True there.
+    S3_USE_ACL = env('S3_USE_ACL', bool, True)
 
     # s3 public media settings
     PRIVATE_MEDIA_LOCATION = env('PRIVATE_MEDIA_LOCATION')
@@ -278,6 +287,7 @@ if USE_S3:
     STORAGES["default"] = {  # TODO allow setting this to local
         "BACKEND": "core.storage_backends.PrivateMediaStorage",
         "OPTIONS": {
+            "endpoint_url": AWS_S3_ENDPOINT_URL,
             "bucket_name": AWS_STORAGE_BUCKET_NAME,
             "custom_domain": False,
             "querystring_auth": AWS_QUERYSTRING_AUTH,
@@ -288,6 +298,7 @@ if USE_S3:
     STORAGES["public_media"] = {
         "BACKEND": "core.storage_backends.PublicMediaStorage",
         "OPTIONS": {
+            "endpoint_url": AWS_S3_ENDPOINT_URL,
             "bucket_name": AWS_STORAGE_BUCKET_NAME,
             "custom_domain": False,
             "location": PUBLIC_MEDIA_LOCATION,
@@ -381,7 +392,10 @@ EXPERIMENTAL_FEATURES = []
 
 
 # CDN settings
-CDN_URL_TRANSFORMATIONS = [
-    ("fra1.digitaloceanspaces.com/albin-storage/", "albin-storage.cdn.datateknologerna.org/"),
-    ("albin-storage.fra1.digitaloceanspaces.com/", "albin-storage.cdn.datateknologerna.org/"),
-]
+# S3_CDN_ORIGIN: the origin hostname+bucket path as it appears in S3 URLs, e.g.
+#   DigitalOcean: "fra1.digitaloceanspaces.com/albin-storage/"
+#   Backblaze B2: "s3.us-west-004.backblazeb2.com/my-bucket/"
+# S3_CDN_DOMAIN: the CDN hostname to rewrite to, e.g. "assets.cdn.datateknologerna.org/"
+_cdn_origin = env('S3_CDN_ORIGIN', str, '')
+_cdn_domain = env('S3_CDN_DOMAIN', str, '')
+CDN_URL_TRANSFORMATIONS = [(_cdn_origin, _cdn_domain)] if _cdn_origin and _cdn_domain else []

--- a/core/storage_backends.py
+++ b/core/storage_backends.py
@@ -1,21 +1,25 @@
 from storages.backends.s3boto3 import S3Boto3Storage
 from django.conf import settings
 
+# When S3_USE_ACL is False (e.g. Backblaze B2), per-object ACLs are not sent.
+# Access control must then be configured at the bucket level in the provider console.
+_use_acl = getattr(settings, 'S3_USE_ACL', True)
+
 
 class StaticStorage(S3Boto3Storage):
     location = 'static'
-    default_acl = 'public-read'
+    default_acl = 'public-read' if _use_acl else None
 
 
 class PrivateMediaStorage(S3Boto3Storage):
     location = settings.PRIVATE_MEDIA_LOCATION
-    default_acl = 'private'
+    default_acl = 'private' if _use_acl else None
     file_overwrite = False
 
 
 class PublicMediaStorage(S3Boto3Storage):
     location = settings.PUBLIC_MEDIA_LOCATION
-    default_acl = 'public-read'
+    default_acl = 'public-read' if _use_acl else None
     file_overwrite = False
     querystring_auth = False
 


### PR DESCRIPTION
- Explicit s3v4 signature version and path-style addressing to fix SignatureDoesNotMatch errors on DigitalOcean Spaces presigned URLs
- Add S3_USE_ACL toggle (default True) so ACLs can be disabled for providers like Backblaze B2 that don't support per-object ACLs
- Add endpoint_url to STORAGES OPTIONS for explicitness
- Replace hardcoded DO CDN_URL_TRANSFORMATIONS with S3_CDN_ORIGIN / S3_CDN_DOMAIN env vars, making provider switching config-only