### PR TITLE
docs: reflect how production actually deploys (Kubernetes + GitOps)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,9 +182,22 @@ Read the corresponding `docs/dev/<app>.md` before changing app internals.
 
 ## Deployment Notes
 
-Compose production uses `docker-compose.prod.yml` and the GHCR image selected by `DATE_IMG_TAG`. Prefer immutable commit SHA or release tags for production rollouts. `qa`, `prod`, and `latest` are moving aliases managed by workflows.
+Production (the association sites) runs on Kubernetes with GitOps: Argo CD
+deploys the published Helm chart (`charts/date-website/`) + per-site values
+from a private operator repository. This repo only *publishes* images and
+the chart — deploys happen in the operator repository. Image/tag rules:
+`main` → `<sha>` + `qa`; SemVer tag or `promote_production` → `prod` /
+`latest`. Blue-green deploys with shared databases: additive (expand-contract)
+migrations are zero-downtime safe; destructive migrations must ship as two
+releases (expand, then contract). Full flow: `docs/dev/kubernetes.md`.
 
-Kubernetes deployment uses the Helm chart in `charts/date-website/`. Run one Helm release per association because each release needs its own `PROJECT_NAME`, settings, static/template paths, hostnames, media prefixes, database, and backup prefix.
+`docker-compose.prod.yml` remains the self-hosted / standalone option
+(compose + `DATE_IMG_TAG`; prefer immutable SHA or release tags — `qa`,
+`prod`, `latest` are moving aliases).
+
+Run one Helm release per association because each release needs its own
+`PROJECT_NAME`, settings, static/template paths, hostnames, media prefixes,
+database, and backup prefix.
 
 Shared monitoring is in `monitoring/` plus the `docker-compose.monitoring.yml` app overlay. Keep Prometheus/Grafana bound to localhost unless there is a trusted authenticated access path.
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,33 @@ The `docs/` directory contains both developer notes (`docs/dev/*.md`) and conten
 Use [docs/index.md](docs/index.md) as the landing page for the published documentation site. Update it when you add a new app guide or rename an existing one.
 For translation architecture and workflow, see [docs/dev/translations.md](docs/dev/translations.md).
 
-## Deployment (`docker-compose.prod.yml`)
+## Deployment
 
-The production stack relies on the published container image at `ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}` plus managed PostgreSQL/Valkey volumes. Typical flow:
+### Production: Kubernetes + GitOps
+
+The association's production sites (date, kk, biocum, pulterit, sf, qa)
+run on a Kubernetes cluster managed with **GitOps**: Argo CD watches a
+private operator repository and deploys the published Helm chart + per-site
+values. You do not deploy to production from this repository — you publish
+an image and promote it:
+
+1. Push to `main` → CI builds `ghcr.io/.../date-website:<sha>` and `:qa`.
+2. Test the image as `qa`.
+3. Cut a SemVer tag (`vX.Y.Z`) or run the `promote_production` workflow →
+   the image becomes `:prod` / `:latest`.
+4. The operator repository pins that tag for the sites being updated; Argo CD
+   rolls them out (blue-green, zero-downtime).
+
+See [`docs/dev/kubernetes.md`](docs/dev/kubernetes.md) for the full
+deployment flow, image/tag rules, and the database-migration rules that
+apply to blue-green deploys. Cluster access details are intentionally not in
+this repository — they live in the private operator repository.
+
+### Self-hosted: `docker-compose.prod.yml`
+
+The compose stack is retained as the self-hosted / standalone deployment
+option (e.g. a single VPS not on the cluster). It relies on the published
+container image at `ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}` plus managed PostgreSQL/Valkey volumes. Typical flow:
 
 1. Copy `.env.prod.example` to `.env` on the deployment host and replace every placeholder.
 2. Ensure the external Docker network referenced by the compose file exists once:

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -1,298 +1,165 @@
-# Kubernetes and k3s Deployment Notes
+# Kubernetes Deployment Notes (production)
 
 ## Purpose
 
-This guide covers the Kubernetes deployment path for `date-website`, with k3s on Hetzner Cloud and Backblaze B2 as the expected object storage provider.
+Production runs on a Kubernetes cluster (k3s) managed with GitOps: Argo CD
+watches a private operator repository and applies everything — chart,
+per-site values, secrets wiring, ingress, blue-green standbys — from git.
+Nothing is deployed by hand against the cluster.
+
+This guide describes the deployment *flow* for developers working on
+`date-website`. It intentionally does not include cluster addresses, access
+paths, or secret locations — those live in the private operator repository
+and its docs. If you are on the ops team, the operator repository is the
+authoritative source; keep this file in sync with it when the flow changes.
 
 Use this together with:
 
-- `charts/date-website/values-hetzner.yaml` for the Hetzner k3s baseline
-- `charts/date-website/values-backblaze-b2.example.yaml` for B2 media and PostgreSQL backup storage
-- `charts/date-website/values-kk.example.yaml`, `charts/date-website/values-biocum.example.yaml`, or `charts/date-website/values-pulterit.example.yaml` for association-specific overrides
-- `README.md` for local development and Docker Compose workflows
+- `charts/date-website/` — the Helm chart this repository publishes
+- `docs/dev/operations.md` — day-to-day app operations
+- `README.md` — local development and Docker Compose workflows
 
-## Cluster Shape
+## Environment model
 
-The first production k3s target is expected to be:
+- **`main`** is the development branch. Every push to `main` builds a
+  container image and publishes it to GHCR as `<sha>` and `qa`.
+- **QA and production are image environments, not branches.** An image is
+  tested as `qa` first, then promoted to production.
+- **SemVer release tags** (`vX.Y.Z`) are the production promotion
+  mechanism. A release tag promotes the already-built image to the
+  production aliases (`prod`, `latest`, and the `vX.Y.Z`/`vX.Y`/`vX`
+  family) — no rebuild.
+- The `promote_production.yaml` workflow can also promote an arbitrary
+  existing tag (e.g. a QA-tested SHA) to `prod`/`latest` manually.
 
-- one CX33 control-plane node with workloads scheduled on it
-- an existing CX23 bastion/backend host for admin access and PostgreSQL
-- Hetzner Cloud Controller Manager and CSI driver installed by `hetzner-k3s` or the Terraform k3s module
-- Traefik with the Kubernetes Gateway API provider enabled
-- Hetzner `hcloud-volumes` storage class for in-cluster persistent workloads
+## Image pipeline
 
-The chart can render either Kubernetes `Ingress` or Gateway API resources. The Hetzner values use Gateway API:
+| Trigger | Image tags pushed |
+|---|---|
+| push to `main` | `:qa`, `:<commit-sha>` |
+| SemVer tag `vX.Y.Z` | `:vX.Y.Z`, `:vX.Y`, `:vX`, `:prod`, `:latest` |
+| manual `promote_production` | `:prod`, `:latest` from a chosen existing tag |
 
-```yaml
-ingress:
-  enabled: false
-gateway:
-  enabled: true
-  className: traefik
-```
+Notes:
 
-Do not manually mount a Hetzner volume for PostgreSQL. Let the Hetzner CSI driver provision it from the chart's PVC by using `storageClass: hcloud-volumes`.
+- `qa`, `prod`, and `latest` are moving aliases — code should not assume they
+  are immutable. Deployment targets pin what they want (see below).
+- The release-tag job waits for the SHA-tagged image from the `main` build,
+  then reuses that digest instead of rebuilding — tag the commit whose
+  `main` build went green.
+- Workflows: `docker_build.yaml`, `release_tag.yaml`,
+  `promote_production.yaml`.
 
-Use either `values-k3s.yaml` or `values-hetzner.yaml` as the cluster-specific storage preset, not both. `values-k3s.yaml` is for a generic k3s cluster using `local-path`; `values-hetzner.yaml` is for Hetzner k3s using `hcloud-volumes` and includes the resource sizing used for the planned CX33 worker.
+## The Helm chart
 
-## Helm Chart
-
-The chart lives in:
-
-```text
-charts/date-website/
-```
-
-It is published as an OCI Helm chart to GHCR by `.github/workflows/helm_chart.yaml` whenever chart files change on `main`, and can also be published manually through the workflow dispatch button. Bump `charts/date-website/Chart.yaml` `version` whenever chart templates or values change; production deploys should pin that immutable chart version.
-
-Current chart reference:
-
-```text
-oci://ghcr.io/datateknologerna-vid-abo-akademi/charts/date-website
-```
+The chart lives in `charts/date-website/` and is published as an OCI chart
+to GHCR by `helm_chart.yaml` whenever chart files change on `main`. Bump
+`charts/date-website/Chart.yaml` `version` on any template or values change;
+deployments pin the immutable chart version.
 
 The chart deploys:
 
 - Django/Gunicorn web deployment
 - Daphne ASGI deployment for WebSocket traffic
 - Celery worker deployment
-- PostgreSQL StatefulSet, unless `postgresql.enabled=false`
+- Optional PostgreSQL StatefulSet (disabled in production — see below)
 - Valkey/Redis StatefulSet
-- Gateway API `Gateway` and `HTTPRoute`, or a Traefik-compatible `Ingress`
-- optional local media PVC
-- PostgreSQL backup CronJob
+- Traefik-compatible `Ingress`, or Gateway API resources
 - optional migration Job
 
-The base chart defaults `web.migrateOnStartup: false` to avoid migration races when `web.replicaCount` is increased. For the current single-worker Hetzner setup, `values-hetzner.yaml` overrides this to `true` and disables the migration Job. If the web deployment is scaled above one replica, move migrations out of web startup and into a controlled migration step.
+The web deployment runs `migrateOnStartup` in the production values. If the
+web replica count is ever raised above 1, move migrations out of startup
+into the migration Job so two pods cannot race.
 
-The public route sends WebSocket traffic to the ASGI service with `asgi.wsPath`, which defaults to `/ws`.
+## How production actually runs (summary)
 
-The application container security context drops capabilities and prevents privilege escalation, but it does not set `runAsNonRoot: true` yet. The current application Dockerfile does not define a non-root `USER`, so forcing `runAsNonRoot` in the chart would break the image. Add a non-root user to the image first, then tighten the chart default.
+- One release per association (currently: date, kk, biocum, pulterit, sf,
+  qa), each in its own namespace with its own `PROJECT_NAME`, hosts,
+  settings module, media prefixes, database, and secrets.
+- **Databases are shared engines, not per-release.** A shared PostgreSQL
+  (and MongoDB/MariaDB for other apps) runs in the cluster; each site gets
+  its own database and user inside it. The chart's built-in PostgreSQL is
+  disabled (`postgresql.enabled: false`, `database.external` used).
+- **Media is S3-compatible object storage**, not local PVCs. The chart's
+  local media PVC is not used in production.
+- **The site Ingress lives outside the chart**, in the operator repository,
+  so blue-green cutover can flip the backend service names without a chart
+  change (see below).
+- **TLS** is issued per site by cert-manager (Let's Encrypt, DNS-01) and
+  terminated at the ingress.
 
-## Multiple Associations
+## Deploying a release (the flow)
 
-Run one Helm release per association. Do not route `date`, `kk`, `biocum`, and `pulterit` through the same release, because each release needs its own `PROJECT_NAME`, Django URL configuration, static/template paths, hosts, media prefixes, database, and backup prefix.
+1. A SemVer tag is cut (or `promote_production` is run) — the image is now
+   available as `prod`/`latest`.
+2. In the operator repository, the site's values file pins the image tag
+   (`image.tag`). A release that includes database migrations carries that
+   pin together with its migrations.
+3. Commit + push to the operator repository. Argo CD detects the change and
+   syncs the release.
+4. Verify: site responds over HTTPS, `/healthz/` and `/readyz/` are green.
 
-Examples:
+The operator repository holds:
 
-```bash
-helm upgrade --install date \
-  oci://ghcr.io/datateknologerna-vid-abo-akademi/charts/date-website \
-  --version 0.2.1 \
-  --namespace date \
-  --create-namespace \
-  -f charts/date-website/values-hetzner.yaml \
-  -f charts/date-website/values-backblaze-b2.example.yaml \
-  --set secret.existingSecret=date-website-prod-secrets \
-  --set gateway.https.secretName='<tls-secret-name>' \
-  --set database.external.host='<bastion-private-ip-or-dns>' \
-  --set image.tag='<release-tag>'
-```
+- the Argo CD Application per site (chart source + per-site values)
+- per-site values files (secrets are referenced by name, never inline)
+- the blue-green standbys and the ingress manifests
+- the deploy tooling (see below)
 
-```bash
-helm upgrade --install kk \
-  oci://ghcr.io/datateknologerna-vid-abo-akademi/charts/date-website \
-  --version 0.2.1 \
-  --namespace kk \
-  --create-namespace \
-  -f charts/date-website/values-hetzner.yaml \
-  -f charts/date-website/values-backblaze-b2.example.yaml \
-  -f charts/date-website/values-kk.example.yaml \
-  --set secret.existingSecret=kk-website-prod-secrets \
-  --set gateway.https.secretName='<tls-secret-name>' \
-  --set database.external.host='<bastion-private-ip-or-dns>' \
-  --set image.tag='<release-tag>'
-```
+## Blue-green deploys (zero-downtime)
 
-```bash
-helm upgrade --install biocum \
-  oci://ghcr.io/datateknologerna-vid-abo-akademi/charts/date-website \
-  --version 0.2.1 \
-  --namespace biocum \
-  --create-namespace \
-  -f charts/date-website/values-hetzner.yaml \
-  -f charts/date-website/values-backblaze-b2.example.yaml \
-  -f charts/date-website/values-biocum.example.yaml \
-  --set secret.existingSecret=biocum-website-prod-secrets \
-  --set gateway.https.secretName='<tls-secret-name>' \
-  --set database.external.host='<bastion-private-ip-or-dns>' \
-  --set image.tag='<release-tag>'
-```
+Every site has a **standby release** (same chart, `fullnameOverride`,
+shares the site's database and secrets, no ingress) that is scaled to zero
+between deploys. A deploy:
 
-```bash
-helm upgrade --install pulterit \
-  oci://ghcr.io/datateknologerna-vid-abo-akademi/charts/date-website \
-  --version 0.2.1 \
-  --namespace pulterit \
-  --create-namespace \
-  -f charts/date-website/values-hetzner.yaml \
-  -f charts/date-website/values-backblaze-b2.example.yaml \
-  -f charts/date-website/values-pulterit.example.yaml \
-  --set secret.existingSecret=pulterit-website-prod-secrets \
-  --set gateway.https.secretName='<tls-secret-name>' \
-  --set database.external.host='<bastion-private-ip-or-dns>' \
-  --set image.tag='<release-tag>'
-```
+1. dumps the site's database first (the rollback mechanism)
+2. sets the new image tag on the standby → Argo syncs it → the standby runs
+   migrations on startup while the live site keeps serving
+3. smoke-tests the standby, then flips the ingress backend service names to
+   the standby (in-place, no traffic gap)
+4. soaks, keeping the old stack as the rollback target, then scales the old
+   stack to zero
 
-Each release should have separate `django.projectName`, `django.allowedHosts`, `django.allowedOrigins`, `ingress.hosts`, media bucket names or prefixes, backup bucket name or prefix, and Kubernetes Secret. `ingress.hosts` is also used as the HTTPRoute hostname source when Gateway API is enabled. Keeping separate namespaces is optional, but it makes secrets, PVCs, and operational commands harder to mix up.
+**Database migration rule (important):** the standby *shares* the site's
+database, so a destructive migration breaks the live site the moment the
+standby migrates — not at cutover. Therefore:
 
-If several associations share one B2 bucket, keep unique media locations such as `date/media`, `kk/media`, `biocum/media`, and `pulterit/media`. If they use separate B2 buckets, still keep distinct backup prefixes such as `date-website/postgresql`, `kk-website/postgresql`, `biocum-website/postgresql`, and `pulterit-website/postgresql`.
+- **Expand-contract (additive) migrations** — new nullable columns/tables,
+  no data reshapes the old code reads — are safe and deploy zero-downtime.
+- **Destructive migrations** — drops, renames, column type changes — must
+  ship as two releases: an additive "expand" release, then a later "contract"
+  release that cleans up. The deploy tooling gates on the live site's health
+  after the standby migrates and aborts + restores the dump if the live site
+  broke, but it cannot make a destructive migration zero-downtime.
 
-## Backblaze B2 Object Storage
+## Secrets
 
-Backblaze B2 should be configured through the S3-compatible API. Backblaze documents the endpoint format in its [S3-compatible API guide](https://www.backblaze.com/docs/cloud-storage-call-the-s3-compatible-api); use the endpoint for the bucket region:
-
-```text
-https://s3.<region>.backblazeb2.com
-```
-
-Example:
-
-```text
-https://s3.us-west-000.backblazeb2.com
-```
-
-B2 uses v4 signatures for the S3-compatible API. The chart example sets:
-
-```yaml
-signatureVersion: "s3v4"
-addressingStyle: "path"
-```
-
-Prefer separate B2 buckets for private media, public media, and database backups:
-
-```yaml
-media:
-  s3:
-    privateBucketName: "date-website-private"
-    publicBucketName: "date-website-public"
-
-backups:
-  objectStorage:
-    bucketName: "date-website-backups"
-```
-
-This avoids depending on per-object ACL behavior. Treat public/private access as a bucket-level decision in B2.
-
-When `media.s3.enabled: true`, the chart does not mount the local media PVC. Uploaded media goes to B2 instead of `/code/media`.
-
-When `backups.objectStorage.enabled: true` and `backups.persistence.enabled: false`, the backup CronJob writes the dump to an `emptyDir`, uploads the compressed dump to B2, and does not allocate a separate Hetzner backup volume.
-
-## Production Secret
-
-Prefer a pre-created Kubernetes Secret for production values:
-
-```bash
-kubectl create namespace date-website
-
-kubectl -n date-website create secret generic date-website-prod-secrets \
-  --from-literal=SECRET_KEY='<django-secret-key>' \
-  --from-literal=DB_PASSWORD='<postgres-password>' \
-  --from-literal=AWS_ACCESS_KEY_ID='<b2-media-application-key-id>' \
-  --from-literal=AWS_SECRET_ACCESS_KEY='<b2-media-application-key>' \
-  --from-literal=OBJECT_STORAGE_ACCESS_KEY_ID='<b2-backup-application-key-id>' \
-  --from-literal=OBJECT_STORAGE_SECRET_ACCESS_KEY='<b2-backup-application-key>' \
-  --from-literal=EMAIL_HOST_USER='<smtp-user>' \
-  --from-literal=EMAIL_HOST_PASSWORD='<smtp-password>' \
-  --from-literal=CF_TURNSTILE_SECRET_KEY='<turnstile-secret>'
-```
-
-Use separate B2 application keys for media and backups if possible. The media key should only access the media buckets; the backup key should only access the backup bucket.
-
-Do not commit real secrets to values files. If `secret.existingSecret` is not set, the chart-created Secret requires real `django.secretKey` and `database.password` values at render time.
-
-When `secret.existingSecret` is used, pod checksum annotations cannot detect changes inside that external Secret. After rotating an external Secret, restart the affected workloads:
-
-```bash
-kubectl -n <namespace> rollout restart deploy/<release>-date-website-web
-kubectl -n <namespace> rollout restart deploy/<release>-date-website-asgi
-kubectl -n <namespace> rollout restart deploy/<release>-date-website-celery
-```
-
-## Deploy
-
-Copy the B2 example values into an environment-specific private values file before production use, or override the bucket names and endpoint from CI/CD.
-
-Typical install or upgrade:
-
-```bash
-helm upgrade --install date-website \
-  oci://ghcr.io/datateknologerna-vid-abo-akademi/charts/date-website \
-  --version 0.2.1 \
-  --namespace date-website \
-  --create-namespace \
-  -f charts/date-website/values-hetzner.yaml \
-  -f charts/date-website/values-backblaze-b2.example.yaml \
-  --set secret.existingSecret=date-website-prod-secrets \
-  --set gateway.https.secretName='<tls-secret-name>' \
-  --set database.external.host='<bastion-private-ip-or-dns>' \
-  --set image.tag='<release-tag>'
-```
-
-Set `image.tag` to a release tag, immutable commit SHA, or the `prod` production alias. Avoid deploying `qa` by accident in production.
-Set `gateway.https.secretName` to a TLS Secret in the release namespace, or provide the same Secret through `ingress.tls[0].secretName`; the Hetzner values enable Gateway HTTPS and require one of those values.
-
-For KK, Biologica, or Pulterit, layer the matching association values file after the B2 values file so the association-specific hosts, `PROJECT_NAME`, media paths, and backup prefix override the default `date` example.
-
-## Verify
-
-Check Kubernetes resources:
-
-```bash
-kubectl -n date-website get pods
-kubectl -n date-website get gateway,httproute
-kubectl -n date-website get pvc
-kubectl -n date-website logs deploy/date-website-web
-```
-
-Check Django probes through the public host after DNS and TLS are configured:
-
-```bash
-curl -fsS https://<host>/healthz/
-curl -fsS https://<host>/readyz/
-```
-
-`/healthz/` only checks that the app process responds. `/readyz/` checks database and cache access.
+- Production secrets live in Kubernetes secrets created out-of-band; site
+  values reference them via `secret.existingSecret`. Nothing secret goes in
+  values files or git.
+- Sealed copies (encrypted, cluster-bound) are kept in the operator
+  repository so a rebuild can recreate them.
+- After rotating a secret, restart the site's deployments (pod checksum
+  annotations do not see external secret changes).
 
 ## Backups
 
-The Hetzner values file enables the backup CronJob by default:
+- The cluster runs nightly restic backups to Backblaze B2, taken from the
+  database engines directly (dumps of every site database). Retention is
+  managed in restic.
+- The chart's backup CronJob is **not** used in production (the cluster-level
+  pipeline supersedes it); it remains available for self-hosted installs.
+- Restore is a documented, tested drill in the operator repository.
 
-```yaml
-backups:
-  enabled: true
-  schedule: "17 2 * * *"
-  retentionDays: 14
-```
+## Operational notes
 
-With the B2 override, the CronJob uploads compressed PostgreSQL dumps to:
-
-```text
-s3://<backup-bucket>/date-website/postgresql/
-```
-
-To trigger one backup manually:
-
-```bash
-kubectl -n date-website create job \
-  --from=cronjob/date-website-postgresql-backup \
-  date-website-postgresql-backup-manual-$(date -u +%Y%m%d%H%M%S)
-```
-
-Then inspect the job logs and confirm the object exists in B2:
-
-```bash
-kubectl -n date-website logs job/<manual-backup-job-name>
-```
-
-For object-storage uploads, prefer a pinned backup image that already contains both `pg_dump` and the AWS CLI, and keep `backups.objectStorage.installAwsCli: false`. The B2 example values intentionally keep runtime package installation disabled, so production deployments using object-storage uploads should override `backups.image` to a backup image with both tools installed. The backup job defaults to the PostgreSQL image's non-root UID/GID and sets `backups.podSecurityContext.fsGroup` so the mounted backup directory is writable. If you temporarily set `installAwsCli: true` with an Alpine image, the backup container needs a root-capable `backups.securityContext` because `apk add --no-cache aws-cli` requires package-install privileges.
-
-`retentionDays` prunes old dump files only from the local `/backups` directory. When the B2 override uses `backups.persistence.enabled: false`, this local retention is only for the temporary `emptyDir`; remote B2 objects are not pruned by the CronJob. Configure a B2 bucket lifecycle rule for `date-website/postgresql/` if remote backup retention should be automatic.
-
-## Operational Notes
-
-- This one-control-plane, one-worker setup is not highly available. If the worker or its Hetzner volume is unavailable, the app and database are unavailable.
-- `values-hetzner.yaml` resource requests are based on observed Docker production usage: web is the largest process at roughly 300-450Mi, Celery sits around 250Mi, ASGI around 90Mi, and idle Postgres/Redis are much smaller. Revisit requests after sustained Kubernetes traffic, especially after larger event registrations or admin uploads.
-- Redis persistence is disabled in `values-hetzner.yaml` to avoid a separate 10Gi Hetzner volume for cache and broker data. This means queued Celery tasks can be lost if Redis restarts.
-- Use B2 for media before scaling web replicas. Local media on a single ReadWriteOnce PVC is simpler but limits scaling and failover.
-- Keep the PostgreSQL volume on `hcloud-volumes`. B2 backups protect against bad migrations and volume corruption, but they do not remove the need to monitor and test restores.
+- The cluster is not highly available by design: a single set of nodes,
+  single database engines, single ingress plane. Bounded blast radius and
+  tested restore are the availability story.
+- Redis persistence is disabled in production values — queued Celery tasks
+  can be lost if Redis restarts. Celery retries/cron are the backstop.
+- Resource requests in `values-hetzner.yaml` are based on observed
+  production usage: web is the largest process (~300–450Mi), Celery ~250Mi,
+  ASGI ~90Mi. Revisit after sustained traffic or big uploads.
+- Media must stay on S3-compatible storage before web replicas are ever
+  scaled up; a local RWO PVC would block scaling and failover.


### PR DESCRIPTION
## What

`docs/dev/kubernetes.md` described a **planned** deployment design (Gateway API, hcloud-volumes CSI, bastion-host PostgreSQL, chart backup CronJob) that never matched live production. This PR rewrites it to describe the deployment flow as it actually works today, and updates the README + AGENTS.md deployment sections to match.

## What the docs now say

- Production = k3s + GitOps: Argo CD applies the published Helm chart + per-site values from a private operator repository. This repo publishes images and the chart; it does not deploy.
- Image pipeline table: main -> sha/qa; SemVer tag or promote_production workflow -> prod/latest (release reuses the existing digest, no rebuild).
- Production architecture summary: one release per association, shared database engines with per-site databases, media on S3-compatible storage, chart-local postgres/backup CronJob disabled.
- Blue-green deploys + the database-migration rule: the standby shares the site's database, so destructive migrations break the live site the moment the standby migrates — expand-contract (additive) migrations only for zero-downtime; destructive migrations ship as two releases (expand, then contract).
- Secrets/backups: referenced by name, sealed copies for rebuild; cluster-level restic to B2 supersedes the chart CronJob.

## Security

Deliberately no cluster addresses, access paths, tool/secret locations, or hostnames — those live in the private operator repository. The doc says so explicitly.