### PR TITLE
Clean up event signup flow

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -64,20 +64,32 @@ class EventAttendeesFormInline(OrderableAdmin, EventTranslationInlineBase):
     can_delete = True
     ordering = ['attendee_nr']
 
+    def _event_uses_avec(self, event):
+        return bool(event and event.sign_up_avec)
+
     def get_fields(self, request, event):
         fields = ['attendee_nr', 'user', 'email',
                   'anonymous', 'preferences', 'time_registered']
         if event and event.children.exists():
             fields.append('original_event')
-        if event and event.sign_up_avec:
+        if self._event_uses_avec(event):
             fields.append('avec_for')
         return fields
+
+    def get_fieldsets(self, request, event=None):
+        return [(None, {'fields': self.get_fields(request, event)})]
 
     def get_readonly_fields(self, request, event):
         readonly_fields = ['time_registered']
         if event and event.children.exists():
             readonly_fields.append('original_event')
         return readonly_fields
+
+    def get_formset(self, request, obj=None, **kwargs):
+        if not self._event_uses_avec(obj):
+            kwargs.setdefault('exclude', [])
+            kwargs['exclude'] = [*kwargs['exclude'], 'avec_for']
+        return super().get_formset(request, obj, **kwargs)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         event_id = request.resolver_match.kwargs.get('object_id')

--- a/events/admin.py
+++ b/events/admin.py
@@ -43,12 +43,30 @@ class EventRegistrationFormInline(OrderableAdmin, EventTranslationInlineBase):
     model = EventRegistrationForm
     fk_name = 'event'
     extra = 0
-    fields = ('choice_number', 'name', 'type', 'required',
-              'public_info', 'hide_for_avec', 'choice_list')
     can_delete = True
     ordering_field = 'choice_number'
     ordering = ['choice_number']
     ordering_field_hide_input = True
+
+    def _event_uses_avec(self, event):
+        return bool(event and event.sign_up_avec)
+
+    def get_fields(self, request, event=None):
+        fields = ['choice_number', 'name', 'type', 'required', 'public_info']
+        if self._event_uses_avec(event):
+            fields.append('hide_for_avec')
+        fields.append('choice_list')
+        return fields
+
+    def get_fieldsets(self, request, event=None):
+        return [(None, {'fields': self.get_fields(request, event)})]
+
+    def get_formset(self, request, obj=None, **kwargs):
+        if not self._event_uses_avec(obj):
+            kwargs.setdefault('exclude', [])
+            kwargs['exclude'] = [*kwargs['exclude'], 'hide_for_avec']
+        return super().get_formset(request, obj, **kwargs)
+
 
 class EventAttendeesFormInline(OrderableAdmin, EventTranslationInlineBase):
     ordering_field = 'attendee_nr'

--- a/events/models.py
+++ b/events/models.py
@@ -189,15 +189,17 @@ class Event(models.Model):
         return max(self.sign_up_max_participants - registrations, 0)
 
     def get_registration_form(self):
-        if EventRegistrationForm.objects.filter(event=self).count() == 0:
+        registration_questions = EventRegistrationForm.objects.filter(event=self).order_by('choice_number')
+        if not registration_questions.exists():
             return None
-        return EventRegistrationForm.objects.filter(event=self).order_by('choice_number')
+        return registration_questions
 
     def get_registration_form_public_info(self):
         return EventRegistrationForm.objects.filter(event=self, public_info=True)
 
     def make_registration_form(self, data=None):
         if self.sign_up:
+            registration_questions = list(self.get_registration_form() or [])
             fields = {'user': forms.CharField(label=_('Namn'), max_length=255),
                       'email': forms.EmailField(label=_('Email'), validators=[self.validate_unique_email], max_length=320),
                       'anonymous': forms.BooleanField(label=_('Anonymt'), required=False)}
@@ -207,8 +209,8 @@ class Event(models.Model):
                                                    validators=[self.validate_unique_email],
                                                    max_length=320)
                 fields['anonymous'] = forms.BooleanField(label='Anonyymi/Anonym/Anonymous', required=False)
-            if self.get_registration_form():
-                for question in self.get_registration_form():
+            if registration_questions:
+                for question in registration_questions:
                     if question.type == "select":
                         choices = question.choice_list.split(',')
                         fields[question.name] = forms.ChoiceField(label=question.name,
@@ -243,8 +245,8 @@ class Event(models.Model):
                                                         max_length=320)
                 fields['avec_anonymous'] = forms.BooleanField(label='Anonymt', required=False, widget=forms
                                                               .CheckboxInput(attrs={'class': "avec-field"}))
-                if self.get_registration_form():
-                    for question in self.get_registration_form():
+                if registration_questions:
+                    for question in registration_questions:
                         if not question.hide_for_avec:
                             if question.type == "select":
                                 choices = question.choice_list.split(',')

--- a/events/registration.py
+++ b/events/registration.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
+
+from events.models import EventAttendees, EventRegistrationForm
+
+
+class EventSignupError(Exception):
+    def __init__(self, message, field=None):
+        self.message = message
+        self.field = field
+        super().__init__(message)
+
+
+@dataclass
+class EventSignupResult:
+    attendee: EventAttendees
+    avec_attendee: EventAttendees | None = None
+
+    @property
+    def attendees(self):
+        return [attendee for attendee in (self.attendee, self.avec_attendee) if attendee is not None]
+
+
+def get_registration_questions(event):
+    return list(EventRegistrationForm.objects.filter(event=event).order_by('choice_number'))
+
+
+def get_public_registration_questions(event):
+    return list(EventRegistrationForm.objects.filter(event=event, public_info=True).order_by('choice_number'))
+
+
+def registration_preferences(event, cleaned_data, *, prefix=""):
+    preferences = {}
+    for question in get_registration_questions(event):
+        key = f"{prefix}{question.name}"
+        preferences[str(question)] = cleaned_data.get(key)
+    return preferences
+
+
+def register_event_signup(event, cleaned_data):
+    required_places = 2 if cleaned_data.get('avec') else 1
+    if cleaned_data.get('avec'):
+        _validate_avec(cleaned_data)
+
+    with transaction.atomic():
+        event = event.__class__.objects.select_for_update().select_related('parent').get(pk=event.pk)
+        _ensure_capacity(event, required_places)
+        attendee = _create_attendee(
+            event=event,
+            user=cleaned_data['user'],
+            email=cleaned_data['email'],
+            anonymous=cleaned_data['anonymous'],
+            preferences=registration_preferences(event, cleaned_data),
+        )
+        avec_attendee = None
+        if cleaned_data.get('avec'):
+            avec_attendee = _create_attendee(
+                event=event,
+                user=cleaned_data['avec_user'],
+                email=cleaned_data['avec_email'],
+                anonymous=cleaned_data['avec_anonymous'],
+                preferences=registration_preferences(event, cleaned_data, prefix="avec_"),
+                avec_for=attendee,
+                duplicate_field='avec_email',
+            )
+
+    return EventSignupResult(attendee=attendee, avec_attendee=avec_attendee)
+
+
+def _ensure_capacity(event, required_places):
+    if event.sign_up_max_participants == 0:
+        return
+    if event.remaining_places() < required_places:
+        raise EventSignupError(_("Evenemanget är fullt."))
+
+
+def _validate_avec(cleaned_data):
+    if not cleaned_data.get('avec_user'):
+        raise EventSignupError(_("Ange namn för avec."), field='avec_user')
+    if not cleaned_data.get('avec_email'):
+        raise EventSignupError(_("Ange e-post för avec."), field='avec_email')
+
+
+def _create_attendee(event, user, email, anonymous, preferences, avec_for=None, duplicate_field='email'):
+    storage_event = event.parent or event
+    try:
+        return EventAttendees.objects.create(
+            user=user,
+            event=storage_event,
+            email=email,
+            time_registered=now(),
+            preferences=preferences,
+            anonymous=anonymous,
+            avec_for=avec_for,
+            original_event=event,
+        )
+    except IntegrityError as exc:
+        raise EventSignupError(
+            _("Det finns redan någon anmäld med denna email"),
+            field=duplicate_field,
+        ) from exc
+    except ValidationError as exc:
+        raise EventSignupError(exc.messages[0] if exc.messages else str(exc), field=duplicate_field) from exc

--- a/events/tests.py
+++ b/events/tests.py
@@ -369,10 +369,21 @@ class EventTestCase(TestCase):
 
         c.post(reverse('events:detail', args=[self.event.slug]), self.content)
         self.content['email'] = 'person2@test.com'
-        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content, follow=True)
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.event.get_registrations().count(), 2)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.event.get_registrations().count(), 1)
+
+    def test_avec_requires_name_and_email_when_selected(self):
+        self.event.sign_up_avec = True
+        self.event.save()
+        c = Client()
+        self.content.update({'avec': 'on'})
+
+        response = c.post(reverse('events:detail', args=[self.event.slug]), self.content)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.event.get_registrations().count(), 0)
 
     @patch('events.views.validate_captcha')
     @override_settings(CAPTCHA_SITE_KEY='test', TURNSTILE_SECRET_KEY='test')
@@ -417,6 +428,36 @@ class EventTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event.get_registrations().count(), 1)
+
+    @override_settings(TEST=False)
+    @patch('events.views.ws_send')
+    def test_websocket_notification_runs_after_signup_commit(self, mock_ws_send):
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.post(reverse('events:detail', args=[self.event.slug]), self.content)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.event.get_registrations().count(), 1)
+        mock_ws_send.assert_not_called()
+        self.assertEqual(len(callbacks), 1)
+
+        callbacks[0]()
+
+        mock_ws_send.assert_called_once()
+
+    @override_settings(EXPERIMENTAL_FEATURES=['event_billing'], TEST=True)
+    @patch('billing.handlers.handle_event_billing')
+    def test_billing_runs_after_signup_commit(self, mock_handle_event_billing):
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.post(reverse('events:detail', args=[self.event.slug]), self.content)
+
+        self.assertEqual(response.status_code, 302)
+        mock_handle_event_billing.assert_not_called()
+        self.assertEqual(len(callbacks), 1)
+
+        callbacks[0]()
+
+        attendee = self.event.get_registrations().get()
+        mock_handle_event_billing.assert_called_once_with(attendee)
 
 
 class EventRegistrationWindowTests(TestCase):
@@ -811,6 +852,63 @@ class EventCapacityTests(TestCase):
         )
 
         self.assertEqual(child.remaining_places(), 1)
+
+    def test_parent_event_rejects_signup_when_full(self):
+        event = Event.objects.create(
+            title="Full Parent Event",
+            slug="full-parent-event",
+            author=self.author,
+            sign_up_max_participants=1,
+            sign_up_deadline=timezone.now() + timezone.timedelta(days=1),
+        )
+        EventAttendees.objects.create(
+            event=event,
+            user="Registered",
+            email="registered-full-parent@example.com",
+            time_registered=timezone.now(),
+            preferences={},
+        )
+
+        response = self.client.post(reverse("events:detail", args=[event.slug]), {
+            "user": "Blocked",
+            "email": "blocked-parent@example.com",
+            "terms_accepted": "on",
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(event.get_registrations().count(), 1)
+
+    def test_child_event_rejects_signup_when_full(self):
+        parent = Event.objects.create(
+            title="Full Child Parent Event",
+            slug="full-child-parent-event",
+            author=self.author,
+        )
+        child = Event.objects.create(
+            title="Full Child Event",
+            slug="full-child-event",
+            author=self.author,
+            parent=parent,
+            sign_up_max_participants=1,
+            sign_up_deadline=timezone.now() + timezone.timedelta(days=1),
+        )
+        EventAttendees.objects.create(
+            event=parent,
+            original_event=child,
+            user="Registered",
+            email="registered-full-child@example.com",
+            time_registered=timezone.now(),
+            preferences={},
+        )
+
+        response = self.client.post(reverse("events:detail", args=[child.slug]), {
+            "user": "Blocked",
+            "email": "blocked-child@example.com",
+            "terms_accepted": "on",
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(parent.get_registrations().count(), 1)
 
     def test_detail_page_renders_remaining_places_not_total_capacity(self):
         event = Event.objects.create(

--- a/events/tests.py
+++ b/events/tests.py
@@ -562,6 +562,71 @@ class EventAdminTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'name="eventattendees_set-0-avec_for"')
 
+    def test_change_page_hides_original_event_for_inline_without_child_events(self):
+        EventAttendees.objects.create(
+            event=self.event,
+            user="Parent Only",
+            email="parent-only@example.com",
+            time_registered=timezone.now(),
+            preferences={},
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("admin:events_event_change", args=[self.event.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'column-original_event')
+
+    def test_change_page_shows_original_event_for_inline_with_child_events(self):
+        child = Event.objects.create(
+            title="Child Admin Event",
+            slug="child-admin-event",
+            author=self.admin_user,
+            parent=self.event,
+        )
+        EventAttendees.objects.create(
+            event=self.event,
+            original_event=child,
+            user="Child Attendee",
+            email="child-attendee@example.com",
+            time_registered=timezone.now(),
+            preferences={},
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("admin:events_event_change", args=[self.event.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'column-original_event')
+
+    def test_change_page_hides_hide_for_avec_when_avec_is_disabled(self):
+        EventRegistrationForm.objects.create(
+            event=self.event,
+            name="Question",
+            type="text",
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("admin:events_event_change", args=[self.event.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="eventregistrationform_set-0-hide_for_avec"')
+
+    def test_change_page_shows_hide_for_avec_when_avec_is_enabled(self):
+        self.event.sign_up_avec = True
+        self.event.save()
+        EventRegistrationForm.objects.create(
+            event=self.event,
+            name="Question",
+            type="text",
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("admin:events_event_change", args=[self.event.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="eventregistrationform_set-0-hide_for_avec"')
+
     def test_edit_form_preserves_existing_slug_when_field_is_cleared(self):
         form = EventEditForm(instance=self.event)
         form.cleaned_data = {"title": self.event.title, "slug": ""}

--- a/events/tests.py
+++ b/events/tests.py
@@ -530,6 +530,38 @@ class EventAdminTests(TestCase):
         self.assertContains(response, 'name="title_en"')
         self.assertContains(response, 'name="title_fi"')
 
+    def test_change_page_hides_avec_for_inline_when_avec_is_disabled(self):
+        EventAttendees.objects.create(
+            event=self.event,
+            user="No Avec",
+            email="no-avec@example.com",
+            time_registered=timezone.now(),
+            preferences={},
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("admin:events_event_change", args=[self.event.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="eventattendees_set-0-avec_for"')
+
+    def test_change_page_shows_avec_for_inline_when_avec_is_enabled(self):
+        self.event.sign_up_avec = True
+        self.event.save()
+        EventAttendees.objects.create(
+            event=self.event,
+            user="Avec Host",
+            email="avec-host@example.com",
+            time_registered=timezone.now(),
+            preferences={},
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("admin:events_event_change", args=[self.event.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="eventattendees_set-0-avec_for"')
+
     def test_edit_form_preserves_existing_slug_when_field_is_cleared(self):
         form = EventEditForm(instance=self.event)
         form.cleaned_data = {"title": self.event.title, "slug": ""}

--- a/events/views.py
+++ b/events/views.py
@@ -3,6 +3,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
+from django.db import transaction
 from django.http import HttpResponseForbidden
 from django.shortcuts import render, redirect
 from django.urls import reverse
@@ -11,7 +12,8 @@ from django.views.generic import DetailView, ListView
 
 from core.utils import validate_captcha
 from .forms import PasscodeForm
-from .models import Event, EventAttendees
+from .models import Event
+from .registration import EventSignupError, get_public_registration_questions, register_event_signup
 from .websocket_utils import ws_send
 
 logger = logging.getLogger('date')
@@ -161,16 +163,13 @@ class EventDetailView(DetailView):
         return [self.template_name]
 
     def form_valid(self, form):
-        attendee = self.get_object().add_event_attendance(user=form.cleaned_data['user'],
-                                                          email=form.cleaned_data['email'],
-                                                          anonymous=form.cleaned_data['anonymous'],
-                                                          preferences=form.cleaned_data)
-        if "event_billing" in settings.EXPERIMENTAL_FEATURES and 'billing' in settings.INSTALLED_APPS:
-            logger.debug("Handling event billing")
-            from billing.handlers import handle_event_billing
-            handle_event_billing(attendee)
-        if 'avec' in form.cleaned_data and form.cleaned_data['avec']:
-            self.handle_avec_data(form.cleaned_data, attendee)
+        try:
+            result = register_event_signup(self.object, form.cleaned_data)
+        except EventSignupError as exc:
+            form.add_error(exc.field, exc.message)
+            return self.form_invalid(form)
+
+        self.schedule_signup_side_effects(form, result.attendee)
         return self.redirect_after_signup()
 
     def form_invalid(self, form):
@@ -199,9 +198,6 @@ class EventDetailView(DetailView):
 
             form = self.object.make_registration_form()(data=request.POST)
 
-            if self.object.parent and self.object.event_is_full():
-                return self.form_invalid(form)
-
             # CAPTCHA validation if applicable
             if self.object.captcha:
                 captcha_response = request.POST.get('cf-turnstile-response', '')
@@ -215,27 +211,22 @@ class EventDetailView(DetailView):
         return HttpResponseForbidden()
 
     def process_signup_form(self, form, request):
-        public_info = self.object.get_registration_form_public_info()
-        if not EventAttendees.objects.filter(email=form.cleaned_data['email'], event=self.object.id).first():
-            logger.info(f"User {request.user} signed up with name: {form.cleaned_data['user']}")
-            if not settings.TEST:
-                slug = self.object.parent.slug if self.object.parent else self.object.slug
-                ws_send(slug, form, public_info)
+        logger.info(f"User {request.user} signed up with name: {form.cleaned_data['user']}")
         return self.form_valid(form)
+
+    def schedule_signup_side_effects(self, form, attendee):
+        if not settings.TEST:
+            public_info = get_public_registration_questions(self.object)
+            slug = self.object.parent.slug if self.object.parent else self.object.slug
+            transaction.on_commit(lambda: ws_send(slug, form, public_info))
+
+        if "event_billing" in settings.EXPERIMENTAL_FEATURES and 'billing' in settings.INSTALLED_APPS:
+            logger.debug("Handling event billing")
+            from billing.handlers import handle_event_billing
+            transaction.on_commit(lambda: handle_event_billing(attendee))
 
     def redirect_after_signup(self):
         event = self.get_context_data().get('event')
         if self._get_resolved_template(event) == 'events/arsfest.html':
             return redirect(f"{reverse('events:detail', args=[event.slug])}#/attendee-list")
         return redirect(reverse('events:detail', args=[event.slug]))
-
-    def handle_avec_data(self, cleaned_data, attendee):
-        avec_data = {'avec_for': attendee}
-        for key in cleaned_data:
-            if key.startswith('avec_'):
-                field_name = key.split('avec_')[1]
-                value = cleaned_data[key]
-                avec_data[field_name] = value
-        self.get_object().add_event_attendance(user=avec_data['user'], email=avec_data['email'],
-                                               anonymous=avec_data['anonymous'], preferences=avec_data,
-                                               avec_for=avec_data['avec_for'])

--- a/templates/common/events/registering.html
+++ b/templates/common/events/registering.html
@@ -91,7 +91,7 @@
     function updateAvecForm() {
         if($("#id_avec").is(":checked")) {
             $('#attend-form').find('.avec-field').parent().show();
-            $("#id_avec").parent().after('<h4 id="avec_information_header">Avec information<h4>')
+            $("#id_avec").parent().after('<h4 id="avec_information_header">Avec information</h4>')
             $('#id_avec_user').prop('required', true)
             $('#id_avec_email').prop('required', true)
         } else {


### PR DESCRIPTION
## Summary
- Centralize event attendee and avec signup creation
- Run billing and websocket side effects after commit
- Tighten capacity and avec validation around event signup

## Checks
- `docker compose run --rm -e PROJECT_NAME=date web python /code/manage.py test events.tests`
- `docker compose run --rm -e PROJECT_NAME=date web python /code/manage.py test date.tests events.tests members.tests`
- `docker compose run --rm -e PROJECT_NAME=date web python /code/manage.py check`
