### PR TITLE
Refine image promotion tags

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -60,11 +60,8 @@ jobs:
 
           TAGS=("${IMAGE_REPO}:${GITHUB_SHA}")
 
-          if [ "${GITHUB_REF_TYPE}" = "branch" ]; then
-            TAGS+=("${IMAGE_REPO}:${GITHUB_REF_NAME}")
-            if [ "${GITHUB_REF_NAME}" = "main" ]; then
-              TAGS+=("${IMAGE_REPO}:qa")
-            fi
+          if [ "${GITHUB_REF_TYPE}" = "branch" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then
+            TAGS+=("${IMAGE_REPO}:qa")
           fi
 
           {

--- a/.github/workflows/promote_production.yaml
+++ b/.github/workflows/promote_production.yaml
@@ -1,0 +1,62 @@
+name: Promote Docker image to production
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Existing image tag to promote, usually the QA-tested commit SHA.
+        required: true
+
+permissions:
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Compute image repository
+        id: image
+        run: |
+          echo "repo_lower=${GITHUB_REPOSITORY,,}" >> "${GITHUB_OUTPUT}"
+
+      - name: Docker login with retry
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          echo "GHCR login failed after 3 attempts."
+          exit 1
+
+      - name: Promote image
+        env:
+          IMAGE_REPO: ghcr.io/${{ steps.image.outputs.repo_lower }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          SOURCE_TAG="${IMAGE_REPO}:${IMAGE_TAG}"
+
+          if ! docker buildx imagetools inspect "${SOURCE_TAG}" >/dev/null 2>&1; then
+            echo "Image tag ${SOURCE_TAG} does not exist."
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --tag "${IMAGE_REPO}:prod" \
+            --tag "${IMAGE_REPO}:latest" \
+            "${SOURCE_TAG}"

--- a/.github/workflows/release_tag.yaml
+++ b/.github/workflows/release_tag.yaml
@@ -14,6 +14,7 @@ on:
           - major
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -125,3 +126,12 @@ jobs:
           git checkout main
           git tag -a "${NEXT_TAG}" -m "Release ${NEXT_TAG}" -m "Automated ${BUMP} bump from ${LAST_TAG}"
           git push origin "${NEXT_TAG}"
+
+      - name: Dispatch Docker release tagging workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ needs.propose_release.outputs.next_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run docker_build.yaml --ref "${NEXT_TAG}"

--- a/README.md
+++ b/README.md
@@ -164,12 +164,13 @@ The stack brings up the `web` (Gunicorn), `asgi` (Daphne/Channels), `celery`, `d
 
 CI image publishing and release tagging are separate on purpose:
 
-- Pushes to `main` publish an immutable commit-SHA tag plus moving `main` and `qa` tags.
+- Pushes to `main` publish an immutable commit-SHA tag plus the moving `qa` tag.
 - QA should deploy `qa` automatically or deploy the immutable commit-SHA tag produced from `main`.
 - Release tags are created manually through `.github/workflows/release_tag.yaml` with `patch` as the default bump and optional `minor` / `major` overrides.
 - When a release tag is created, CI reuses the already-published commit image and adds the SemVer, `prod`, and `latest` tags to the same image instead of rebuilding.
+- Production can also be promoted manually through `.github/workflows/promote_production.yaml` by entering the already-tested image tag, usually the commit SHA currently running in QA.
 
-For production rollouts, prefer a release tag or immutable commit SHA in `DATE_IMG_TAG`; `prod` and `latest` are production aliases updated only by the release promotion workflow.
+For production rollouts, prefer a release tag or immutable commit SHA in `DATE_IMG_TAG`; `prod` and `latest` are production aliases updated only by the production promotion workflows.
 
 Although Django 6 ships with the new Tasks framework, this project still uses Celery for production background work. The current task dispatch points defer enqueuing until after successful database commits where that matters, so new code should preserve that behavior.
 


### PR DESCRIPTION
## Summary
- stop publishing the redundant moving `main` image tag from main builds
- keep commit SHA and `qa` tags for QA deployments
- add a manual production promotion workflow that retags an existing image as `prod` and `latest`

## Notes
The existing release-tag workflow is still in place for SemVer releases. This adds the direct manual promotion path for a QA-tested image tag.