### PR TITLE
chart 0.3.1: secret-sourced ALUMNI_SETTINGS

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-asgi.yaml
+++ b/charts/date-website/templates/deployment-asgi.yaml
@@ -57,6 +57,14 @@ spec:
               set -e
               ./wait-for-postgres.sh "${DB_HOST}:${DB_PORT}"
               exec daphne -b 0.0.0.0 -p 8000 core.routing:application
+          env:
+            {{- if .Values.django.alumniSettingsSecretName }}
+            - name: ALUMNI_SETTINGS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.django.alumniSettingsSecretName }}
+                  key: ALUMNI_SETTINGS
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "date-website.fullname" . }}

--- a/charts/date-website/templates/deployment-celery.yaml
+++ b/charts/date-website/templates/deployment-celery.yaml
@@ -57,6 +57,14 @@ spec:
               set -e
               ./wait-for-postgres.sh "${DB_HOST}:${DB_PORT}"
               exec celery -A core worker -l {{ .Values.celery.logLevel }} -c {{ .Values.celery.concurrency }}
+          env:
+            {{- if .Values.django.alumniSettingsSecretName }}
+            - name: ALUMNI_SETTINGS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.django.alumniSettingsSecretName }}
+                  key: ALUMNI_SETTINGS
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "date-website.fullname" . }}

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -68,6 +68,14 @@ spec:
                 --max-requests-jitter {{ .Values.web.gunicorn.maxRequestsJitter }} \
                 --bind=0.0.0.0:8000 \
                 core.wsgi
+          env:
+            {{- if .Values.django.alumniSettingsSecretName }}
+            - name: ALUMNI_SETTINGS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.django.alumniSettingsSecretName }}
+                  key: ALUMNI_SETTINGS
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "date-website.fullname" . }}

--- a/charts/date-website/templates/job-migrate.yaml
+++ b/charts/date-website/templates/job-migrate.yaml
@@ -48,6 +48,14 @@ spec:
               set -e
               ./wait-for-postgres.sh "${DB_HOST}:${DB_PORT}"
               python /code/manage.py migrate --noinput
+          env:
+            {{- if .Values.django.alumniSettingsSecretName }}
+            - name: ALUMNI_SETTINGS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.django.alumniSettingsSecretName }}
+                  key: ALUMNI_SETTINGS
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "date-website.fullname" . }}

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -5,60 +5,117 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "minLength": 1 },
-        "tag": { "type": "string" },
-        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
       }
     },
     "secret": {
       "type": "object",
       "properties": {
-        "existingSecret": { "type": "string" },
-        "extraEnv": { "type": "object", "additionalProperties": { "type": "string" } }
+        "existingSecret": {
+          "type": "string"
+        },
+        "extraEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
       }
     },
     "django": {
       "type": "object",
       "properties": {
-        "projectName": { "type": "string", "minLength": 1 },
-        "secretKey": { "type": "string" },
+        "projectName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "secretKey": {
+          "type": "string"
+        },
         "allowedHosts": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "allowedOrigins": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "github": {
           "type": "object",
           "properties": {
-            "clientId": { "type": "string" },
-            "clientSecret": { "type": "string" },
-            "mfaPolicy": { "type": "string" }
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            },
+            "mfaPolicy": {
+              "type": "string"
+            }
           }
         },
         "turnstile": {
           "type": "object",
           "properties": {
-            "siteKey": { "type": "string" },
-            "secretKey": { "type": "string" }
+            "siteKey": {
+              "type": "string"
+            },
+            "secretKey": {
+              "type": "string"
+            }
           }
+        },
+        "alumniSettingsSecretName": {
+          "type": "string",
+          "default": ""
         }
       }
     },
     "database": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "username": { "type": "string", "minLength": 1 },
-        "password": { "type": "string" },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "username": {
+          "type": "string",
+          "minLength": 1
+        },
+        "password": {
+          "type": "string"
+        },
         "external": {
           "type": "object",
           "properties": {
-            "host": { "type": "string" },
-            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            }
           }
         }
       }
@@ -66,14 +123,20 @@
     "postgresql": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": {
+          "type": "boolean"
+        }
       }
     },
     "redis": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "externalUrl": { "type": "string" }
+        "enabled": {
+          "type": "boolean"
+        },
+        "externalUrl": {
+          "type": "string"
+        }
       }
     },
     "media": {
@@ -82,14 +145,30 @@
         "s3": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" },
-            "endpointUrl": { "type": "string" },
-            "regionName": { "type": "string" },
-            "bucketName": { "type": "string" },
-            "privateLocation": { "type": "string" },
-            "publicLocation": { "type": "string" },
-            "accessKeyId": { "type": "string" },
-            "secretAccessKey": { "type": "string" }
+            "enabled": {
+              "type": "boolean"
+            },
+            "endpointUrl": {
+              "type": "string"
+            },
+            "regionName": {
+              "type": "string"
+            },
+            "bucketName": {
+              "type": "string"
+            },
+            "privateLocation": {
+              "type": "string"
+            },
+            "publicLocation": {
+              "type": "string"
+            },
+            "accessKeyId": {
+              "type": "string"
+            },
+            "secretAccessKey": {
+              "type": "string"
+            }
           }
         }
       }
@@ -97,16 +176,30 @@
     "backups": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
+        "enabled": {
+          "type": "boolean"
+        },
         "objectStorage": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" },
-            "endpointUrl": { "type": "string" },
-            "regionName": { "type": "string" },
-            "bucketName": { "type": "string" },
-            "accessKeyId": { "type": "string" },
-            "secretAccessKey": { "type": "string" }
+            "enabled": {
+              "type": "boolean"
+            },
+            "endpointUrl": {
+              "type": "string"
+            },
+            "regionName": {
+              "type": "string"
+            },
+            "bucketName": {
+              "type": "string"
+            },
+            "accessKeyId": {
+              "type": "string"
+            },
+            "secretAccessKey": {
+              "type": "string"
+            }
           }
         }
       }
@@ -114,44 +207,80 @@
     "web": {
       "type": "object",
       "properties": {
-        "replicaCount": { "type": "integer", "minimum": 1 }
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1
+        }
       }
     },
     "asgi": {
       "type": "object",
       "properties": {
-        "replicaCount": { "type": "integer", "minimum": 1 },
-        "wsPath": { "type": "string", "pattern": "^/" }
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "wsPath": {
+          "type": "string",
+          "pattern": "^/"
+        }
       }
     },
     "celery": {
       "type": "object",
       "properties": {
-        "replicaCount": { "type": "integer", "minimum": 1 },
-        "concurrency": { "type": "integer", "minimum": 1 }
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "concurrency": {
+          "type": "integer",
+          "minimum": 1
+        }
       }
     },
     "ingress": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
+        "enabled": {
+          "type": "boolean"
+        },
         "hosts": {
           "type": "array",
           "minItems": 1,
           "items": {
             "type": "object",
-            "required": ["host", "paths"],
+            "required": [
+              "host",
+              "paths"
+            ],
             "properties": {
-              "host": { "type": "string", "minLength": 1 },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
               "paths": {
                 "type": "array",
                 "minItems": 1,
                 "items": {
                   "type": "object",
-                  "required": ["path", "pathType"],
+                  "required": [
+                    "path",
+                    "pathType"
+                  ],
                   "properties": {
-                    "path": { "type": "string", "pattern": "^/" },
-                    "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
+                    "path": {
+                      "type": "string",
+                      "pattern": "^/"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": [
+                        "Exact",
+                        "Prefix",
+                        "ImplementationSpecific"
+                      ]
+                    }
                   }
                 }
               }
@@ -163,7 +292,9 @@
           "items": {
             "type": "object",
             "properties": {
-              "secretName": { "type": "string" }
+              "secretName": {
+                "type": "string"
+              }
             }
           }
         }
@@ -172,13 +303,21 @@
     "gateway": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "className": { "type": "string" },
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
         "https": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" },
-            "secretName": { "type": "string" }
+            "enabled": {
+              "type": "boolean"
+            },
+            "secretName": {
+              "type": "string"
+            }
           }
         }
       }
@@ -190,7 +329,9 @@
         "properties": {
           "secret": {
             "properties": {
-              "existingSecret": { "const": "" }
+              "existingSecret": {
+                "const": ""
+              }
             }
           }
         }
@@ -198,15 +339,25 @@
       "then": {
         "properties": {
           "django": {
-            "required": ["secretKey"],
+            "required": [
+              "secretKey"
+            ],
             "properties": {
-              "secretKey": { "type": "string", "minLength": 1 }
+              "secretKey": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           },
           "database": {
-            "required": ["password"],
+            "required": [
+              "password"
+            ],
             "properties": {
-              "password": { "type": "string", "minLength": 1 }
+              "password": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         }
@@ -217,7 +368,9 @@
         "properties": {
           "postgresql": {
             "properties": {
-              "enabled": { "const": false }
+              "enabled": {
+                "const": false
+              }
             }
           }
         }
@@ -227,9 +380,14 @@
           "database": {
             "properties": {
               "external": {
-                "required": ["host"],
+                "required": [
+                  "host"
+                ],
                 "properties": {
-                  "host": { "type": "string", "minLength": 1 }
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }
@@ -242,7 +400,9 @@
         "properties": {
           "redis": {
             "properties": {
-              "enabled": { "const": false }
+              "enabled": {
+                "const": false
+              }
             }
           }
         }
@@ -250,9 +410,14 @@
       "then": {
         "properties": {
           "redis": {
-            "required": ["externalUrl"],
+            "required": [
+              "externalUrl"
+            ],
             "properties": {
-              "externalUrl": { "type": "string", "minLength": 1 }
+              "externalUrl": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         }
@@ -265,7 +430,9 @@
             "properties": {
               "s3": {
                 "properties": {
-                  "enabled": { "const": true }
+                  "enabled": {
+                    "const": true
+                  }
                 }
               }
             }
@@ -285,11 +452,26 @@
                   "publicLocation"
                 ],
                 "properties": {
-                  "endpointUrl": { "type": "string", "minLength": 1 },
-                  "regionName": { "type": "string", "minLength": 1 },
-                  "bucketName": { "type": "string", "minLength": 1 },
-                  "privateLocation": { "type": "string", "minLength": 1 },
-                  "publicLocation": { "type": "string", "minLength": 1 }
+                  "endpointUrl": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "regionName": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "bucketName": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "privateLocation": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "publicLocation": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }
@@ -304,7 +486,9 @@
             "properties": {
               "objectStorage": {
                 "properties": {
-                  "enabled": { "const": true }
+                  "enabled": {
+                    "const": true
+                  }
                 }
               }
             }
@@ -316,10 +500,19 @@
           "backups": {
             "properties": {
               "objectStorage": {
-                "required": ["endpointUrl", "bucketName"],
+                "required": [
+                  "endpointUrl",
+                  "bucketName"
+                ],
                 "properties": {
-                  "endpointUrl": { "type": "string", "minLength": 1 },
-                  "bucketName": { "type": "string", "minLength": 1 }
+                  "endpointUrl": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "bucketName": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }
@@ -332,10 +525,14 @@
         "properties": {
           "gateway": {
             "properties": {
-              "enabled": { "const": true },
+              "enabled": {
+                "const": true
+              },
               "https": {
                 "properties": {
-                  "enabled": { "const": true }
+                  "enabled": {
+                    "const": true
+                  }
                 }
               }
             }
@@ -350,7 +547,10 @@
                 "properties": {
                   "https": {
                     "properties": {
-                      "secretName": { "type": "string", "minLength": 1 }
+                      "secretName": {
+                        "type": "string",
+                        "minLength": 1
+                      }
                     }
                   }
                 }
@@ -366,9 +566,14 @@
                     "minItems": 1,
                     "items": {
                       "type": "object",
-                      "required": ["secretName"],
+                      "required": [
+                        "secretName"
+                      ],
                       "properties": {
-                        "secretName": { "type": "string", "minLength": 1 }
+                        "secretName": {
+                          "type": "string",
+                          "minLength": 1
+                        }
                       }
                     }
                   }

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -51,6 +51,7 @@ django:
   trustXForwardedProto: true
   extraStaffGroups: []
   alumniSettings: "{}"
+  alumniSettingsSecretName: ""
   turnstile:
     siteKey: ""
     secretKey: ""


### PR DESCRIPTION
The alumni/Google-Sheets config contains a service-account private key — cannot be in git values. Adds `django.alumniSettingsSecretName` (default empty, backward compatible); when set, deployment-web/asgi/celery + the migrate job read ALUMNI_SETTINGS from that secret (explicit env wins over the configmap).