### PR TITLE
Register AlumniEmailRecipient in admin

### DIFF
--- a/alumni/admin.py
+++ b/alumni/admin.py
@@ -1,1 +1,10 @@
-# Register your models here.
+from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
+
+from alumni.models import AlumniEmailRecipient
+
+
+@admin.register(AlumniEmailRecipient)
+class AlumniEmailRecipientAdmin(admin.ModelAdmin):
+    list_display = ("recipient_email",)
+    search_fields = ("recipient_email",)

--- a/alumni/admin.py
+++ b/alumni/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.utils.translation import gettext_lazy as _
 
 from alumni.models import AlumniEmailRecipient
 


### PR DESCRIPTION
## Summary
- Register `AlumniEmailRecipient` model in the Django admin panel with list display and search on the email field

## Test plan
- [ ] Verify the model appears in the admin panel under the alumni section
- [ ] Verify search works on the email field