### PR TITLE
Fixed Pulterit officials page filter visibility and event sign-up field requirement

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -69,10 +69,10 @@ class EventCreationForm(UnfoldFormMixin, forms.ModelForm):
     published_time = flatpickr_datetime_field(initial=now, required=False)
     event_date_start = flatpickr_datetime_field(initial=now())
     event_date_end = flatpickr_datetime_field(initial=now())
-    sign_up_others = flatpickr_datetime_field(initial=now())
-    sign_up_members = flatpickr_datetime_field(initial=now())
-    sign_up_deadline = flatpickr_datetime_field(initial=now())
-    sign_up_cancelling_deadline = flatpickr_datetime_field(initial=now())
+    sign_up_others = flatpickr_datetime_field(initial=now(), required=False)
+    sign_up_members = flatpickr_datetime_field(initial=now(), required=False)
+    sign_up_deadline = flatpickr_datetime_field(initial=now(), required=False)
+    sign_up_cancelling_deadline = flatpickr_datetime_field(initial=now(), required=False)
     parent = forms.ModelChoiceField(queryset=Event.objects.filter(event_date_end__gte=now()), required=False)
 
     def __init__(self, *args, **kwargs):

--- a/templates/common/members/functionaries.html
+++ b/templates/common/members/functionaries.html
@@ -11,7 +11,6 @@
         <div class="container-size">
             <div class="content">
             <h2>{% trans "Funktionärer" %} {% if all_years %}{% trans "Alla år" %}{% else %}{{ selected_year }}{% endif %}</h2>
-            {% if user.is_authenticated %}
                 <form class="form-inline mt-2" action="{% url 'members:functionaries' %}" method="get">
                     <div class="form-group mb-2">
                         <label for="year" class="mr-2">{% trans "Välj ett år:" %}</label>
@@ -39,7 +38,6 @@
                     </div>
                     <button type="submit" class="theme-button ml-2 mb-2">{% trans "Filtrera" %}</button>
                 </form>
-            {% endif %}
                 <div class="row">
                     {% if board_functionaries_by_role %}
                         <div class="col-md-12 mb-4">


### PR DESCRIPTION
- Removed the {% if user.is_authenticated %} gate on the officials page filter form so year/role filtering is visible to all visitors, not just logged-in users.
- Fixed EventCreationForm in events/forms.py so that sign-up time fields (sign_up_others, sign_up_members, sign_up_deadline, sign_up_cancelling_deadline) are no longer required when creating an event with registration disabled.