### PR TITLE
Skip CDN rewrite for presigned S3 URLs

### DIFF
--- a/date/middleware.py
+++ b/date/middleware.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -53,19 +55,36 @@ class CDNRewriteMiddleware:
     Middleware to rewrite URLs for static and media files to use a CDN if configured.
     """
 
+    URL_BYTES_PATTERN = rb'[^"\'\s<>()]+'
+    PRESIGNED_S3_MARKERS = (b"X-Amz-Algorithm=", b"X-Amz-Signature=")
+
     def __init__(self, get_response):
         self.get_response = get_response
         self.cdn_url_transformations = getattr(settings, "CDN_URL_TRANSFORMATIONS", [])
+        self._cdn_patterns = []
+        for original, new in self.cdn_url_transformations:
+            if original and new:
+                self._cdn_patterns.append(
+                    (
+                        original.encode("utf-8"),
+                        new.encode("utf-8"),
+                        re.compile(re.escape(original.encode("utf-8")) + self.URL_BYTES_PATTERN),
+                    )
+                )
 
     def __call__(self, request):
         response = self.get_response(request)
 
         if not getattr(response, "streaming", False):
-            for original, new in self.cdn_url_transformations:
-                if original and new:
-                    response.content = response.content.replace(
-                        bytes(original, "utf-8"), bytes(new, "utf-8")
-                    )
+            for original, new, pattern in self._cdn_patterns:
+                # Keep presigned private-media URLs on their original host, since
+                # their signatures cover the request host and break if rewritten.
+                response.content = pattern.sub(
+                    lambda match: match.group(0)
+                    if any(marker in match.group(0) for marker in self.PRESIGNED_S3_MARKERS)
+                    else match.group(0).replace(original, new, 1),
+                    response.content,
+                )
         # Streaming responses do not expose a mutable `.content` buffer here.
 
         return response


### PR DESCRIPTION
Following from Codex:

## What changed
This PR narrows `CDNRewriteMiddleware` so it no longer rewrites presigned S3 URLs in HTML responses.

The middleware now:
- continues rewriting ordinary CDN-eligible URLs
- skips URLs that contain S3 presigning markers such as `X-Amz-Algorithm` or `X-Amz-Signature`

That keeps the existing CDN behavior for public/static-style URLs while leaving private presigned media URLs on their original origin host.

## Why this had to be done
Production archive/gallery images started failing with `403 Forbidden` after image updates. The failing URLs were private S3 presigned media URLs, for example under `date/media/...`, and they included `X-Amz-*` query parameters with `X-Amz-SignedHeaders=host`.

We also confirmed that the application had CDN rewrite rules configured to rewrite:
- `fra1.digitaloceanspaces.com/albin-storage/` -> `albin-storage.cdn.datateknologerna.org/`
- `albin-storage.fra1.digitaloceanspaces.com/` -> `albin-storage.cdn.datateknologerna.org/`

That combination breaks presigned private media delivery:
1. Django signs a URL for the Spaces origin host.
2. The response middleware rewrites the URL to the CDN host.
3. The browser requests the rewritten CDN hostname.
4. Signature validation fails because the signed request host no longer matches the requested host.

We verified this directly in production by:
- generating a fresh signed archive image URL from Django
- requesting the original origin-host URL successfully
- requesting the same URL with only the hostname changed to the CDN host and reproducing the `403`

That made the root cause clear: the middleware was applying a public-CDN optimization to private presigned URLs, where host preservation is required for signature validation.

## Why this approach
The immediate safe fix is to stop rewriting presigned private-media URLs while preserving the current CDN behavior for URLs that are actually suitable for CDN rewriting.

This is the least invasive correction because it:
- restores private archive image access immediately
- does not require storage endpoint reconfiguration in production
- does not assume that the CDN hostname can safely act as the signed host for S3-compatible presigned URLs
- keeps public/static CDN benefits intact

A future CDN-based private media design is still possible, but it should be implemented intentionally by generating URLs for the correct host from the start or by moving authorization to the CDN layer. Rewriting the host after signing is not safe for presigned S3 URLs.

## User impact
- Private archive/gallery images work again in production.
- Public CDN-eligible URLs still keep their rewrite behavior.
- Private presigned media no longer goes through the CDN hostname unless we later implement a CDN-compatible private media strategy.

## Validation
Ran locally:
- `python -m compileall date/middleware.py`

Validated operationally in production before this patch by comparing:
- fresh Django-generated origin-host signed URL: worked
- same signed URL with only the hostname changed to the CDN host: failed with `403`
