### PR TITLE
Clean up site shell templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DaTe Website 2.0
 
-DaTe Website 2.0 powers [Datateknologerna vid Åbo Akademi rf](https://date.abo.fi)'s public site, membership tools, alumni portal, polls, and a handful of seasonal or one-off apps. The stack is Django 6.0 running on Python 3.13 inside Docker Compose with Celery workers, Channels/Daphne, PostgreSQL, Valkey (Redis compatible), and S3-compatible storage.
+DaTe Website 2.0 powers [Datateknologerna vid Åbo Akademi rf](https://date.abo.fi)'s public site, membership tools, alumni portal, polls, and a handful of seasonal or one-off apps. The stack is Django 6.0 running on Python 3.14 inside Docker Compose with Celery workers, Channels/Daphne, PostgreSQL, Valkey (Redis compatible), and S3-compatible storage.
 
 > Active development happens on `develop`. The `master` branch mirrors production releases, so branch off `develop` when you start new work.
 

--- a/core/tests/test_incident_check.py
+++ b/core/tests/test_incident_check.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -15,14 +14,12 @@ class IncidentCheckCommandTests(TestCase):
     def test_outputs_runtime_blank_slugs_and_recent_admin_edits(self):
         user = get_user_model().objects.create_user(username="incident-admin")
         event = Event.objects.create(title="Broken Event", slug="", author=user)
-        content_type = ContentType.objects.get_for_model(Event)
-        LogEntry.objects.log_action(
+        LogEntry.objects.log_actions(
             user_id=user.pk,
-            content_type_id=content_type.pk,
-            object_id=event.pk,
-            object_repr=str(event),
+            queryset=Event.objects.filter(pk=event.pk),
             action_flag=CHANGE,
             change_message="Changed title.",
+            single_object=True,
         )
 
         output = StringIO()
@@ -56,14 +53,15 @@ class IncidentCheckCommandTests(TestCase):
     def test_admin_edit_fields_are_redacted_before_output(self):
         user = get_user_model().objects.create_user(username="redacted-admin")
         event = Event.objects.create(title="Sensitive Event", slug="", author=user)
-        content_type = ContentType.objects.get_for_model(Event)
-        LogEntry.objects.log_action(
+        LogEntry.objects.log_actions(
             user_id=user.pk,
-            content_type_id=content_type.pk,
-            object_id=event.pk,
-            object_repr='client_email="service@example.com"',
+            queryset=Event.objects.filter(pk=event.pk),
             action_flag=CHANGE,
             change_message='ALUMNI_SETTINGS={"private_key":"secret-key"}',
+            single_object=True,
+        )
+        LogEntry.objects.filter(object_id=event.pk).update(
+            object_repr='client_email="service@example.com"',
         )
 
         output = StringIO()

--- a/date/tests.py
+++ b/date/tests.py
@@ -1,5 +1,7 @@
 from datetime import date, timedelta
 import importlib
+import re
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.conf import settings
@@ -8,6 +10,7 @@ from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.template import Context, Template
+from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import clear_url_caches, reverse, set_urlconf
@@ -23,6 +26,96 @@ from events.models import Event
 def localized_reverse(name, language_code, *args, **kwargs):
     with translation.override(language_code):
         return reverse(name, args=args or None, kwargs=kwargs or None)
+
+
+class SiteShellTemplateTests(TestCase):
+    def _content_context(self):
+        return {
+            "ASSOCIATION_NAME": "Test Association",
+            "ASSOCIATION_NAME_FULL": "Test Association rf",
+            "ASSOCIATION_NAME_SHORT": "TA",
+            "ASSOCIATION_EMAIL": "test@example.com",
+            "ASSOCIATION_ADDRESS_L1": "Line 1",
+            "ASSOCIATION_ADDRESS_L2": "Line 2",
+            "ASSOCIATION_POSTAL_CODE": "12345",
+            "ASSOCIATION_OFFICE_HOURS": "",
+            "SOCIAL_BUTTONS": [],
+            "categories": [],
+            "urls": [],
+            "ENABLE_LANGUAGE_FEATURES": False,
+            "LANGUAGES": (("sv", "Svenska"),),
+        }
+
+    def test_base_template_has_one_body_and_keeps_shell_sections(self):
+        rendered = render_to_string("core/base.html", self._content_context())
+
+        self.assertEqual(len(re.findall(r"<body\b", rendered)), 1)
+        self.assertEqual(rendered.count("</body>"), 1)
+        self.assertIn("<nav", rendered)
+        self.assertIn("association-footer", rendered)
+        self.assertIn("core/js/external-links.js", rendered)
+        self.assertLess(rendered.index("<body>"), rendered.index("<nav"))
+        self.assertLess(rendered.index("core/js/external-links.js"), rendered.index("</body>"))
+
+    def test_header_uses_unique_dropdown_ids_for_categories(self):
+        categories = [
+            SimpleNamespace(category_name="About", use_category_url=False, url=""),
+            SimpleNamespace(category_name="Members", use_category_url=False, url=""),
+        ]
+        template = Template("{% include 'core/header.html' %}")
+        rendered = template.render(Context({
+            **self._content_context(),
+            "categories": categories,
+        }))
+
+        dropdown_ids = re.findall(r'id="(navbarDropdownMenuLink\d+)"', rendered)
+        self.assertEqual(dropdown_ids, ["navbarDropdownMenuLink0", "navbarDropdownMenuLink1"])
+        self.assertEqual(len(dropdown_ids), len(set(dropdown_ids)))
+        self.assertIn('aria-labelledby="navbarDropdownMenuLink0"', rendered)
+        self.assertIn('aria-labelledby="navbarDropdownMenuLink1"', rendered)
+        self.assertNotIn('id="navbarDarkDropdownMenuLink"', rendered)
+
+    def test_pulterit_header_override_keeps_custom_logo_and_container(self):
+        pulterit_settings = importlib.import_module("core.settings.pulterit")
+
+        with override_settings(
+            TEMPLATES=pulterit_settings.TEMPLATES,
+            STATICFILES_DIRS=pulterit_settings.STATICFILES_DIRS,
+        ):
+            template = Template("{% include 'core/header.html' %}")
+            rendered = template.render(Context({
+                **self._content_context(),
+                "ASSOCIATION_NAME": "Pulterit",
+                "ENABLE_LANGUAGE_FEATURES": True,
+                "LANGUAGES": (("sv", "Svenska"), ("en", "English")),
+            }))
+
+        self.assertIn("container-fluid px-3", rendered)
+        self.assertIn("pulterit-white-wo-text.svg", rendered)
+        self.assertIn("navbarLanguageMenuLink", rendered)
+        self.assertIn("pulterit-mobile-language-switcher", rendered)
+
+    def test_language_picker_hides_when_disabled_in_header_template(self):
+        template = Template("{% include 'core/header.html' %}")
+        rendered = template.render(Context(self._content_context()))
+
+        self.assertNotIn('name="lang"', rendered)
+        self.assertNotIn("language-dropdown-toggle", rendered)
+
+    def test_footer_handles_blank_social_urls_and_office_hours(self):
+        template = Template("{% include 'core/footer.html' %}")
+        rendered = template.render(Context({
+            **self._content_context(),
+            "SOCIAL_BUTTONS": [
+                ["fa-facebook-f", "https://example.com/facebook"],
+                ["fa-github", ""],
+            ],
+        }))
+
+        self.assertIn("https://example.com/facebook", rendered)
+        self.assertNotIn('href=""', rendered)
+        self.assertIn("test@example.com", rendered)
+        self.assertNotIn("test@example.com<br>", rendered)
 
 
 class HealthCheckTests(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "date-website"
 version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
-    "Django~=5.2",
+    "Django~=6.0",
     "django-unfold>=0.90,<0.91",
     "asgiref",
     "django-ckeditor-5",

--- a/static/common/core/js/external-links.js
+++ b/static/common/core/js/external-links.js
@@ -1,0 +1,23 @@
+function setExternalLinksOpenInNewTab() {
+    const currentURL = new URL(document.URL);
+    document.querySelectorAll('a[href]').forEach((elem) => {
+        const rawHref = (elem.getAttribute('href') || '').trim();
+        if (!rawHref || rawHref.startsWith('#')) return;
+
+        let linkHref;
+        try {
+            linkHref = new URL(rawHref, document.baseURI);
+        } catch (err) {
+            return;
+        }
+
+        if (!['http:', 'https:'].includes(linkHref.protocol)) return;
+
+        if (currentURL.origin !== linkHref.origin) {
+            elem.target = '_blank';
+            elem.rel = 'noopener noreferrer';
+        }
+    });
+}
+
+setExternalLinksOpenInNewTab();

--- a/templates/common/core/404.html
+++ b/templates/common/core/404.html
@@ -1,19 +1,14 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
-{% block title %}{{ event.title }}{% endblock %}
+{% block title %}{% trans "Page not found" %}{% endblock %}
 
 {% block extra_head %}
     {{ block.super }}
-    <meta charset="UTF-8">
-    <title>{% trans "Page not found" %}</title>
     <link href="{% static 'core/css/error-view.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
-
-
-<body>
     <div class="container-soft">
         <div class="text-wrapper">
             {% if error_msg %}
@@ -25,6 +20,4 @@
             <p><a href="{% url 'index' %}">{% trans 'Till startsidan' %}</a></p>
         </div>
     </div>
-
-</body>
 {% endblock %}

--- a/templates/common/core/418.html
+++ b/templates/common/core/418.html
@@ -1,19 +1,14 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
-{% block title %}{{ event.title }}{% endblock %}
+{% block title %}{% trans "I'm a teapot" %}{% endblock %}
 
 {% block extra_head %}
     {{ block.super }}
-        <meta charset="UTF-8">
-        <title>{% trans "I'm a teapot" %}</title>
-        <link href="{% static 'core/css/error-view.css' %}" rel="stylesheet">
+    <link href="{% static 'core/css/error-view.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
-
-
-    <body>
     <div class="container-soft">
         <div class="text-wrapper">
             {% if error_msg %}
@@ -28,6 +23,4 @@
             <p><a href="{% url 'index' %}">{% trans 'Till startsidan' %}</a></p>
         </div>
     </div>
-
-    </body>
 {% endblock %}

--- a/templates/common/core/500.html
+++ b/templates/common/core/500.html
@@ -1,17 +1,14 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
-{% block title %}{{ event.title }}{% endblock %}
+{% block title %}{% trans "Server error" %}{% endblock %}
 
 {% block extra_head %}
     {{ block.super }}
-    <meta charset="UTF-8">
-    <title>{% trans "Server error" %}</title>
     <link href="{% static 'core/css/error-view.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
-<body>
     <div class="container-soft">
         <div class="text-wrapper">
             <h1>- 500 -</h1>
@@ -19,6 +16,4 @@
             <p><a href="{% url 'index' %}">{% trans 'Till startsidan' %}</a></p>
         </div>
     </div>
-
-</body>
 {% endblock %}

--- a/templates/common/core/base.html
+++ b/templates/common/core/base.html
@@ -27,8 +27,8 @@
     <link rel="stylesheet" href="{% static 'core/css/footer.css' %}">
 </head>
 
-{% include 'core/header.html' %}
 <body>
+{% include 'core/header.html' %}
 {% if messages %}
     <div class="container pt-3" style="margin-top: 70px;">
         {% for message in messages %}
@@ -46,34 +46,9 @@
         integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
         crossorigin="anonymous"></script>
 <script src="{% static 'core/js/cookie-banner.js' %}"></script>
+<script src="{% static 'core/js/external-links.js' %}" defer></script>
 {% block footer %}
 {% include 'core/footer.html' %}
 {% endblock %}
 </body>
-<!-- JavaScript for opening external links in new tab -->
-<script defer>
-    function setExternalLinksOpenInNewTab() {
-        const currentURL = new URL(document.URL);
-        document.querySelectorAll('a[href]').forEach((elem) => {
-            const rawHref = (elem.getAttribute('href') || '').trim();
-            if (!rawHref) return;
-            if (rawHref.startsWith('#')) return;
-
-            let linkHref;
-            try {
-                linkHref = new URL(rawHref, document.baseURI);
-            } catch (err) {
-                return;
-            }
-
-            if (!['http:', 'https:'].includes(linkHref.protocol)) return;
-
-            if (currentURL.origin !== linkHref.origin) {
-                elem.target = '_blank';
-                elem.rel = 'noopener noreferrer';
-            }
-        });
-    }
-    setExternalLinksOpenInNewTab();
-</script>
 </html>

--- a/templates/common/core/footer.html
+++ b/templates/common/core/footer.html
@@ -1,23 +1,18 @@
 {% load static %}
-{%  load i18n %}
+{% load i18n %}
 
 <footer class="container association-footer{% block footer_class_suffix %}{% endblock %}">
     <div class="association-footer-shell{% block footer_shell_class_suffix %}{% endblock %}">
         <hr>
-        <!-- Grid container -->
-        <!-- Section: Social media -->
         <section class="col text-center association-footer-social{% block footer_social_class_suffix %}{% endblock %}">
-
             {% for btn in SOCIAL_BUTTONS %}
                 {% if btn.1 %}
-                <a class="btn btn-outline-light btn-floating" href="{{ btn.1 }}" role="button"
-                    ><i class="fab {{ btn.0 }}"></i
-                ></a>
+                    <a class="btn btn-outline-light btn-floating" href="{{ btn.1 }}" role="button">
+                        <i class="fab {{ btn.0 }}"></i>
+                    </a>
                 {% endif %}
             {% endfor %}
-
         </section>
-        <!-- Section: Social media -->
         <div class="row align-middle align-items-center association-footer-content{% block footer_content_class_suffix %}{% endblock %}">
             <div class="col-12 col-md-4 text-center association-footer-brand{% block footer_brand_class_suffix %}{% endblock %}">
                 {% block footer_logo %}
@@ -32,8 +27,8 @@
                 </p>
                 <p>
                     {% trans 'E-post' %}:<br>
-                    {{ ASSOCIATION_EMAIL }}<br>
-                    {{ ASSOCIATION_OFFICE_HOURS }}
+                    {{ ASSOCIATION_EMAIL }}
+                    {% if ASSOCIATION_OFFICE_HOURS %}<br>{{ ASSOCIATION_OFFICE_HOURS }}{% endif %}
                 </p>
                 <p>{% trans "Address" %}:<br>
                     {{ ASSOCIATION_ADDRESS_L1 }}<br>
@@ -43,12 +38,9 @@
             </div>
             {% block footer_right %}{% endblock %}
         </div>
-        <!-- Copyright -->
         {% block extra_footer %}{% endblock %}
         <div class="text-center p-3">
             &copy {% now "Y" %}
         </div>
-        <!-- Copyright -->
-        <!-- Grid container -->
     </div>
 </footer>

--- a/templates/common/core/header.html
+++ b/templates/common/core/header.html
@@ -2,64 +2,74 @@
 {% load i18n %}
 {% load localized_urls %}
 <nav class="navbar navbar-expand-lg navbar-light fixed-top">
-    <div class="container">
-        <a id="logo" href="{% url 'index' %}"><img class="header-logo" src="{% static 'core/images/headerlogo.png' %}" alt="Albin"></a>
+    <div class="{% block header_container_class %}container{% endblock %}">
+        {% block header_logo %}
+        <a id="logo" href="{% url 'index' %}">
+            <img class="header-logo" src="{% static 'core/images/headerlogo.png' %}" alt="Albin">
+        </a>
+        {% endblock %}
         <button class="btn btn-secondary navbar-toggler border-3 px-2" type="button" data-bs-toggle="offcanvas"
-        data-bs-target="#offcanvasExample" aria-controls="offcanvasExample"
-        >
-        <i class="bi bi-list fa-2x"></i>
+                data-bs-target="#offcanvasExample" aria-controls="offcanvasExample">
+            <i class="bi bi-list fa-2x"></i>
         </button>
         <div class="offcanvas offcanvas-start-lg" tabindex="-1" id="offcanvasExample"
-        aria-labelledby="offcanvasExampleLabel"
-        >
-        <div class="offcanvas-header d-flex d-lg-none">
-            <h5 class="offcanvas-title text-white" id="offcanvasExampleLabel">{{ ASSOCIATION_NAME_SHORT }}</h5>
-            <a href="javascript:void(0) "
-                class="text-reset p-0"
-                data-bs-dismiss="offcanvas"
-                aria-label="close"
-            >
-            <svg xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                fill="#FFFFFF"
-                class="bi bi-x-circle"
-                viewBox="0 0 16 16"
-              >
-                <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path>
-                <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path>
-            </svg>
-          </a>
-        </div>
-        <div class="offcanvas-body p-lg-0 justify-content-end">
-            <ul class="navbar-nav{% if not ENABLE_LANGUAGE_FEATURES or LANGUAGES|length <= 1 %} navbar-nav-no-language{% endif %}">
-                {% for category in categories %}
-                    {% if category.use_category_url %}
-                        <li class="nav-item">
-                            <a class="nav-link" aria-current="page" href="{{ category.url|localized_url }}">{{category.category_name}}</a>
-                    {% else %}
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            {{category.category_name}}
-                            </a>
-                            <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDarkDropdownMenuLink">
-                                {% url 'members:login' as login_url %}
-                                {% for page in urls %}
-                                    {% if page.category|lower == category.category_name|lower %}
-                                        {% if user.is_authenticated and page.url|localized_url == login_url %}
-                                            <li><form action="{% url 'members:logout' %}" method="post">{% csrf_token %}<button class="dropdown-item">{% translate "Logga ut" %}</button></form></li>
-                                        {% elif not page.logged_in_only or user.is_authenticated %}
-                                            <li><a class="dropdown-item" href="{{ page.url|localized_url }}">{{page.title}}</a></li>
+             aria-labelledby="offcanvasExampleLabel">
+            {% block header_offcanvas_header %}
+            <div class="offcanvas-header d-flex d-lg-none">
+                <h5 class="offcanvas-title text-white" id="offcanvasExampleLabel">{{ ASSOCIATION_NAME_SHORT }}</h5>
+                <button type="button"
+                        class="btn text-reset p-0"
+                        data-bs-dismiss="offcanvas"
+                        aria-label="{% trans 'Close' %}">
+                    <svg xmlns="http://www.w3.org/2000/svg"
+                         width="24"
+                         height="24"
+                         fill="#FFFFFF"
+                         class="bi bi-x-circle"
+                         viewBox="0 0 16 16"
+                         aria-hidden="true"
+                         focusable="false">
+                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path>
+                        <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path>
+                    </svg>
+                </button>
+            </div>
+            {% endblock %}
+            <div class="offcanvas-body p-lg-0 justify-content-end">
+                <ul class="navbar-nav{% if not ENABLE_LANGUAGE_FEATURES or LANGUAGES|length <= 1 %} navbar-nav-no-language{% endif %}">
+                    {% block header_nav_items %}
+                    {% for category in categories %}
+                        {% if category.use_category_url %}
+                            <li class="nav-item">
+                                <a class="nav-link" aria-current="page" href="{{ category.url|localized_url }}">{{ category.category_name }}</a>
+                            </li>
+                        {% else %}
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink{{ forloop.counter0 }}" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                    {{ category.category_name }}
+                                </a>
+                                <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDropdownMenuLink{{ forloop.counter0 }}">
+                                    {% url 'members:login' as login_url %}
+                                    {% for page in urls %}
+                                        {% if page.category|lower == category.category_name|lower %}
+                                            {% if user.is_authenticated and page.url|localized_url == login_url %}
+                                                <li>
+                                                    <form action="{% url 'members:logout' %}" method="post">
+                                                        {% csrf_token %}
+                                                        <button class="dropdown-item">{% translate "Logga ut" %}</button>
+                                                    </form>
+                                                </li>
+                                            {% elif not page.logged_in_only or user.is_authenticated %}
+                                                <li><a class="dropdown-item" href="{{ page.url|localized_url }}">{{ page.title }}</a></li>
+                                            {% endif %}
                                         {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-
-
-                            </ul>
-                    {% endif %}
-                    </li>
-                {% endfor %}
-                    <!-- Language picker -->
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                    {% endblock %}
+                    {% block header_language_picker %}
                     {% if ENABLE_LANGUAGE_FEATURES and LANGUAGES|length > 1 %}
                     {% get_current_language as LANGUAGE_CODE %}
                     <li class="nav-item dropdown">
@@ -109,9 +119,9 @@
                         </ul>
                     </li>
                     {% endif %}
-                    <!-- Language picker ends here -->
-            </ul>
+                    {% endblock %}
+                </ul>
+            </div>
         </div>
-      </div>
     </div>
 </nav>

--- a/templates/pulterit/core/header.html
+++ b/templates/pulterit/core/header.html
@@ -1,98 +1,46 @@
+{% extends "core/header.html" %}
 {% load static %}
 {% load i18n %}
-{% load localized_urls %}
-<nav class="navbar navbar-expand-lg navbar-light fixed-top">
-    <div class="container-fluid px-3">
-        <a id="logo" href="{% url 'index' %}"><img class="header-logo" src="{% static 'core/images/pulterit-white-wo-text.svg' %}" alt="{{ ASSOCIATION_NAME }} logo"></a>
-        <button class="btn btn-secondary navbar-toggler border-3 px-2" type="button" data-bs-toggle="offcanvas"
-        data-bs-target="#offcanvasExample" aria-controls="offcanvasExample"
-        >
-        <i class="bi bi-list fa-2x"></i>
-        </button>
-        <div class="offcanvas offcanvas-start-lg" tabindex="-1" id="offcanvasExample"
-        aria-labelledby="offcanvasExampleLabel"
-        >
-        <div class="offcanvas-header d-flex d-lg-none">
-            <h5 class="offcanvas-title text-white" id="offcanvasExampleLabel">{{ ASSOCIATION_NAME_SHORT }}</h5>
-            <a href="javascript:void(0) "
-                class="text-reset p-0"
-                data-bs-dismiss="offcanvas"
-                aria-label="close"
-            >
-            <svg xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                fill="#FFFFFF"
-                class="bi bi-x-circle"
-                viewBox="0 0 16 16"
-              >
-                <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path>
-                <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path>
-            </svg>
-          </a>
-        </div>
-        <div class="offcanvas-body p-lg-0 justify-content-end">
-            <ul class="navbar-nav{% if not ENABLE_LANGUAGE_FEATURES or LANGUAGES|length <= 1 %} navbar-nav-no-language{% endif %}">
-                {% for category in categories %}
-                    {% if category.use_category_url %}
-                        <li class="nav-item">
-                            <a class="nav-link" aria-current="page" href="{{ category.url|localized_url }}">{{category.category_name}}</a>
-                    {% else %}
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            {{category.category_name}}
-                            </a>
-                            <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDarkDropdownMenuLink">
-                                {% url 'members:login' as login_url %}
-                                {% for page in urls %}
-                                    {% if page.category|lower == category.category_name|lower %}
-                                        {% if user.is_authenticated and page.url|localized_url == login_url %}
-                                            <li><form action="{% url 'members:logout' %}" method="post">{% csrf_token %}<button class="dropdown-item">{% translate "Logga ut" %}</button></form></li>
-                                        {% elif not page.logged_in_only or user.is_authenticated %}
-                                            <li><a class="dropdown-item" href="{{ page.url|localized_url }}">{{page.title}}</a></li>
-                                        {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-                            </ul>
-                    {% endif %}
-                    </li>
-                {% endfor %}
-                <!-- Language picker -->
-                {% if ENABLE_LANGUAGE_FEATURES and LANGUAGES|length > 1 %}
-                <li class="nav-item dropdown d-none d-lg-block">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarLanguageMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                    {% trans "Language" %}
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarLanguageMenuLink">
-                        {% for language in LANGUAGES %}
-                            <li>
-                                <form action="{% url 'set_lang' %}" method="post">
-                                    {% csrf_token %}
-                                    <button class="dropdown-item" name="lang" type="submit" value="{{ language.0 }}">{{ language.1 }}</button>
-                                </form>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </li>
-                <li class="nav-item dropdown d-lg-none pulterit-mobile-language-switcher">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarMobileLanguageMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                    {% trans "Language" %}
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarMobileLanguageMenuLink">
-                        {% for language in LANGUAGES %}
-                            <li>
-                                <form action="{% url 'set_lang' %}" method="post">
-                                    {% csrf_token %}
-                                    <button class="dropdown-item" name="lang" type="submit" value="{{ language.0 }}">{{ language.1 }}</button>
-                                </form>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </li>
-                {% endif %}
-                <!-- Language picker ends here -->
-            </ul>
-        </div>
-      </div>
-    </div>
-</nav>
+
+{% block header_container_class %}container-fluid px-3{% endblock %}
+
+{% block header_logo %}
+<a id="logo" href="{% url 'index' %}">
+    <img class="header-logo" src="{% static 'core/images/pulterit-white-wo-text.svg' %}" alt="{{ ASSOCIATION_NAME }} logo">
+</a>
+{% endblock %}
+
+{% block header_language_picker %}
+{% if ENABLE_LANGUAGE_FEATURES and LANGUAGES|length > 1 %}
+<li class="nav-item dropdown d-none d-lg-block">
+    <a class="nav-link dropdown-toggle" href="#" id="navbarLanguageMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        {% trans "Language" %}
+    </a>
+    <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarLanguageMenuLink">
+        {% for language in LANGUAGES %}
+            <li>
+                <form action="{% url 'set_lang' %}" method="post">
+                    {% csrf_token %}
+                    <button class="dropdown-item" name="lang" type="submit" value="{{ language.0 }}">{{ language.1 }}</button>
+                </form>
+            </li>
+        {% endfor %}
+    </ul>
+</li>
+<li class="nav-item dropdown d-lg-none pulterit-mobile-language-switcher">
+    <a class="nav-link dropdown-toggle" href="#" id="navbarMobileLanguageMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        {% trans "Language" %}
+    </a>
+    <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarMobileLanguageMenuLink">
+        {% for language in LANGUAGES %}
+            <li>
+                <form action="{% url 'set_lang' %}" method="post">
+                    {% csrf_token %}
+                    <button class="dropdown-item" name="lang" type="submit" value="{{ language.0 }}">{{ language.1 }}</button>
+                </form>
+            </li>
+        {% endfor %}
+    </ul>
+</li>
+{% endif %}
+{% endblock %}

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ requires-dist = [
     { name = "channels" },
     { name = "channels-redis" },
     { name = "daphne" },
-    { name = "django", specifier = "~=5.2" },
+    { name = "django", specifier = "~=6.0" },
     { name = "django-admin-ordering", specifier = "==0.20.0" },
     { name = "django-bootstrap3" },
     { name = "django-ckeditor-5" },
@@ -466,16 +466,16 @@ dev = []
 
 [[package]]
 name = "django"
-version = "5.2.12"
+version = "6.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b9445fc0695b03746f355c05b2eecc54c34e05198c686f4fc4406b722b52/django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb", size = 10860574, upload-time = "2026-03-03T13:56:05.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/32/4b144e125678efccf5d5b61581de1c4088d6b0286e46096e3b8de0d556c8/django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7", size = 8310245, upload-time = "2026-03-03T13:56:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Clean up shared core header/footer/base templates
- Reduce the Pulterit header override to focused blocks
- Update dependency metadata to Django 6 and Python 3.14 docs

## Checks
- `docker compose run --rm -e PROJECT_NAME=date web python /code/manage.py test date.tests staticpages.tests core.tests.test_absolute_urls`
- `docker compose run --rm -e PROJECT_NAME=date web python /code/manage.py check`
