### PR TITLE
chart: celery liveness probe 60s -> 300s (cut probe CPU ~5x)

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-celery.yaml
+++ b/charts/date-website/templates/deployment-celery.yaml
@@ -70,6 +70,9 @@ spec:
                 name: {{ include "date-website.fullname" . }}
             - secretRef:
                 name: {{ include "date-website.secretName" . }}
+          # Liveness via `celery inspect ping`: a real worker-response check,
+          # but each invocation imports the whole Django app (~3s user CPU on
+          # prod). Keep the cadence coarse (default 300s) — see values.yaml.
           livenessProbe:
             exec:
               command:

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -208,8 +208,11 @@ celery:
   concurrency: 2
   logLevel: info
   livenessProbe:
+    # `celery inspect ping` imports the whole Django app on every invocation
+    # (~3s of user CPU measured on prod). 60s -> 300s keeps the probe cheap
+    # while still restarting a dead worker within ~15 min (3 x 300s).
     initialDelaySeconds: 60
-    periodSeconds: 60
+    periodSeconds: 300
     timeoutSeconds: 10
     failureThreshold: 3
   resources: {}


### PR DESCRIPTION
chart: celery liveness probe 60s -> 300s (cut probe CPU ~5x)

## Problem

Measured on prod (2026-08-05): the celery liveness probe runs `celery -A core inspect ping` every **60s**, and each invocation imports the whole Django app — **~2.9s user CPU** (2.56s user + 0.37s sys).

With 6 sites x every 60s, the probes were the dominant CPU consumer on the worker: constant **~150-280m** spikes that correlated exactly with the 60s probe period (verified by sampling).

## Fix

- `celery.livenessProbe.periodSeconds`: 60 -> **300**
- Restart-on-death stays within ~15 min (`failureThreshold: 3` x 300s) — fine for a worker
- Comment added at both the values default and the template so the cost is documented
- Chart version **0.3.2**

## Why not remove the probe

Celery has no Service (nothing routes to it), so this is liveness-only — but liveness still matters: if the worker dies, tasks pile up in Redis (persistence disabled) with nothing consuming them. Keep the check, make it cheap.

## Measurement evidence

- `kubectl top` over 70s: 2m -> 286m -> 2m -> 2m -> 286m... repeating every ~60s
- Single probe invocation: `real 2.97s, user 2.56s, sys 0.37s`
- Zombie celery children accumulating between probes (short-lived probe processes)

## Checklist

- [x] Chart version bumped (0.3.2)
- [x] `helm template` renders `periodSeconds: 300` for the celery deployment
- [x] No secrets or environment-specific values