### PR TITLE
Fix password reset email NoReverseMatch

### DIFF
--- a/members/tests.py
+++ b/members/tests.py
@@ -21,6 +21,29 @@ from members.two_factor import (
 )
 
 
+class PasswordResetFlowTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.membership_type = MembershipType.objects.get(pk=ORDINARY_MEMBER)
+        cls.member = Member.objects.create_user(
+            username='resetuser',
+            email='reset@example.com',
+            password='testpass123',
+            membership_type=cls.membership_type,
+        )
+
+    @patch('members.forms.send_email_task.delay')
+    def test_password_reset_renders_email_and_redirects(self, mock_delay):
+        response = self.client.post(
+            reverse('members:password_reset'),
+            data={'email': 'reset@example.com'},
+        )
+        self.assertEqual(response.status_code, 302)
+        mock_delay.assert_called_once()
+        body = mock_delay.call_args[0][1]
+        self.assertIn('/members/reset/', body)
+
+
 class UsernameValidatorTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/members/urls.py
+++ b/members/urls.py
@@ -1,7 +1,7 @@
 import django.views.generic
 from django.conf import settings
 from django.contrib.auth import views as auth_views
-from django.urls import path, re_path
+from django.urls import path, re_path, reverse_lazy
 
 from functionaries import views as functionary_views
 
@@ -19,7 +19,11 @@ urlpatterns = [
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('password_reset/', views.CustomPasswordResetView.as_view(), name='password_reset'),
     path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(), name='password_reset_done'),
-    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path(
+        'reset/<uidb64>/<token>/',
+        auth_views.PasswordResetConfirmView.as_view(success_url=reverse_lazy('members:password_reset_complete')),
+        name='password_reset_confirm',
+    ),
     path('reset/done/', auth_views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),
     path('password_change/', views.CustomPasswordChangeView.as_view(), name='password_change'),
     path('password_change/done/', auth_views.PasswordChangeDoneView.as_view(), name='password_change_done'),

--- a/members/views.py
+++ b/members/views.py
@@ -10,7 +10,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
@@ -144,7 +144,9 @@ def activate(request, uidb64, token):
 
 class CustomPasswordResetView(PasswordResetView):
     form_class = CustomPasswordResetForm
+    success_url = reverse_lazy('members:password_reset_done')
 
 
 class CustomPasswordChangeView(PasswordChangeView):
     template_name = "members/registration/password_change_form.html"
+    success_url = reverse_lazy('members:password_change_done')

--- a/templates/common/members/registration/password_reset_email.html
+++ b/templates/common/members/registration/password_reset_email.html
@@ -2,7 +2,7 @@
 {% autoescape off %}
   {% blocktrans with username=user.get_username %}För att inleda lösenordsåterställningen för kontot {{ username }},{% endblocktrans %}
   {% trans "klicka på länken nedan:" %}
-  {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+  {{ protocol }}://{{ domain }}{% url 'members:password_reset_confirm' uidb64=uid token=token %}
   {% trans "Ifall det inte går att klicka på länken, vänligen kopiera och klistra in länken i din webbläsare." %}
   {% trans "Om ytterligare frågor uppstår, vänligen kontakta styrelsen." %}
   {% trans "Mvh," %}


### PR DESCRIPTION
## Summary
- Fix `NoReverseMatch: Reverse for 'password_reset_confirm' not found` when submitting the password reset form
- Django 6 removed the deprecated fallback that resolved un-namespaced URL names across all namespaces — the email template needed the `members:` namespace prefix
- Add e2e test that exercises the full password reset POST flow

## Root cause
Commit adb545b (Upgrade to django 6) upgraded from Django 5.2 to 6.0 but didn't update the password reset email template to use the namespaced URL.

## Test plan
- [ ] Submit password reset form with valid email, verify no 500 error
- [ ] Verify the reset link in the email points to the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)