### PR TITLE
feat: Add Open Graph and Twitter Card meta tags for social sharing

### DIFF
--- a/date/templatetags/og_tags.py
+++ b/date/templatetags/og_tags.py
@@ -1,0 +1,26 @@
+import re
+
+from django import template
+from django.utils.html import strip_tags
+
+register = template.Library()
+
+
+@register.filter
+def plaintext_truncate(value, arg=160):
+    try:
+        max_length = int(arg)
+    except Exception:
+        max_length = 160
+
+    if not value:
+        return ""
+
+    text = strip_tags(value)
+    text = re.sub(r"\s+", " ", text)
+    text = text.strip()
+
+    if len(text) > max_length:
+        text = text[:max_length] + "..."
+
+    return text

--- a/templates/biocum/events/arsfest.html
+++ b/templates/biocum/events/arsfest.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/arsfest.css' %}">

--- a/templates/common/core/base.html
+++ b/templates/common/core/base.html
@@ -36,6 +36,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.slim.min.js"
             integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
             crossorigin="anonymous"></script>
+    {% block og_meta %}
+      <meta property="og:title" content="{{ ASSOCIATION_NAME }}">
+      <meta property="og:type" content="website">
+      <meta name="twitter:card" content="summary">
+    {% endblock %}
     {% block extra_head %}{% endblock %}
     <link rel="stylesheet"
           type="text/css"

--- a/templates/common/events/arsfest.html
+++ b/templates/common/events/arsfest.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/arsfest.css' %}">

--- a/templates/common/events/baal_detail.html
+++ b/templates/common/events/baal_detail.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/baal.css' %}">

--- a/templates/common/events/detail.html
+++ b/templates/common/events/detail.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   {% if event.exclude_indexing and not event.in_past_event_list %}<meta name="robots" content="noindex">{% endif %}

--- a/templates/common/events/kk100_detail.html
+++ b/templates/common/events/kk100_detail.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/kk100.css' %}">

--- a/templates/common/events/tomtejakt.html
+++ b/templates/common/events/tomtejakt.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/tomtejakt.css' %}">

--- a/templates/common/events/wappmiddag.html
+++ b/templates/common/events/wappmiddag.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/wappmiddag.css' %}">

--- a/templates/common/news/article.html
+++ b/templates/common/news/article.html
@@ -1,7 +1,17 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
+{% load og_tags %}
 {% block title %}{{ article.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ article.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if article.content %}<meta property="og:description" content="{{ article.content|plaintext_truncate:160 }}">{% endif %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ article.title }}">
+  {% if article.content %}<meta name="twitter:description" content="{{ article.content|plaintext_truncate:160 }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'news/css/style.css' %}">

--- a/templates/common/publications/viewer.html
+++ b/templates/common/publications/viewer.html
@@ -1,7 +1,19 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
+{% load og_tags %}
 {% block title %}{{ ASSOCIATION_NAME_SHORT }} - {{ pdf_file.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ pdf_file.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if pdf_file.description %}<meta property="og:description" content="{{ pdf_file.description|plaintext_truncate:160 }}">{% endif %}
+  {% if pdf_file.cover_image %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ pdf_file.cover_image.url }}">{% endif %}
+  <meta name="twitter:card" content="{% if pdf_file.cover_image %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ pdf_file.title }}">
+  {% if pdf_file.description %}<meta name="twitter:description" content="{{ pdf_file.description|plaintext_truncate:160 }}">{% endif %}
+  {% if pdf_file.cover_image %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ pdf_file.cover_image.url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/common/staticpages/staticpage.html
+++ b/templates/common/staticpages/staticpage.html
@@ -1,7 +1,19 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
+{% load og_tags %}
 {% block title %}{{ page.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ page.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if page.content %}<meta property="og:description" content="{{ page.content|plaintext_truncate:160 }}">{% endif %}
+  {% if page.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ page.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if page.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ page.title }}">
+  {% if page.content %}<meta name="twitter:description" content="{{ page.content|plaintext_truncate:160 }}">{% endif %}
+  {% if page.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ page.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet"

--- a/templates/date/events/arsfest.html
+++ b/templates/date/events/arsfest.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/arsfest.css' %}">

--- a/templates/date/news/article.html
+++ b/templates/date/news/article.html
@@ -1,7 +1,17 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
+{% load og_tags %}
 {% block title %}{{ article.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ article.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if article.content %}<meta property="og:description" content="{{ article.content|plaintext_truncate:160 }}">{% endif %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ article.title }}">
+  {% if article.content %}<meta name="twitter:description" content="{{ article.content|plaintext_truncate:160 }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'news/css/style.css' %}">

--- a/templates/pulterit/events/arsfest.html
+++ b/templates/pulterit/events/arsfest.html
@@ -3,7 +3,19 @@
 {% load i18n %}
 {% load shared_filters %}
 {% load localized_time %}
+{% load og_tags %}
 {% block title %}{{ event.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ event.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if event.content %}<meta property="og:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+  <meta name="twitter:card" content="{% if event.background_image_url %}summary_large_image{% else %}summary{% endif %}">
+  <meta name="twitter:title" content="{{ event.title }}">
+  {% if event.content %}<meta name="twitter:description" content="{{ event.content|plaintext_truncate:160 }}">{% endif %}
+  {% if event.background_image_url %}<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ event.background_image_url }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'events/css/arsfest.css' %}">

--- a/templates/pulterit/news/article.html
+++ b/templates/pulterit/news/article.html
@@ -1,7 +1,17 @@
 {% extends 'core/base.html' %}
 {% load static %}
 {% load i18n %}
+{% load og_tags %}
 {% block title %}{{ article.title }}{% endblock %}
+{% block og_meta %}
+  <meta property="og:title" content="{{ article.title }}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  {% if article.content %}<meta property="og:description" content="{{ article.content|plaintext_truncate:160 }}">{% endif %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ article.title }}">
+  {% if article.content %}<meta name="twitter:description" content="{{ article.content|plaintext_truncate:160 }}">{% endif %}
+{% endblock %}
 {% block extra_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'news/css/style.css' %}">

--- a/templates/sf/core/base.html
+++ b/templates/sf/core/base.html
@@ -37,6 +37,11 @@
               integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
               crossorigin="anonymous"></script>
     {% endblock %}
+    {% block og_meta %}
+      <meta property="og:title" content="{{ ASSOCIATION_NAME }}">
+      <meta property="og:type" content="website">
+      <meta name="twitter:card" content="summary">
+    {% endblock %}
     {% block extra_head %}{% endblock %}
     <link rel="stylesheet"
           type="text/css"


### PR DESCRIPTION
## Summary

- Adds `{% block og_meta %}` to both base templates with generic association-name defaults
- Overrides the block in events, news, static pages, and publications detail templates with page-specific title, description, and image
- Creates `plaintext_truncate` template filter to strip HTML and truncate content for meta descriptions
- Intentionally excludes auth-protected pages (CTF, archive, polls, lucia) from page-specific OG tags

Closes #1020

## Test plan

- [ ] Start dev stack and visit event/news/staticpage/publication detail pages
- [ ] View page source and confirm OG + Twitter Card meta tags are present with correct values
- [ ] Confirm image URLs are absolute
- [ ] Confirm no hardcoded association names appear in meta tags
- [ ] Confirm CTF/archive/polls/lucia pages only show base defaults
- [ ] Test link preview with https://www.opengraph.io/link-preview
- [ ] Run `date-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)