### PR TITLE
fix: fixed pulterit officials requiring users to be members in order to filter officials

### DIFF
--- a/functionaries/selectors.py
+++ b/functionaries/selectors.py
@@ -23,7 +23,7 @@ def get_selected_year(request, distinct_years):
     selected_year = get_current_year()
     all_years = False
 
-    if request.user.is_authenticated and 'year' in request.GET:
+    if 'year' in request.GET:
         year_param = request.GET['year']
 
         if year_param == 'all':
@@ -44,7 +44,7 @@ def get_selected_role(request, functionary_roles):
     selected_role = None
     all_roles = False
 
-    if request.user.is_authenticated and 'role' in request.GET:
+    if 'role' in request.GET:
         role_param = request.GET['role']
 
         if role_param == 'all':
@@ -53,7 +53,7 @@ def get_selected_role(request, functionary_roles):
         else:
             try:
                 role_id = int(role_param)
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 pass
             else:
                 selected_role = FunctionaryRole.objects.filter(pk=role_id).first()

--- a/functionaries/selectors.py
+++ b/functionaries/selectors.py
@@ -53,7 +53,9 @@ def get_selected_role(request, functionary_roles):
         else:
             try:
                 role_id = int(role_param)
-            except (ValueError, TypeError):
+            except ValueError:
+                pass
+            except TypeError:
                 pass
             else:
                 selected_role = FunctionaryRole.objects.filter(pk=role_id).first()

--- a/functionaries/tests.py
+++ b/functionaries/tests.py
@@ -100,12 +100,12 @@ class FunctionaryHelperTests(TestCase):
         self.assertEqual(list(selected), list(years))
         self.assertTrue(all_years)
 
-    def test_get_selected_year_ignores_parameters_for_anonymous_user(self):
+    def test_get_selected_year_applies_parameters_for_anonymous_user(self):
         request = self.factory.get('/funktionarer/?year=2020')
         request.user = AnonymousUser()
         years = Functionary.objects.values_list('year', flat=True).distinct().order_by('-year')
         selected, _ = get_selected_year(request, years)
-        self.assertEqual(selected, timezone.now().year)
+        self.assertEqual(selected, 2020)
 
     def test_get_selected_role_supports_all_and_specific_roles(self):
         request_all = self.factory.get('/funktionarer/?role=all')
@@ -129,13 +129,13 @@ class FunctionaryHelperTests(TestCase):
         self.assertIsNone(selected)
         self.assertFalse(all_roles)
 
-    def test_get_selected_role_ignores_anonymous_requests(self):
+    def test_get_selected_role_applies_for_anonymous_requests(self):
         request = self.factory.get('/funktionarer/?role=all')
         request.user = AnonymousUser()
         roles = FunctionaryRole.objects.all()
         selected, all_roles = get_selected_role(request, roles)
-        self.assertIsNone(selected)
-        self.assertFalse(all_roles)
+        self.assertTrue(all_roles)
+        self.assertEqual(list(selected), list(roles))
 
     def test_get_filtered_functionaries_accepts_all_years_queryset(self):
         years = Functionary.objects.values_list('year', flat=True).distinct().order_by('-year')


### PR DESCRIPTION
- Fixed except ValueError, TypeError: in functionaries/selectors.py that was a hard SyntaxError under Python 3, breaking the entire public functionaries (/members/funktionarer/) page.
- Removed the request.user.is_authenticated requirement on the year/role filters — the listing itself is already fully public, and not every hosted association has member accounts, so gating the filter behind login served no purpose and silently broke filtering for logged-out visitors.
- Updated the two tests that had locked in the old "ignore filters for anonymous users" behavior to assert the new, correct behavior instead.