### PR TITLE
chart: GitHub OAuth config + secret.extraEnv

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/configmap.yaml
+++ b/charts/date-website/templates/configmap.yaml
@@ -36,6 +36,8 @@ data:
   DEFAULT_FROM_EMAIL: {{ .Values.email.defaultFrom | quote }}
   EMAIL_HOST: {{ .Values.email.host | quote }}
   CF_TURNSTILE_SITE_KEY: {{ .Values.django.turnstile.siteKey | quote }}
+  GITHUB_CLIENT_ID: {{ .Values.django.github.clientId | quote }}
+  GITHUB_MFA_POLICY: {{ .Values.django.github.mfaPolicy | quote }}
   {{- range $key, $value := .Values.extraEnv }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/date-website/templates/secret.yaml
+++ b/charts/date-website/templates/secret.yaml
@@ -16,4 +16,8 @@ stringData:
   EMAIL_HOST_USER: {{ .Values.email.username | quote }}
   EMAIL_HOST_PASSWORD: {{ .Values.email.password | quote }}
   CF_TURNSTILE_SECRET_KEY: {{ .Values.django.turnstile.secretKey | quote }}
+  GITHUB_CLIENT_SECRET: {{ .Values.django.github.clientSecret | quote }}
+  {{- range $key, $value := .Values.secret.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -13,7 +13,8 @@
     "secret": {
       "type": "object",
       "properties": {
-        "existingSecret": { "type": "string" }
+        "existingSecret": { "type": "string" },
+        "extraEnv": { "type": "object", "additionalProperties": { "type": "string" } }
       }
     },
     "django": {
@@ -29,6 +30,21 @@
         "allowedOrigins": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "github": {
+          "type": "object",
+          "properties": {
+            "clientId": { "type": "string" },
+            "clientSecret": { "type": "string" },
+            "mfaPolicy": { "type": "string" }
+          }
+        },
+        "turnstile": {
+          "type": "object",
+          "properties": {
+            "siteKey": { "type": "string" },
+            "secretKey": { "type": "string" }
+          }
         }
       }
     },

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -26,7 +26,16 @@ tolerations: []
 affinity: {}
 
 secret:
+  # Use a pre-created Secret (created out-of-band) instead of the generated
+  # one. Expected keys: SECRET_KEY, DB_PASSWORD, AWS_ACCESS_KEY_ID,
+  # AWS_SECRET_ACCESS_KEY, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD,
+  # CF_TURNSTILE_SECRET_KEY, GITHUB_CLIENT_SECRET (if django.github set),
+  # plus every key in secret.extraEnv.
   existingSecret: ""
+  # Extra secret-backed environment variables. When existingSecret is unset
+  # these are added to the generated Secret; when existingSecret is set they
+  # must be present as keys in that Secret. Keys must be valid env var names.
+  extraEnv: {}
 
 django:
   projectName: date
@@ -45,6 +54,13 @@ django:
   turnstile:
     siteKey: ""
     secretKey: ""
+  github:
+    # GitHub OAuth (used by the member login). clientSecret goes into the
+    # Secret (GITHUB_CLIENT_SECRET key); clientId and mfaPolicy into the
+    # ConfigMap.
+    clientId: ""
+    clientSecret: ""
+    mfaPolicy: "enrolled"
 
 database:
   name: postgres


### PR DESCRIPTION
Adds the missing chart capabilities needed for the Hetzner cutover:

- `django.github.clientId` / `mfaPolicy` (ConfigMap) and `clientSecret` (Secret key `GITHUB_CLIENT_SECRET`) so member login via GitHub SSO can be wired without plaintext values
- `secret.extraEnv`: generic secret-backed env vars (rendered into the generated Secret, or expected as keys in an `existingSecret`)
- schema + values docs, version 0.3.0 (publishes to GHCR on merge)