### PR TITLE
fix: allow dots in usernames

### DIFF
--- a/members/forms.py
+++ b/members/forms.py
@@ -16,10 +16,10 @@ from members.models import (SUB_RE_SCALE_DAY, SUB_RE_SCALE_MONTH,
 
 logger = logging.getLogger('date')
 
-# Restrict usernames to ASCII letters, numbers, underscores, and hyphens
+# Restrict usernames to ASCII letters, numbers, dots, underscores, and hyphens
 USERNAME_VALIDATOR = RegexValidator(
-    r'^[0-9a-zA-Z_-]+$',
-    _('Enter a valid username consisting only of letters, numbers, underscores, and hyphens.')
+    r'^[0-9a-zA-Z._-]+$',
+    _('Enter a valid username consisting only of letters, numbers, dots, underscores, and hyphens.')
 )
 
 

--- a/members/tests.py
+++ b/members/tests.py
@@ -53,6 +53,17 @@ class UsernameValidatorTest(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('username', form.errors)
 
+    def test_member_creation_form_accepts_dotted_username(self):
+        form = MemberCreationForm(data={
+            'username': 'first.last',
+            'email': 'dotted@example.com',
+            'first_name': 'Dot',
+            'last_name': 'User',
+            'membership_type': self.membership_type.id,
+            'password': 'secret123',
+        })
+        self.assertTrue(form.is_valid())
+
     def test_signup_form_rejects_invalid_username(self):
         form = SignUpForm(data={
             'username': 'bad!name',


### PR DESCRIPTION
## Summary
- Add `.` to the username regex validator so usernames like `first.last` are accepted
- Update the validation error message to mention dots
- Add test case for dotted usernames

## Test plan
- [ ] Verify existing username tests still pass
- [ ] Verify new dotted username test passes
- [ ] Test signup and member creation forms accept usernames with dots