### PR TITLE
Simplify Compose environment loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,13 +11,13 @@
 # Sets docker compose project name to use
 COMPOSE_PROJECT_NAME="datewebsite"
 
+# Compose file used by plain `docker compose ...` commands
+COMPOSE_FILE="docker-compose.yml"
+
 # [Postgres]
 
 # PostgreSQL version to use. DO NOT change this manually after the database has been created!!!
 DATE_POSTGRESQL_VERSION=16
-
-# DB port (disable in production)
-DATE_DB_PORT=5432
 
 # DB password
 DATE_DB_PASSWORD="password"
@@ -76,10 +76,6 @@ EMAIL_HOST_USER=''
 EMAIL_HOST_PASSWORD=''
 
 # [Redis]
-
-# Host port used by Docker Compose to expose the Redis container.
-# Django/Channels/Celery use the Redis URLs below instead.
-REDIS_PORT=6379
 
 # Redis URL used by Django cache/channels
 REDIS_SERVER="redis://redis:6379"

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,78 @@
+############################################################
+#
+# Production environment example for docker-compose.prod.yml
+#
+# Copy this to .env on the production host and replace every
+# placeholder before deploying. Do not commit real production values.
+#
+############################################################
+
+# [Docker]
+
+COMPOSE_PROJECT_NAME="datewebsite"
+COMPOSE_FILE="docker-compose.prod.yml"
+DATE_IMG_TAG="vX.Y.Z"
+
+# [Postgres]
+
+DATE_POSTGRESQL_VERSION=16
+DATE_DB_PASSWORD="replace-with-a-long-random-password"
+
+# [Django]
+
+PROJECT_NAME="date"
+DATE_SECRET_KEY="replace-with-a-long-random-django-secret-key"
+DATE_DEBUG=False
+DATE_DEVELOP=False
+ENABLE_LANGUAGE_FEATURES=False
+
+ALLOWED_HOSTS='["date.abo.fi"]'
+ALLOWED_ORIGINS='["https://date.abo.fi"]'
+
+USE_X_FORWARDED_HOST=True
+TRUST_X_FORWARDED_PROTO=True
+
+EXTRA_STAFF_GROUPS='[]'
+ALUMNI_SETTINGS='{}'
+
+# [Email]
+
+EMAIL_HOST_RECEIVER='info@datateknologerna.org'
+DEFAULT_FROM_EMAIL='admin@datateknologerna.org'
+EMAIL_HOST='smtp.gmail.com'
+EMAIL_HOST_USER=''
+EMAIL_HOST_PASSWORD=''
+
+# [Redis]
+
+REDIS_SERVER="redis://redis:6379"
+CELERY_BROKER_URL="redis://redis:6379/0"
+CELERY_RESULT_BACKEND="redis://redis:6379/0"
+
+# [S3]
+
+USE_S3=True
+S3_ENDPOINT_URL="https://s3.example.com"
+S3_ACCESS_KEY="replace-with-access-key"
+S3_SECRET_KEY="replace-with-secret-key"
+S3_BUCKET_NAME="date-images"
+
+S3_PRIVATE_BUCKET_NAME=""
+S3_PUBLIC_BUCKET_NAME=""
+S3_REGION_NAME=""
+S3_SIGNATURE_VERSION="s3v4"
+S3_ADDRESSING_STYLE="path"
+
+PRIVATE_MEDIA_LOCATION="date/media"
+PUBLIC_MEDIA_LOCATION="date/public"
+
+# [Cloudflare Turnstile]
+
+CF_TURNSTILE_SITE_KEY=""
+CF_TURNSTILE_SECRET_KEY=""
+
+# [GitHub OAuth]
+
+GITHUB_CLIENT_ID=""
+GITHUB_CLIENT_SECRET=""
+GITHUB_MFA_POLICY="enrolled"

--- a/.github/workflows/web_startup.yaml
+++ b/.github/workflows/web_startup.yaml
@@ -53,6 +53,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Prepare environment file
+        run: cp .env.example .env
+
       - name: Ensure docker-compose command exists
         run: |
           set -euo pipefail
@@ -101,29 +104,25 @@ jobs:
         if: steps.prebuilt.outputs.compose_file == 'docker-compose.yml'
         run: |
           set -euo pipefail
-          source env.sh dev
           docker-compose build web celery
 
       - name: Run django unit tests
         run: |
           set -euo pipefail
-          source env.sh dev
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose run --rm --no-deps web python scripts/validate_translations.py
           docker-compose run --rm --no-deps web python manage.py compilemessages
-          date-test
+          docker-compose run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test'
 
       - name: Build and run Docker Compose
         run: |
           set -euo pipefail
-          source env.sh dev
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose up -d
 
       - name: Wait for web container
         run: |
           set -euo pipefail
-          source env.sh dev
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           for i in $(seq 1 30); do
             if [ "$(docker-compose ps -q web | wc -l)" -eq 1 ] && \
@@ -155,7 +154,6 @@ jobs:
         if: failure()
         run: |
           set -euo pipefail
-          source env.sh dev
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose ps
           docker-compose logs --tail=200 web db redis
@@ -164,6 +162,5 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          source env.sh dev
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .claude/
 
 *.env*
+!.env.example
+!.env.prod.example
 
 *.mo
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://github.com/datateknologerna-vid-abo-akademi/date-website.git
 cd date-website
 git checkout develop
 cp .env.example .env            # adjust passwords, ports, S3, etc.
-source env.sh dev               # registers helper aliases
+source env.sh                   # registers helper aliases
 date-start-detached             # builds containers, runs migrations, collects static files
 date-createsuperuser            # creates your admin account
 open http://localhost:8000      # admin lives at /admin
@@ -46,7 +46,7 @@ The main workflow in this README is Linux-first. On Windows and macOS, the easie
 
 ```bash
 cd ~/code/date-website
-source env.sh dev
+source env.sh
 date-start-detached
 ```
 
@@ -56,7 +56,7 @@ date-start-detached
 ### macOS
 
 - Install Docker Desktop for Mac so `docker compose` is available.
-- Use Terminal, iTerm2, or another shell that can run Bash-compatible commands. `zsh` is fine; `source env.sh dev` still works.
+- Use Terminal, iTerm2, or another shell that can run Bash-compatible commands. `zsh` is fine; `source env.sh` works.
 - The rest of the workflow is the same as Linux: clone the repo, copy `.env.example`, source `env.sh`, and use the `date-*` aliases.
 - The `open http://localhost:8000` command from the quick start already works on macOS.
 
@@ -69,11 +69,24 @@ date-start-detached
 
 Docker Compose reads `.env` automatically. Create it once from `.env.example`, then edit it for your local or deployed environment.
 
-`env.sh` is only for helper aliases:
+`env.sh` is only for helper aliases. Compose file selection lives in `.env` through `COMPOSE_FILE`.
 
-- `source env.sh dev` points the `date-*` aliases at `docker-compose.yml`.
-- `source env.sh prod` points the `date-*` aliases at `docker-compose.prod.yml`.
-- `source env.sh path/to/compose.yml` points the aliases at a custom Compose file.
+- `.env.example` sets `COMPOSE_FILE=docker-compose.yml`.
+- `.env.prod.example` sets `COMPOSE_FILE=docker-compose.prod.yml`.
+- `source env.sh` registers the `date-*` aliases without loading or changing app configuration.
+
+If you use these helpers often, install them into your shell config:
+
+```bash
+./scripts/install_shell_aliases.sh
+```
+
+Or add them manually and adjust the path to wherever you cloned the repository:
+
+```bash
+export DATE_WEBSITE_DIR="/path/to/date-website"
+source "$DATE_WEBSITE_DIR/env.sh"
+```
 
 Important environment flags:
 
@@ -81,7 +94,7 @@ Important environment flags:
 - `ENABLE_LANGUAGE_FEATURES=True` enables the language switcher, translated admin tabs, and runtime selection between the languages configured for the active association on unprefixed URLs. DaTe currently uses Swedish and English at runtime; some other associations also expose Finnish. When omitted or false, the project runs Swedish-only.
 - `USE_S3` toggles whether uploads use local disk storage or the configured S3-compatible backend.
 
-The script exports `COMPOSE_FILE_PATH` and defines the `date-*` aliases used throughout this README:
+The script defines the `date-*` aliases used throughout this README:
 
 | Command | Description |
 | --- | --- |
@@ -95,7 +108,7 @@ The script exports `COMPOSE_FILE_PATH` and defines the `date-*` aliases used thr
 
 Recreate or restart containers after editing `.env` so Docker Compose passes the updated values into services.
 
-Once that is loaded, the `date-*` commands are the normal way to work with the project.
+Once the aliases are registered, the `date-*` commands are the normal way to work with the project.
 
 ## Database, migrations, and seed data
 
@@ -139,8 +152,7 @@ The production stack relies on the published container image at `ghcr.io/datatek
    ```bash
    docker network create web
    ```
-3. Register the production aliases: `source env.sh prod`.
-4. Deploy: `date up -d`.
+3. Deploy: `docker compose up -d` or run `source env.sh` once and use `date up -d`.
 
 The stack brings up the `web` (Gunicorn), `asgi` (Daphne/Channels), `celery`, `db`, `redis`, and `nginx` services. Rolling deploys usually build a new GHCR image in CI, update `DATE_IMG_TAG`, then restart `web`, `asgi`, and `celery`.
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ Docker Compose reads `.env` automatically. Create it once from `.env.example`, t
 - `.env.example` sets `COMPOSE_FILE=docker-compose.yml`.
 - `.env.prod.example` sets `COMPOSE_FILE=docker-compose.prod.yml`.
 - `source env.sh` registers the `date-*` aliases without loading or changing app configuration.
+- The helpers use the nearest `date-website` checkout from your current directory, so globally installed helpers follow whichever clone you are working in. When you are outside a checkout, they fall back to `DATE_WEBSITE_DIR`.
 
 If you use these helpers often, install them into your shell config:
 
 ```bash
 ./scripts/install_shell_aliases.sh
 ```
+
+The installer writes the current checkout path as `DATE_WEBSITE_DIR`, which is only used as the fallback target when your shell is not inside a checkout.
 
 Or add them manually and adjust the path to wherever you cloned the repository:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://github.com/datateknologerna-vid-abo-akademi/date-website.git
 cd date-website
 git checkout develop
 cp .env.example .env            # adjust passwords, ports, S3, etc.
-source env.sh dev               # loads .env and registers helper aliases
+source env.sh dev               # registers helper aliases
 date-start-detached             # builds containers, runs migrations, collects static files
 date-createsuperuser            # creates your admin account
 open http://localhost:8000      # admin lives at /admin
@@ -67,11 +67,13 @@ date-start-detached
 
 ## Environment configuration & helper aliases
 
-`env.sh` centralises environment loading:
+Docker Compose reads `.env` automatically. Create it once from `.env.example`, then edit it for your local or deployed environment.
 
-- `source env.sh dev` uses `.env` (falling back to `.env.example`) and sets `DATE_DEVELOP=True`, which in turn selects `docker-compose.yml`.
-- `source env.sh prod` prefers `.env.prod`, flips `DATE_DEVELOP=False`, and switches aliases to `docker-compose.prod.yml`.
-- `source env.sh path/to/custom.env` lets you provide an explicit file (relative or absolute path).
+`env.sh` is only for helper aliases:
+
+- `source env.sh dev` points the `date-*` aliases at `docker-compose.yml`.
+- `source env.sh prod` points the `date-*` aliases at `docker-compose.prod.yml`.
+- `source env.sh path/to/compose.yml` points the aliases at a custom Compose file.
 
 Important environment flags:
 
@@ -91,7 +93,7 @@ The script exports `COMPOSE_FILE_PATH` and defines the `date-*` aliases used thr
 | `date-pull` | Pull the defined Docker images. |
 | `date-cleaninit` | Reset local data and reload the development fixtures plus generated sample media. |
 
-Reload `env.sh` whenever you edit the `.env` files so the aliases pick up your changes.
+Recreate or restart containers after editing `.env` so Docker Compose passes the updated values into services.
 
 Once that is loaded, the `date-*` commands are the normal way to work with the project.
 
@@ -132,13 +134,13 @@ For translation architecture and workflow, see [docs/dev/translations.md](docs/d
 
 The production stack relies on the published container image at `ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}` plus managed PostgreSQL/Valkey volumes. Typical flow:
 
-1. Place your production secrets in `.env.prod` (or pass a custom env file to `env.sh`).
+1. Copy `.env.prod.example` to `.env` on the deployment host and replace every placeholder.
 2. Ensure the external Docker network referenced by the compose file exists once:
    ```bash
    docker network create web
    ```
-3. Load the production env vars: `source env.sh prod`.
-4. Deploy: `docker compose -f docker-compose.prod.yml up -d`.
+3. Register the production aliases: `source env.sh prod`.
+4. Deploy: `date up -d`.
 
 The stack brings up the `web` (Gunicorn), `asgi` (Daphne/Channels), `celery`, `db`, `redis`, and `nginx` services. Rolling deploys usually build a new GHCR image in CI, update `DATE_IMG_TAG`, then restart `web`, `asgi`, and `celery`.
 
@@ -181,7 +183,7 @@ Only use `update-postgres.sh` for **major** PostgreSQL version upgrades. The scr
 
 1. Set `DATE_POSTGRESQL_VERSION` to the **current** version in your `.env`.
 2. Run `./update-postgres.sh <target_version> [env_file]`.
-3. Re-source your env (`source env.sh dev`) and restart the stack.
+3. Restart the stack.
 
 The script now refuses same-major upgrades, verifies that PostgreSQL is storing data inside a mounted volume before it removes anything, and compares the restored schema against the source database before declaring success.
 
@@ -193,7 +195,7 @@ For minor upgrades, change `DATE_POSTGRESQL_VERSION` and recreate the containers
 
 - `date-start` fails with "docker: permission denied": add your user to the `docker` group (`sudo usermod -aG docker $USER`) and reopen the terminal.
 - Shell complains about `clean_init.sh`: run it explicitly with Bash (`/bin/bash scripts/clean_init.sh`).
-- Services restarted but settings not updated: ensure you re-run `source env.sh dev|prod` after editing `.env` files so `COMPOSE_FILE_PATH` and aliases refresh.
+- Services restarted but settings not updated: recreate the affected containers after editing `.env`.
 
 ## Internationalization
 
@@ -326,7 +328,7 @@ Use the dedicated backup script for routine PostgreSQL backups:
 ```
 
 If no env argument is provided, the script resolves `prod`, which checks `.env.prod`, then `.env`, then `.env.example`.
-Like `env.sh`, you can also pass `dev` or a specific env file path.
+You can also pass `dev` or a specific env file path.
 If no `output_dir` is provided, backups are written to `./backups`.
 
 Each run creates two timestamped files that a collector script can scan across many similar repos:
@@ -371,10 +373,10 @@ Run
 ```
 
 The upgrade helper now calls `./scripts/backup_postgres.sh` first and reuses the generated SQL dump during restore.
-If no env argument is provided, it resolves `prod` first using the same lookup order as `env.sh`.
+If no env argument is provided, it resolves `prod` first using the backup script's lookup order.
 For upgrades, the resolved env file must be writable; the script will not modify `.env.example`.
 
-Run `source env.sh dev` afterward to reload your development configuration.
+Restart the stack afterward so containers use the updated `.env`.
 
 ## License
 

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -25,6 +25,21 @@ env = environ.Env(
     DEVELOP=(bool, False),
 )
 
+
+_MISSING = object()
+
+
+def env_alias(name, *aliases, cast=str, default=_MISSING):
+    for env_name in (name, *aliases):
+        if env_name in os.environ:
+            return env(env_name, cast)
+
+    if default is _MISSING:
+        return env(name, cast)
+
+    return default
+
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -32,12 +47,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env('SECRET_KEY', str, 'SECRET_KEY')
+SECRET_KEY = env_alias('DATE_SECRET_KEY', 'SECRET_KEY', default='SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env('DEBUG', bool, False)
+DEBUG = env_alias('DATE_DEBUG', 'DEBUG', cast=bool, default=False)
 
-DEVELOP = env('DEVELOP', bool, False)
+DEVELOP = env_alias('DATE_DEVELOP', 'DEVELOP', cast=bool, default=False)
 
 # This gets set only when tests are ran with date-test command
 TEST = env('TEST', bool, False)
@@ -147,7 +162,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': env('DB_DATABASE', str, 'postgres'),
         'USER': env('DB_USERNAME', str, 'postgres'),
-        'PASSWORD': env('DB_PASSWORD', default=''),
+        'PASSWORD': env_alias('DATE_DB_PASSWORD', 'DB_PASSWORD', default=''),
         'HOST': env('DB_HOST', str, 'db'),
         'PORT': env('DB_PORT', int, 5432)
     }
@@ -173,7 +188,7 @@ REDIS_CACHE = {
     },
 }
 
-CACHES = DUMMY_CACHE if env("DEVELOP") else REDIS_CACHE
+CACHES = DUMMY_CACHE if DEVELOP else REDIS_CACHE
 
 # Custom members model
 AUTH_USER_MODEL = 'members.Member'
@@ -275,15 +290,27 @@ STORAGES = {
 
 if USE_S3:
     # aws settings
-    AWS_S3_ENDPOINT_URL = env('AWS_S3_ENDPOINT_URL')
-    AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID')
-    AWS_SECRET_ACCESS_KEY = env('AWS_SECRET_ACCESS_KEY')
-    AWS_STORAGE_BUCKET_NAME = env('AWS_STORAGE_BUCKET_NAME')
-    AWS_PRIVATE_STORAGE_BUCKET_NAME = env('AWS_PRIVATE_STORAGE_BUCKET_NAME', str, '') or AWS_STORAGE_BUCKET_NAME
-    AWS_PUBLIC_STORAGE_BUCKET_NAME = env('AWS_PUBLIC_STORAGE_BUCKET_NAME', str, '') or AWS_STORAGE_BUCKET_NAME
-    AWS_S3_REGION_NAME = env('AWS_S3_REGION_NAME', str, None)
-    AWS_S3_SIGNATURE_VERSION = env('AWS_S3_SIGNATURE_VERSION', str, None)
-    AWS_S3_ADDRESSING_STYLE = env('AWS_S3_ADDRESSING_STYLE', str, None)
+    AWS_S3_ENDPOINT_URL = env_alias('S3_ENDPOINT_URL', 'AWS_S3_ENDPOINT_URL')
+    AWS_ACCESS_KEY_ID = env_alias('S3_ACCESS_KEY', 'AWS_ACCESS_KEY_ID')
+    AWS_SECRET_ACCESS_KEY = env_alias('S3_SECRET_KEY', 'AWS_SECRET_ACCESS_KEY')
+    AWS_STORAGE_BUCKET_NAME = env_alias('S3_BUCKET_NAME', 'AWS_STORAGE_BUCKET_NAME')
+    AWS_PRIVATE_STORAGE_BUCKET_NAME = (
+        env_alias(
+            'S3_PRIVATE_BUCKET_NAME',
+            'AWS_PRIVATE_STORAGE_BUCKET_NAME',
+            default='',
+        ) or AWS_STORAGE_BUCKET_NAME
+    )
+    AWS_PUBLIC_STORAGE_BUCKET_NAME = (
+        env_alias(
+            'S3_PUBLIC_BUCKET_NAME',
+            'AWS_PUBLIC_STORAGE_BUCKET_NAME',
+            default='',
+        ) or AWS_STORAGE_BUCKET_NAME
+    )
+    AWS_S3_REGION_NAME = env_alias('S3_REGION_NAME', 'AWS_S3_REGION_NAME', default=None)
+    AWS_S3_SIGNATURE_VERSION = env_alias('S3_SIGNATURE_VERSION', 'AWS_S3_SIGNATURE_VERSION', default=None)
+    AWS_S3_ADDRESSING_STYLE = env_alias('S3_ADDRESSING_STYLE', 'AWS_S3_ADDRESSING_STYLE', default=None)
     AWS_QUERYSTRING_AUTH = True
     AWS_QUERYSTRING_EXPIRE = 3600
 

--- a/docker-compose.dev-all.yml
+++ b/docker-compose.dev-all.yml
@@ -12,6 +12,7 @@
 #   pulterit → http://localhost:8004
 
 x-web-common: &web-common
+  env_file: .env
   build: .
   restart: unless-stopped
   volumes:
@@ -24,37 +25,8 @@ x-web-common: &web-common
       condition: service_started
 
 x-web-env: &web-env
-  SECRET_KEY: ${DATE_SECRET_KEY}
-  DEBUG: "True"
-  DEVELOP: "True"
-  DB_PASSWORD: ${DATE_DB_PASSWORD}
-  USE_S3: ${USE_S3}
-  AWS_S3_ENDPOINT_URL: ${S3_ENDPOINT_URL}
-  AWS_ACCESS_KEY_ID: ${S3_ACCESS_KEY}
-  AWS_SECRET_ACCESS_KEY: ${S3_SECRET_KEY}
-  AWS_STORAGE_BUCKET_NAME: ${S3_BUCKET_NAME}
-  AWS_PRIVATE_STORAGE_BUCKET_NAME: ${S3_PRIVATE_BUCKET_NAME:-}
-  AWS_PUBLIC_STORAGE_BUCKET_NAME: ${S3_PUBLIC_BUCKET_NAME:-}
-  AWS_S3_REGION_NAME: ${S3_REGION_NAME:-}
-  AWS_S3_SIGNATURE_VERSION: ${S3_SIGNATURE_VERSION:-}
-  AWS_S3_ADDRESSING_STYLE: ${S3_ADDRESSING_STYLE:-}
-  PUBLIC_MEDIA_LOCATION: ${PUBLIC_MEDIA_LOCATION}
-  PRIVATE_MEDIA_LOCATION: ${PRIVATE_MEDIA_LOCATION}
-  ALLOWED_HOSTS: ${ALLOWED_HOSTS}
-  ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
-  EXTRA_STAFF_GROUPS: ${EXTRA_STAFF_GROUPS}
-  EMAIL_HOST_RECEIVER: ${EMAIL_HOST_RECEIVER}
-  DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
-  EMAIL_HOST: ${EMAIL_HOST}
-  EMAIL_HOST_USER: ${EMAIL_HOST_USER}
-  EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
-  CF_TURNSTILE_SITE_KEY: ${CF_TURNSTILE_SITE_KEY}
-  CF_TURNSTILE_SECRET_KEY: ${CF_TURNSTILE_SECRET_KEY}
-  ALUMNI_SETTINGS: ${ALUMNI_SETTINGS}
-  ENABLE_LANGUAGE_FEATURES: ${ENABLE_LANGUAGE_FEATURES}
-  GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
-  GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
-  GITHUB_MFA_POLICY: ${GITHUB_MFA_POLICY:-enrolled}
+  DATE_DEBUG: "True"
+  DATE_DEVELOP: "True"
 
 services:
   db:
@@ -67,8 +39,8 @@ services:
       - dev_all_postgres_data:/var/lib/postgresql/data/
       - ./scripts/postgres-entrypoint.sh:/scripts/postgres-entrypoint.sh:ro
     environment:
-      - POSTGRES_PASSWORD=${DATE_DB_PASSWORD}
-      - PGDATA=/var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: ${DATE_DB_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - "5433:5432"
 
@@ -82,6 +54,7 @@ services:
   # representative project). All web containers wait for this to finish before
   # starting, so they only need to serve requests.
   init:
+    env_file: .env
     build: .
     restart: "no"
     command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python manage.py migrate --noinput && python manage.py collectstatic --noinput && python manage.py compilemessages -l en -l fi -l sv --verbosity 0"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,109 +9,35 @@ services:
       - date_postgres_data:/var/lib/postgresql/data/
       - ./scripts/postgres-entrypoint.sh:/scripts/postgres-entrypoint.sh:ro
     environment:
-      - POSTGRES_PASSWORD=${DATE_DB_PASSWORD}
-      - PGDATA=/var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: ${DATE_DB_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
     networks:
       - internal
   web:
+    env_file: .env
     image: ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}
     restart: always
     command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn -w 3 --max-requests 1000 --max-requests-jitter 100 --bind=0.0.0.0 core.wsgi"
-    environment:
-      - SECRET_KEY=${DATE_SECRET_KEY}
-      - APP_VERSION=${DATE_IMG_TAG}
-      - DEBUG=${DATE_DEBUG}
-      - DEVELOP=${DATE_DEVELOP}
-      - PROJECT_NAME=${PROJECT_NAME}
-      - ENABLE_LANGUAGE_FEATURES=${ENABLE_LANGUAGE_FEATURES}
-      - DB_PASSWORD=${DATE_DB_PASSWORD}
-      - USE_S3=${USE_S3}
-      - AWS_S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
-      - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}
-      - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
-      - AWS_STORAGE_BUCKET_NAME=${S3_BUCKET_NAME}
-      - AWS_PRIVATE_STORAGE_BUCKET_NAME=${S3_PRIVATE_BUCKET_NAME:-}
-      - AWS_PUBLIC_STORAGE_BUCKET_NAME=${S3_PUBLIC_BUCKET_NAME:-}
-      - AWS_S3_REGION_NAME=${S3_REGION_NAME:-}
-      - AWS_S3_SIGNATURE_VERSION=${S3_SIGNATURE_VERSION:-}
-      - AWS_S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-}
-      - PUBLIC_MEDIA_LOCATION=${PUBLIC_MEDIA_LOCATION}
-      - PRIVATE_MEDIA_LOCATION=${PRIVATE_MEDIA_LOCATION}
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
-      - EXTRA_STAFF_GROUPS=${EXTRA_STAFF_GROUPS}
-      - EMAIL_HOST_RECEIVER=${EMAIL_HOST_RECEIVER}
-      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - EMAIL_HOST_USER=${EMAIL_HOST_USER}
-      - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - CF_TURNSTILE_SITE_KEY=${CF_TURNSTILE_SITE_KEY}
-      - CF_TURNSTILE_SECRET_KEY=${CF_TURNSTILE_SECRET_KEY}
-      - ALUMNI_SETTINGS=${ALUMNI_SETTINGS}
-      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
-      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
-      - GITHUB_MFA_POLICY=${GITHUB_MFA_POLICY:-enrolled}
     depends_on:
       - db
       - redis
     networks:
       - internal
   asgi:
+    env_file: .env
     image: ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}
     restart: always
     command: /bin/bash -c "./wait-for-postgres.sh db:5432 && daphne -b 0.0.0.0 core.routing:application"
-    environment:
-      - SECRET_KEY=${DATE_SECRET_KEY}
-      - APP_VERSION=${DATE_IMG_TAG}
-      - DEBUG=${DATE_DEBUG}
-      - DEVELOP=${DATE_DEVELOP}
-      - PROJECT_NAME=${PROJECT_NAME}
-      - ENABLE_LANGUAGE_FEATURES=${ENABLE_LANGUAGE_FEATURES}
-      - DB_PASSWORD=${DATE_DB_PASSWORD}
-      - USE_S3=${USE_S3}
-      - AWS_S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
-      - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}
-      - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
-      - AWS_STORAGE_BUCKET_NAME=${S3_BUCKET_NAME}
-      - AWS_PRIVATE_STORAGE_BUCKET_NAME=${S3_PRIVATE_BUCKET_NAME:-}
-      - AWS_PUBLIC_STORAGE_BUCKET_NAME=${S3_PUBLIC_BUCKET_NAME:-}
-      - AWS_S3_REGION_NAME=${S3_REGION_NAME:-}
-      - AWS_S3_SIGNATURE_VERSION=${S3_SIGNATURE_VERSION:-}
-      - AWS_S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-}
-      - PUBLIC_MEDIA_LOCATION=${PUBLIC_MEDIA_LOCATION}
-      - PRIVATE_MEDIA_LOCATION=${PRIVATE_MEDIA_LOCATION}
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
-      - EXTRA_STAFF_GROUPS=${EXTRA_STAFF_GROUPS}
-      - EMAIL_HOST_RECEIVER=${EMAIL_HOST_RECEIVER}
-      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - EMAIL_HOST_USER=${EMAIL_HOST_USER}
-      - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - CF_TURNSTILE_SITE_KEY=${CF_TURNSTILE_SITE_KEY}
-      - CF_TURNSTILE_SECRET_KEY=${CF_TURNSTILE_SECRET_KEY}
-      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
-      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
-      - GITHUB_MFA_POLICY=${GITHUB_MFA_POLICY:-enrolled}
     depends_on:
       - db
       - redis
     networks:
       - internal
   celery:
+    env_file: .env
     restart: always
     image: ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}
     command: celery -A core worker -l info -c 2
-    environment:
-      - DEBUG=${DATE_DEBUG}
-      - APP_VERSION=${DATE_IMG_TAG}
-      - ENABLE_LANGUAGE_FEATURES=${ENABLE_LANGUAGE_FEATURES}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
-      - EMAIL_HOST_USER=${EMAIL_HOST_USER}
-      - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - ALUMNI_SETTINGS=${ALUMNI_SETTINGS}
-      - DB_PASSWORD=${DATE_DB_PASSWORD}
     depends_on:
       - db
       - redis
@@ -120,8 +46,6 @@ services:
   redis:
     restart: always
     image: valkey/valkey:7.2-alpine
-    ports:
-      - ${REDIS_PORT}:6379
     networks:
       - internal
     volumes:
@@ -129,8 +53,6 @@ services:
   nginx:
     restart: always
     image: nginx:stable-alpine
-    ports:
-      - ${DATE_DJANGO_PORT}:80
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,10 @@ services:
       - date_postgres_data:/var/lib/postgresql/data/
       - ./scripts/postgres-entrypoint.sh:/scripts/postgres-entrypoint.sh:ro
     environment:
-      - POSTGRES_PASSWORD=${DATE_DB_PASSWORD}
-      - PGDATA=/var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: ${DATE_DB_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
   web:
+    env_file: .env
     build: .
     restart: unless-stopped
     #igSheduler startup command (nohup python /code/social/igupdate.py &) &&
@@ -20,56 +21,16 @@ services:
       - .:/code
     ports:
       - ${DATE_DJANGO_PORT}:8000
-    environment:
-      - SECRET_KEY=${DATE_SECRET_KEY}
-      - DEBUG=${DATE_DEBUG}
-      - DEVELOP=${DATE_DEVELOP}
-      - PROJECT_NAME=${PROJECT_NAME}
-      - DB_PASSWORD=${DATE_DB_PASSWORD}
-      - USE_S3=${USE_S3}
-      - AWS_S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
-      - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}
-      - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
-      - AWS_STORAGE_BUCKET_NAME=${S3_BUCKET_NAME}
-      - AWS_PRIVATE_STORAGE_BUCKET_NAME=${S3_PRIVATE_BUCKET_NAME:-}
-      - AWS_PUBLIC_STORAGE_BUCKET_NAME=${S3_PUBLIC_BUCKET_NAME:-}
-      - AWS_S3_REGION_NAME=${S3_REGION_NAME:-}
-      - AWS_S3_SIGNATURE_VERSION=${S3_SIGNATURE_VERSION:-}
-      - AWS_S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-}
-      - PUBLIC_MEDIA_LOCATION=${PUBLIC_MEDIA_LOCATION}
-      - PRIVATE_MEDIA_LOCATION=${PRIVATE_MEDIA_LOCATION}
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
-      - EXTRA_STAFF_GROUPS=${EXTRA_STAFF_GROUPS}
-      - EMAIL_HOST_RECEIVER=${EMAIL_HOST_RECEIVER}
-      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - EMAIL_HOST_USER=${EMAIL_HOST_USER}
-      - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - CF_TURNSTILE_SITE_KEY=${CF_TURNSTILE_SITE_KEY}
-      - CF_TURNSTILE_SECRET_KEY=${CF_TURNSTILE_SECRET_KEY}
-      - ALUMNI_SETTINGS=${ALUMNI_SETTINGS}
-      - ENABLE_LANGUAGE_FEATURES=${ENABLE_LANGUAGE_FEATURES}
-      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
-      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
-      - GITHUB_MFA_POLICY=${GITHUB_MFA_POLICY:-enrolled}
     depends_on:
       - db
       - redis
   celery:
+    env_file: .env
     restart: unless-stopped
     build: .
     command: celery -A core worker -l info -c 2
     volumes:
       - .:/code
-    environment:
-      - DEBUG=${DATE_DEBUG}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - EMAIL_HOST_USER=${EMAIL_HOST_USER}
-      - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
-      - ALUMNI_SETTINGS=${ALUMNI_SETTINGS}
-      - DB_PASSWORD=${DATE_DB_PASSWORD}
     depends_on:
       - web
       - redis

--- a/docs/dev/operations.md
+++ b/docs/dev/operations.md
@@ -11,7 +11,7 @@ Most scripts assume:
 - you run them from the repository root or via their documented path
 - Docker is installed and available in `PATH`
 - you are not running the script from inside a container
-- the environment is resolved through `env.sh` or the same helper logic used by `scripts/lib/date_env.sh`
+- `.env` exists in the repository root
 
 Unless a script says otherwise, prefer running it from a Bash-compatible shell.
 
@@ -25,7 +25,7 @@ What it does:
 
 - warns before destructive actions
 - optionally deletes uploaded media under `media/archive` and `media/pdfs`
-- loads the development environment through `env.sh dev`
+- uses the repository `.env` through Docker Compose
 - rebuilds and starts the database service
 - recreates the PostgreSQL database from scratch
 - runs migrations
@@ -87,7 +87,7 @@ The `web` service (port 8002) is named `web` specifically so `clean_init.sh` can
 #### Notes
 
 - Static files are collected once by `init` at startup. If you change CSS or JS, restart with `date-all-start` to pick up the changes.
-- The `date-all-cleaninit` alias passes `COMPOSE_FILE_PATH=docker-compose.dev-all.yml` before sourcing `env.sh`, which `clean_init.sh` preserves to avoid being overridden.
+- The `date-all-cleaninit` alias passes `COMPOSE_FILE_PATH=docker-compose.dev-all.yml` so `clean_init.sh` targets the dev-all stack.
 
 ## Backups and Database Upgrades
 
@@ -103,7 +103,7 @@ Typical usage:
 
 Behavior:
 
-- resolves the environment file with the same lookup rules as `env.sh`
+- resolves an environment file with `scripts/lib/date_env.sh`
 - starts the `db` service if needed
 - waits for PostgreSQL readiness
 - creates a plain SQL dump

--- a/docs/dev/operations.md
+++ b/docs/dev/operations.md
@@ -69,7 +69,9 @@ Each association gets its own web container on a dedicated port, sharing one Pos
 
 The database is exposed on host port `5433` to avoid conflicting with the regular dev stack on `5432`.
 
-#### Aliases (after `source env.sh` or adding the helpers to your shell config)
+#### Helpers (after `source env.sh` or adding them to your shell config)
+
+The helpers use the nearest `date-website` checkout from your current directory, falling back to `DATE_WEBSITE_DIR` when you are outside a checkout.
 
 ```bash
 date-all-start       # build and start all containers

--- a/docs/dev/operations.md
+++ b/docs/dev/operations.md
@@ -65,12 +65,11 @@ Each association gets its own web container on a dedicated port, sharing one Pos
 | biocum      | http://localhost:8001 |
 | date        | http://localhost:8002 |
 | kk          | http://localhost:8003 |
-| on          | http://localhost:8004 |
-| pulterit    | http://localhost:8005 |
+| pulterit    | http://localhost:8004 |
 
 The database is exposed on host port `5433` to avoid conflicting with the regular dev stack on `5432`.
 
-#### Aliases (after `source env.sh`)
+#### Aliases (after `source env.sh` or adding the helpers to your shell config)
 
 ```bash
 date-all-start       # build and start all containers
@@ -87,7 +86,7 @@ The `web` service (port 8002) is named `web` specifically so `clean_init.sh` can
 #### Notes
 
 - Static files are collected once by `init` at startup. If you change CSS or JS, restart with `date-all-start` to pick up the changes.
-- The `date-all-cleaninit` alias passes `COMPOSE_FILE_PATH=docker-compose.dev-all.yml` so `clean_init.sh` targets the dev-all stack.
+- The `date-all-cleaninit` alias passes `COMPOSE_FILE_PATH=docker-compose.dev-all.yml` directly to `clean_init.sh` so it targets the dev-all stack.
 
 ## Backups and Database Upgrades
 

--- a/env.sh
+++ b/env.sh
@@ -1,38 +1,19 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DEFAULT_MODE="dev"
-REQUESTED_MODE="${1:-$DEFAULT_MODE}"
+DATE_WEBSITE_DIR="${DATE_WEBSITE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
-if [ -n "${2:-}" ]; then
-    echo "Usage: source env.sh [dev|prod|path/to/compose.yml]" >&2
+if [ -n "${1:-}" ]; then
+    echo "Usage: source env.sh" >&2
+    echo "COMPOSE_FILE in .env selects the stack; env.sh only registers helper aliases." >&2
     return 1 2>/dev/null || exit 1
 fi
 
-case "$REQUESTED_MODE" in
-    dev)
-        export COMPOSE_FILE_PATH="docker-compose.yml"
-        ;;
-    prod)
-        export COMPOSE_FILE_PATH="docker-compose.prod.yml"
-        ;;
-    *)
-        export COMPOSE_FILE_PATH="$REQUESTED_MODE"
-        ;;
-esac
-
-if [[ "$COMPOSE_FILE_PATH" = /* ]]; then
-    DATE_COMPOSE_FILE="$COMPOSE_FILE_PATH"
-else
-    DATE_COMPOSE_FILE="${SCRIPT_DIR}/${COMPOSE_FILE_PATH}"
-fi
-
-alias date="docker compose --project-directory \"${SCRIPT_DIR}\" -f \"${DATE_COMPOSE_FILE}\""
+alias date="docker compose --project-directory \"${DATE_WEBSITE_DIR}\""
 alias date-manage="date run web python /code/manage.py"
 alias date-migrate="date-manage migrate --noinput"
 alias date-makemigrations="date-manage makemigrations"
 alias date-collectstatic="date-manage collectstatic"
-alias date-cleaninit="\"${SCRIPT_DIR}/scripts/clean_init.sh\""
+alias date-cleaninit="\"${DATE_WEBSITE_DIR}/scripts/clean_init.sh\""
 alias date-stop="date down"
 alias date-start="date-pull; date-stop; date up --build"
 alias date-start-detached="date-pull; date up -d --build"
@@ -41,14 +22,14 @@ alias date-pull="date pull"
 alias date-seed-gallery="date-manage seed_gallery"
 alias date-seed-gallery-clear="date-manage seed_gallery --clear"
 
-alias date-all="docker compose --project-directory \"${SCRIPT_DIR}\" -f \"${SCRIPT_DIR}/docker-compose.dev-all.yml\""
+alias date-all="docker compose --project-directory \"${DATE_WEBSITE_DIR}\" -f \"${DATE_WEBSITE_DIR}/docker-compose.dev-all.yml\""
 alias date-all-manage="date-all run web python /code/manage.py"
 alias date-all-start="date-all up --build"
 alias date-all-stop="date-all down"
-alias date-all-cleaninit="COMPOSE_FILE_PATH=\"docker-compose.dev-all.yml\" \"${SCRIPT_DIR}/scripts/clean_init.sh\""
+alias date-all-cleaninit="COMPOSE_FILE_PATH=\"docker-compose.dev-all.yml\" \"${DATE_WEBSITE_DIR}/scripts/clean_init.sh\""
 alias date-all-seed-gallery="date-all-manage seed_gallery"
 alias date-all-seed-gallery-clear="date-all-manage seed_gallery --clear"
 
 date-test() {
-    docker compose --project-directory "${SCRIPT_DIR}" -f "${DATE_COMPOSE_FILE}" run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"'
+    docker compose --project-directory "${DATE_WEBSITE_DIR}" run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"' -- "$@"
 }

--- a/env.sh
+++ b/env.sh
@@ -1,35 +1,38 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1091
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/scripts/lib/date_env.sh"
 DEFAULT_MODE="dev"
 REQUESTED_MODE="${1:-$DEFAULT_MODE}"
 
 if [ -n "${2:-}" ]; then
-    echo "Usage: source env.sh [dev|prod|path/to/env]" >&2
+    echo "Usage: source env.sh [dev|prod|path/to/compose.yml]" >&2
     return 1 2>/dev/null || exit 1
 fi
 
-ENV_FILE="$(date_resolve_env_file "$SCRIPT_DIR" "$REQUESTED_MODE")" || {
-    return 1 2>/dev/null || exit 1
-}
-ENV_MODE="$(date_resolve_env_mode "$REQUESTED_MODE" "$ENV_FILE")"
+case "$REQUESTED_MODE" in
+    dev)
+        export COMPOSE_FILE_PATH="docker-compose.yml"
+        ;;
+    prod)
+        export COMPOSE_FILE_PATH="docker-compose.prod.yml"
+        ;;
+    *)
+        export COMPOSE_FILE_PATH="$REQUESTED_MODE"
+        ;;
+esac
 
-set -a
-. "${ENV_FILE}"
-set +a
+if [[ "$COMPOSE_FILE_PATH" = /* ]]; then
+    DATE_COMPOSE_FILE="$COMPOSE_FILE_PATH"
+else
+    DATE_COMPOSE_FILE="${SCRIPT_DIR}/${COMPOSE_FILE_PATH}"
+fi
 
-date_apply_env_mode "$ENV_MODE"
-
-export COMPOSE_FILE_PATH="$(date_resolve_compose_file)"
-
-alias date="docker compose -f \"${COMPOSE_FILE_PATH}\""
+alias date="docker compose --project-directory \"${SCRIPT_DIR}\" -f \"${DATE_COMPOSE_FILE}\""
 alias date-manage="date run web python /code/manage.py"
 alias date-migrate="date-manage migrate --noinput"
 alias date-makemigrations="date-manage makemigrations"
 alias date-collectstatic="date-manage collectstatic"
-alias date-cleaninit="./scripts/clean_init.sh"
+alias date-cleaninit="\"${SCRIPT_DIR}/scripts/clean_init.sh\""
 alias date-stop="date down"
 alias date-start="date-pull; date-stop; date up --build"
 alias date-start-detached="date-pull; date up -d --build"
@@ -38,7 +41,7 @@ alias date-pull="date pull"
 alias date-seed-gallery="date-manage seed_gallery"
 alias date-seed-gallery-clear="date-manage seed_gallery --clear"
 
-alias date-all="docker compose -f \"${SCRIPT_DIR}/docker-compose.dev-all.yml\""
+alias date-all="docker compose --project-directory \"${SCRIPT_DIR}\" -f \"${SCRIPT_DIR}/docker-compose.dev-all.yml\""
 alias date-all-manage="date-all run web python /code/manage.py"
 alias date-all-start="date-all up --build"
 alias date-all-stop="date-all down"
@@ -47,5 +50,5 @@ alias date-all-seed-gallery="date-all-manage seed_gallery"
 alias date-all-seed-gallery-clear="date-all-manage seed_gallery --clear"
 
 date-test() {
-    docker compose run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"'
+    docker compose --project-directory "${SCRIPT_DIR}" -f "${DATE_COMPOSE_FILE}" run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"'
 }

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-DATE_WEBSITE_DIR="${DATE_WEBSITE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    DATE_WEBSITE_SOURCE="${BASH_SOURCE[0]}"
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    DATE_WEBSITE_SOURCE="${(%):-%x}"
+else
+    DATE_WEBSITE_SOURCE="$0"
+fi
+
+DATE_WEBSITE_DIR="${DATE_WEBSITE_DIR:-$(cd "$(dirname "$DATE_WEBSITE_SOURCE")" && pwd)}"
 
 if [ -n "${1:-}" ]; then
     echo "Usage: source env.sh" >&2
@@ -8,28 +16,129 @@ if [ -n "${1:-}" ]; then
     return 1 2>/dev/null || exit 1
 fi
 
-alias date="docker compose --project-directory \"${DATE_WEBSITE_DIR}\""
-alias date-manage="date run web python /code/manage.py"
-alias date-migrate="date-manage migrate --noinput"
-alias date-makemigrations="date-manage makemigrations"
-alias date-collectstatic="date-manage collectstatic"
-alias date-cleaninit="\"${DATE_WEBSITE_DIR}/scripts/clean_init.sh\""
-alias date-stop="date down"
-alias date-start="date-pull; date-stop; date up --build"
-alias date-start-detached="date-pull; date up -d --build"
-alias date-createsuperuser="date-manage createsuperuser"
-alias date-pull="date pull"
-alias date-seed-gallery="date-manage seed_gallery"
-alias date-seed-gallery-clear="date-manage seed_gallery --clear"
+unalias date date-manage date-migrate date-makemigrations date-collectstatic \
+    date-cleaninit date-stop date-start date-start-detached date-createsuperuser \
+    date-pull date-seed-gallery date-seed-gallery-clear date-all date-all-manage \
+    date-all-start date-all-stop date-all-cleaninit date-all-seed-gallery \
+    date-all-seed-gallery-clear 2>/dev/null || true
 
-alias date-all="docker compose --project-directory \"${DATE_WEBSITE_DIR}\" -f \"${DATE_WEBSITE_DIR}/docker-compose.dev-all.yml\""
-alias date-all-manage="date-all run web python /code/manage.py"
-alias date-all-start="date-all up --build"
-alias date-all-stop="date-all down"
-alias date-all-cleaninit="COMPOSE_FILE_PATH=\"docker-compose.dev-all.yml\" \"${DATE_WEBSITE_DIR}/scripts/clean_init.sh\""
-alias date-all-seed-gallery="date-all-manage seed_gallery"
-alias date-all-seed-gallery-clear="date-all-manage seed_gallery --clear"
+# Resolve the checkout to operate on. This lets globally installed helpers
+# follow the current working directory while still having DATE_WEBSITE_DIR as a
+# fallback when run outside any checkout.
+_date_website_project_dir() {
+    local dir
+    dir="$PWD"
+
+    while [ "$dir" != "/" ]; do
+        if [ -f "$dir/env.sh" ] && [ -f "$dir/docker-compose.yml" ] && [ -f "$dir/manage.py" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+
+    if [ -n "${DATE_WEBSITE_DIR:-}" ] && [ -d "$DATE_WEBSITE_DIR" ]; then
+        printf '%s\n' "$DATE_WEBSITE_DIR"
+        return 0
+    fi
+
+    echo "Could not find a date-website checkout. cd into one or set DATE_WEBSITE_DIR." >&2
+    return 1
+}
+
+date() {
+    local project_dir
+    project_dir="$(_date_website_project_dir)" || return
+    docker compose --project-directory "$project_dir" "$@"
+}
+
+date-manage() {
+    date run web python /code/manage.py "$@"
+}
+
+date-migrate() {
+    date-manage migrate --noinput "$@"
+}
+
+date-makemigrations() {
+    date-manage makemigrations "$@"
+}
+
+date-collectstatic() {
+    date-manage collectstatic "$@"
+}
+
+date-cleaninit() {
+    local project_dir
+    project_dir="$(_date_website_project_dir)" || return
+    "$project_dir/scripts/clean_init.sh" "$@"
+}
+
+date-stop() {
+    date down "$@"
+}
+
+date-start() {
+    date-pull
+    date-stop
+    date up --build "$@"
+}
+
+date-start-detached() {
+    date-pull
+    date up -d --build "$@"
+}
+
+date-createsuperuser() {
+    date-manage createsuperuser "$@"
+}
+
+date-pull() {
+    date pull "$@"
+}
+
+date-seed-gallery() {
+    date-manage seed_gallery "$@"
+}
+
+date-seed-gallery-clear() {
+    date-manage seed_gallery --clear "$@"
+}
+
+date-all() {
+    local project_dir
+    project_dir="$(_date_website_project_dir)" || return
+    docker compose --project-directory "$project_dir" -f "$project_dir/docker-compose.dev-all.yml" "$@"
+}
+
+date-all-manage() {
+    date-all run web python /code/manage.py "$@"
+}
+
+date-all-start() {
+    date-all up --build "$@"
+}
+
+date-all-stop() {
+    date-all down "$@"
+}
+
+date-all-cleaninit() {
+    local project_dir
+    project_dir="$(_date_website_project_dir)" || return
+    COMPOSE_FILE_PATH="docker-compose.dev-all.yml" "$project_dir/scripts/clean_init.sh" "$@"
+}
+
+date-all-seed-gallery() {
+    date-all-manage seed_gallery "$@"
+}
+
+date-all-seed-gallery-clear() {
+    date-all-manage seed_gallery --clear "$@"
+}
 
 date-test() {
-    docker compose --project-directory "${DATE_WEBSITE_DIR}" run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"' -- "$@"
+    local project_dir
+    project_dir="$(_date_website_project_dir)" || return
+    docker compose --project-directory "$project_dir" run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"' -- "$@"
 }

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -30,11 +30,16 @@ set -a
 source "$config_file"
 set +a
 
+config_compose_file="$(date_read_env_value "$config_file" COMPOSE_FILE)"
 date_apply_env_mode "$resolved_mode"
 
-compose_file="$(date_resolve_compose_file)"
+compose_file="$(date_resolve_compose_file "$resolved_mode" "$config_compose_file")"
 
-compose_path="${PROJECT_ROOT}/${compose_file}"
+if [[ "$compose_file" = /* ]]; then
+  compose_path="$compose_file"
+else
+  compose_path="${PROJECT_ROOT}/${compose_file}"
+fi
 if [ ! -f "$compose_path" ]; then
   echo "Compose file $compose_path not found"
   exit 1
@@ -58,7 +63,7 @@ dump_file="${output_dir}/${project_name}-${timestamp}.sql"
 manifest_file="${output_dir}/${project_name}-${timestamp}.json"
 
 docker_compose() {
-  docker compose -f "$compose_path" "$@"
+  docker compose --project-directory "$PROJECT_ROOT" -f "$compose_path" "$@"
 }
 
 db_started_by_script=0

--- a/scripts/clean_init.sh
+++ b/scripts/clean_init.sh
@@ -19,6 +19,24 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     DELETE_MEDIA=true
 fi
 
+read_compose_file_from_env() {
+    local env_file="$PROJECT_DIR/.env"
+
+    if [[ ! -f "$env_file" ]]; then
+        return 0
+    fi
+
+    (
+        unset COMPOSE_FILE
+        set -a
+        # shellcheck disable=SC1090
+        source "$env_file"
+        set +a
+        printf '%s' "${COMPOSE_FILE:-}"
+    )
+}
+
+COMPOSE_FILE_PATH="${COMPOSE_FILE_PATH:-$(read_compose_file_from_env)}"
 COMPOSE_FILE_PATH="${COMPOSE_FILE_PATH:-docker-compose.yml}"
 if [[ "$COMPOSE_FILE_PATH" = /* ]]; then
     COMPOSE_PATH="$COMPOSE_FILE_PATH"

--- a/scripts/clean_init.sh
+++ b/scripts/clean_init.sh
@@ -19,13 +19,16 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     DELETE_MEDIA=true
 fi
 
-# Preserve any caller-supplied COMPOSE_FILE_PATH before env.sh overwrites it.
-_COMPOSE_FILE_PATH_OVERRIDE="${COMPOSE_FILE_PATH:-}"
-source "$PROJECT_DIR/env.sh" dev
-if [ -n "$_COMPOSE_FILE_PATH_OVERRIDE" ]; then
-    COMPOSE_FILE_PATH="$_COMPOSE_FILE_PATH_OVERRIDE"
+COMPOSE_FILE_PATH="${COMPOSE_FILE_PATH:-docker-compose.yml}"
+if [[ "$COMPOSE_FILE_PATH" = /* ]]; then
+    COMPOSE_PATH="$COMPOSE_FILE_PATH"
+else
+    COMPOSE_PATH="$PROJECT_DIR/$COMPOSE_FILE_PATH"
 fi
-COMPOSE_PATH="$PROJECT_DIR/${COMPOSE_FILE_PATH:-docker-compose.yml}"
+
+docker_compose() {
+    docker compose --project-directory "$PROJECT_DIR" -f "$COMPOSE_PATH" "$@"
+}
 
 validate_fixtures() {
     echo "Validating fixtures..."
@@ -48,7 +51,7 @@ wait_for_db() {
     local max_attempts=30
     local attempt=0
     while [[ $attempt -lt $max_attempts ]]; do
-        if docker compose -f "$COMPOSE_PATH" exec -T db pg_isready -U postgres -q 2>/dev/null; then
+        if docker_compose exec -T db pg_isready -U postgres -q 2>/dev/null; then
             echo "Database is ready."
             return 0
         fi
@@ -69,25 +72,25 @@ if [[ "$DELETE_MEDIA" == "true" ]]; then
 fi
 
 echo "Shutting down containers..."
-docker compose -f "$COMPOSE_PATH" down --remove-orphans
+docker_compose down --remove-orphans
 
 echo "Building required images and starting database container..."
-docker compose -f "$COMPOSE_PATH" build db web
-docker compose -f "$COMPOSE_PATH" up -d db
+docker_compose build db web
+docker_compose up -d db
 
 wait_for_db
 
 echo "Recreating database..."
-docker compose -f "$COMPOSE_PATH" exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS temp;" 2>/dev/null || true
-docker compose -f "$COMPOSE_PATH" exec -T db psql -U postgres -c "CREATE DATABASE temp;"
-docker compose -f "$COMPOSE_PATH" exec -T db psql -U postgres -d temp -c "DROP DATABASE postgres;"
-docker compose -f "$COMPOSE_PATH" exec -T db psql -U postgres -d temp -c "CREATE DATABASE postgres;"
-docker compose -f "$COMPOSE_PATH" exec -T db psql -U postgres -c "DROP DATABASE temp;"
+docker_compose exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS temp;" 2>/dev/null || true
+docker_compose exec -T db psql -U postgres -c "CREATE DATABASE temp;"
+docker_compose exec -T db psql -U postgres -d temp -c "DROP DATABASE postgres;"
+docker_compose exec -T db psql -U postgres -d temp -c "CREATE DATABASE postgres;"
+docker_compose exec -T db psql -U postgres -c "DROP DATABASE temp;"
 
 echo "Database cleared."
 
 echo "Running migrations and loading fixtures..."
-docker compose -f "$COMPOSE_PATH" run --rm web /bin/bash -c "
+docker_compose run --rm web /bin/bash -c "
     ./wait-for-postgres.sh db:5432 && \
     python /code/manage.py migrate --noinput && \
     ./scripts/load_all_fixtures.sh && \
@@ -101,7 +104,7 @@ print('Passwords set for all users.')
 \"
 "
 
-docker compose -f "$COMPOSE_PATH" down --remove-orphans
+docker_compose down --remove-orphans
 
 echo ""
 echo "============================================"

--- a/scripts/install_shell_aliases.sh
+++ b/scripts/install_shell_aliases.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+detect_shell_config() {
+    local shell_name
+    shell_name="$(basename "${SHELL:-}")"
+
+    case "$shell_name" in
+        zsh)
+            echo "${ZDOTDIR:-$HOME}/.zshrc"
+            ;;
+        bash)
+            if [ -f "$HOME/.bashrc" ] || [ ! -f "$HOME/.bash_profile" ]; then
+                echo "$HOME/.bashrc"
+            else
+                echo "$HOME/.bash_profile"
+            fi
+            ;;
+        *)
+            echo "$HOME/.profile"
+            ;;
+    esac
+}
+
+target_file="${1:-$(detect_shell_config)}"
+target_dir="$(dirname "$target_file")"
+mkdir -p "$target_dir"
+touch "$target_file"
+
+start_marker="# >>> date-website aliases >>>"
+end_marker="# <<< date-website aliases <<<"
+block="$(mktemp)"
+tmp_target="$(mktemp)"
+
+cat > "$block" <<EOF
+$start_marker
+export DATE_WEBSITE_DIR="$PROJECT_DIR"
+source "\$DATE_WEBSITE_DIR/env.sh"
+$end_marker
+EOF
+
+awk -v start="$start_marker" -v end="$end_marker" '
+    $0 == start { skip = 1; next }
+    $0 == end { skip = 0; next }
+    !skip { print }
+' "$target_file" > "$tmp_target"
+
+if [ -s "$tmp_target" ] && [ "$(tail -c 1 "$tmp_target")" != "" ]; then
+    printf '\n' >> "$tmp_target"
+fi
+
+cat "$block" >> "$tmp_target"
+mv "$tmp_target" "$target_file"
+rm -f "$block"
+
+echo "Installed date-website aliases in $target_file"
+echo "Open a new shell or run: source \"$target_file\""

--- a/scripts/lib/date_env.sh
+++ b/scripts/lib/date_env.sh
@@ -78,7 +78,7 @@ date_apply_env_mode() {
 
     case "$resolved_mode" in
         prod)
-            export DATE_DEVELOP="False"
+            export DATE_DEVELOP="${DATE_DEVELOP:-False}"
             ;;
         dev)
             export DATE_DEVELOP="${DATE_DEVELOP:-True}"
@@ -87,9 +87,28 @@ date_apply_env_mode() {
 }
 
 date_resolve_compose_file() {
-    if [ "${DATE_DEVELOP:-True}" = "False" ]; then
+    local resolved_mode="${1:-}"
+    local compose_file_override="${2:-}"
+
+    if [ -n "$compose_file_override" ]; then
+        echo "$compose_file_override"
+    elif [ "$resolved_mode" = "prod" ]; then
         echo "docker-compose.prod.yml"
     else
         echo "docker-compose.yml"
     fi
+}
+
+date_read_env_value() {
+    local config_file="$1"
+    local env_name="$2"
+
+    (
+        unset "$env_name"
+        set -a
+        # shellcheck disable=SC1090
+        source "$config_file"
+        set +a
+        printf '%s' "${!env_name:-}"
+    )
 }

--- a/scripts/s3_upload.py
+++ b/scripts/s3_upload.py
@@ -8,10 +8,19 @@ import datetime
 import requests
 import pytz
 
-AWS_S3_ENDPOINT_URL = os.environ['AWS_S3_ENDPOINT_URL']
-AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
-AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
-AWS_STORAGE_BUCKET_NAME = os.environ['AWS_STORAGE_BUCKET_NAME']
+
+def env_alias(name, *aliases):
+    for env_name in (name, *aliases):
+        value = os.environ.get(env_name)
+        if value is not None:
+            return value
+    raise KeyError(name)
+
+
+AWS_S3_ENDPOINT_URL = env_alias('S3_ENDPOINT_URL', 'AWS_S3_ENDPOINT_URL')
+AWS_ACCESS_KEY_ID = env_alias('S3_ACCESS_KEY', 'AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = env_alias('S3_SECRET_KEY', 'AWS_SECRET_ACCESS_KEY')
+AWS_STORAGE_BUCKET_NAME = env_alias('S3_BUCKET_NAME', 'AWS_STORAGE_BUCKET_NAME')
 PRIVATE_MEDIA_LOCATION = os.environ['PRIVATE_MEDIA_LOCATION']
 
 

--- a/update-postgres.sh
+++ b/update-postgres.sh
@@ -34,14 +34,19 @@ set -a
 source "$config_file"
 set +a
 
+config_compose_file="$(date_read_env_value "$config_file" COMPOSE_FILE)"
 date_apply_env_mode "$resolved_mode"
 
-compose_file="$(date_resolve_compose_file)"
+compose_file="$(date_resolve_compose_file "$resolved_mode" "$config_compose_file")"
 
-compose_path="${SCRIPT_DIR}/${compose_file}"
+if [[ "$compose_file" = /* ]]; then
+  compose_path="$compose_file"
+else
+  compose_path="${SCRIPT_DIR}/${compose_file}"
+fi
 
 docker_compose() {
-  docker compose -f "$compose_path" "$@"
+  docker compose --project-directory "$SCRIPT_DIR" -f "$compose_path" "$@"
 }
 
 wait_for_db() {
@@ -120,7 +125,7 @@ read_django_migration_count() {
 }
 
 # Check if the required environment variables are set
-if [ -z "${DATE_POSTGRESQL_VERSION:-}" ] || [ -z "${DATE_DB_PORT:-}" ] || [ -z "${DATE_DB_PASSWORD:-}" ] || [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
+if [ -z "${DATE_POSTGRESQL_VERSION:-}" ] || [ -z "${DATE_DB_PASSWORD:-}" ] || [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
   echo "Error: Required environment variables are not set"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- simplify Docker Compose environment loading so `.env` is the project source of truth
- move dev/prod Compose selection into `COMPOSE_FILE` in the example env files
- reduce duplicated environment mappings in the Compose files and remove prod host port exposure
- add a production-ready `.env.prod.example`
- update helper scripts, backup/update scripts, CI, and docs to match the new env flow
- add a shell alias installer for developers who want persistent `date-*` helpers

## Why

The previous workflow depended on sourcing `env.sh` to load environment variables into the shell. That made switching between dev and prod fragile when old exported values were still present. The new flow lets Docker Compose read `.env` directly and keeps `env.sh` focused on optional shell aliases.

## Validation

- `docker compose config --quiet` with the development example env
- `docker compose -f docker-compose.dev-all.yml config --quiet` with the development example env
- `docker compose config --quiet` with the production example env
- `python manage.py check`
- `bash -n` for the updated shell scripts
- `git diff --check`
