### PR TITLE
chore: simplify issue templates to reduce required fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,29 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report this. Please include enough detail for someone else to reproduce the problem from a clean checkout when possible.
-  - type: dropdown
-    id: area
-    attributes:
-      label: Affected area
-      options:
-        - Public website
-        - Admin/editor tools
-        - Membership or alumni tools
-        - Polls, events, or seasonal apps
-        - Authentication or permissions
-        - Translations or language switching
-        - Docker/local development
-        - Deployment or infrastructure
-        - Documentation
-        - Other
-    validations:
-      required: true
+        Thanks for reporting this. Describe the problem briefly — repro steps, screenshots, and logs are helpful but not required.
   - type: textarea
     id: summary
     attributes:
       label: What happened?
-      description: Describe the broken behavior and what you expected instead.
+      description: What went wrong, and what did you expect instead?
       placeholder: The page/form/job does X, but I expected Y.
     validations:
       required: true
@@ -36,33 +19,30 @@ body:
     id: steps
     attributes:
       label: Steps to reproduce
-      description: Give precise steps, URLs, commands, test data, or user roles.
+      description: URLs, commands, or user roles help us reproduce it.
       placeholder: |
-        1. Start from ...
-        2. Go to ...
-        3. Submit ...
-        4. See ...
+        1. Go to ...
+        2. Do ...
+        3. See ...
     validations:
-      required: true
+      required: false
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Include anything relevant to reproducing the issue.
+      description: Leave blank if not sure.
       value: |
         - Branch/commit:
         - Browser/device:
         - PROJECT_NAME:
-        - ENABLE_LANGUAGE_FEATURES:
-        - Docker Compose file(s):
         - Local, staging, or production:
     validations:
-      required: true
+      required: false
   - type: textarea
     id: logs
     attributes:
       label: Logs or error output
-      description: Paste tracebacks, browser console output, Celery logs, or links to failing CI runs. Remove secrets first.
+      description: Paste tracebacks, browser console output, or Celery logs. Remove secrets first.
       render: shell
     validations:
       required: false
@@ -70,14 +50,7 @@ body:
     id: screenshots
     attributes:
       label: Screenshots or recordings
-      description: Drag and drop images or screen recordings here. Leave blank if not applicable.
-    validations:
-      required: false
-  - type: textarea
-    id: workaround
-    attributes:
-      label: Workaround
-      description: If there is a temporary workaround, describe it here.
+      description: Drag and drop images here if helpful.
     validations:
       required: false
   - type: checkboxes
@@ -85,7 +58,5 @@ body:
     attributes:
       label: Pre-submit checks
       options:
-        - label: I searched existing issues and did not find a duplicate.
-          required: true
         - label: I removed secrets, passwords, tokens, and private production data from this report.
           required: true

--- a/.github/ISSUE_TEMPLATE/config_request.yml
+++ b/.github/ISSUE_TEMPLATE/config_request.yml
@@ -7,37 +7,6 @@ body:
     attributes:
       value: |
         Do not paste real secrets, passwords, app keys, tokens, private bucket names, or production data into this issue.
-  - type: dropdown
-    id: target
-    attributes:
-      label: Target environment
-      options:
-        - Local development
-        - Review app or staging
-        - Production Docker Compose
-        - Production Kubernetes/Helm
-        - CI/CD
-        - Documentation/example configuration
-        - Other
-    validations:
-      required: true
-  - type: dropdown
-    id: category
-    attributes:
-      label: Configuration category
-      options:
-        - Environment variable
-        - Secret or credential rotation
-        - Database or Valkey/Redis
-        - S3-compatible storage
-        - Domain, TLS, or ingress
-        - Docker Compose
-        - Kubernetes or Helm
-        - GitHub Actions
-        - Language or association setting
-        - Other
-    validations:
-      required: true
   - type: textarea
     id: request
     attributes:
@@ -47,41 +16,27 @@ body:
     validations:
       required: true
   - type: textarea
-    id: reason
-    attributes:
-      label: Why is this needed?
-      description: Explain the impact, dependency, deadline, or user-facing reason.
-    validations:
-      required: true
-  - type: textarea
     id: details
     attributes:
-      label: Non-secret details
-      description: Include variable names, service names, chart values, compose files, expected URLs, or documentation links.
+      label: Details
+      description: Variable names, services affected, files, or docs links, if known.
       placeholder: |
         - Variable or setting names:
         - Services affected:
-        - Files affected:
-        - Relevant docs:
     validations:
       required: false
   - type: textarea
-    id: deadline
+    id: reason
     attributes:
-      label: Urgency or deadline
-      description: When is this needed, and what breaks or blocks if it is delayed?
-      placeholder: Needed by ... because ...
+      label: Why is this needed?
+      description: Impact, dependency, or deadline, if any.
     validations:
       required: false
   - type: textarea
     id: validation
     attributes:
       label: Validation plan
-      description: How should we confirm the configuration is correct after it changes?
-      placeholder: |
-        - Run ...
-        - Check ...
-        - Visit ...
+      description: How should we confirm the configuration is correct?
     validations:
       required: false
   - type: checkboxes
@@ -90,6 +45,4 @@ body:
       label: Pre-submit checks
       options:
         - label: I did not include secret values or private production data.
-          required: true
-        - label: I identified the target environment and affected services as clearly as I can.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,73 +1,49 @@
 name: Feature request
-description: Propose a new capability or meaningful product improvement.
+description: Propose a new capability or improvement.
 title: "feat: "
 labels: ["feature"]
 body:
   - type: markdown
     attributes:
       value: |
-        Use this for new behavior or larger improvements. If something is broken, please open a bug report instead.
-  - type: dropdown
-    id: area
+        Describe what you'd like to see. If something is broken, please open a bug report instead.
+  - type: textarea
+    id: proposal
     attributes:
-      label: Product area
-      options:
-        - Public website
-        - Admin/editor tools
-        - Membership or alumni tools
-        - Polls, events, or seasonal apps
-        - Authentication or permissions
-        - Translations or language switching
-        - Developer experience
-        - Deployment or infrastructure
-        - Documentation
-        - Other
+      label: Proposed solution
+      description: What should exist, and what should it let users do?
+      placeholder: A ... that lets users ...
     validations:
       required: true
   - type: textarea
     id: problem
     attributes:
       label: Problem or opportunity
-      description: What user need, workflow, or project goal does this address?
+      description: What need does this address?
       placeholder: As a ..., I want ..., so that ...
     validations:
-      required: true
-  - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed solution
-      description: Describe the behavior, screens, permissions, data model, or workflow you have in mind.
-    validations:
-      required: true
+      required: false
   - type: textarea
     id: acceptance
     attributes:
       label: Acceptance criteria
-      description: List the concrete outcomes that would make this ready to merge.
+      description: Concrete outcomes that would make this done.
       placeholder: |
         - [ ] Users can ...
-        - [ ] Admins can ...
-        - [ ] Existing behavior remains ...
     validations:
-      required: true
+      required: false
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Mention simpler options, manual workarounds, or reasons not to solve this another way.
+      description: Simpler options or reasons not to solve it another way.
     validations:
       required: false
   - type: textarea
     id: qa
     attributes:
       label: Testing and rollout notes
-      description: Include expected tests, migrations, fixture needs, translation work, documentation updates, or deployment considerations.
-      placeholder: |
-        - Tests:
-        - Migrations:
-        - Translations:
-        - Docs:
-        - Rollout:
+      description: Tests, migrations, translations, docs, or deployment considerations.
     validations:
       required: false
   - type: checkboxes
@@ -76,6 +52,4 @@ body:
       label: Pre-submit checks
       options:
         - label: I searched existing issues and did not find a duplicate.
-          required: true
-        - label: I included enough detail for someone else to assess scope and priority.
-          required: true
+          required: false

--- a/.github/ISSUE_TEMPLATE/fix_request.yml
+++ b/.github/ISSUE_TEMPLATE/fix_request.yml
@@ -6,21 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this when the current behavior mostly works, but something should be cleaned up, clarified, modernized, or made less fragile.
-  - type: dropdown
-    id: kind
+        Use this when something mostly works but should be cleaned up or improved.
+  - type: textarea
+    id: desired
     attributes:
-      label: Change type
-      options:
-        - Code cleanup
-        - UI polish
-        - Copy or content correction
-        - Documentation correction
-        - Dependency or tooling update
-        - Test coverage
-        - Performance
-        - Accessibility
-        - Other
+      label: What should change?
+      description: Describe the correction or cleanup you want.
     validations:
       required: true
   - type: textarea
@@ -29,33 +20,12 @@ body:
       label: Current state
       description: What exists now, and why is it worth improving?
     validations:
-      required: true
-  - type: textarea
-    id: desired
-    attributes:
-      label: Desired state
-      description: Describe the exact correction or cleanup you want.
-    validations:
-      required: true
-  - type: textarea
-    id: scope
-    attributes:
-      label: Scope boundaries
-      description: Note files, apps, pages, or behavior that should be included or left untouched.
-      placeholder: |
-        In scope:
-        Out of scope:
-    validations:
       required: false
   - type: textarea
     id: verification
     attributes:
       label: Verification
-      description: How should someone confirm this fix is complete?
-      placeholder: |
-        - Run ...
-        - Visit ...
-        - Confirm ...
+      description: How should someone confirm the change is complete?
     validations:
       required: false
   - type: checkboxes
@@ -64,6 +34,6 @@ body:
       label: Pre-submit checks
       options:
         - label: This is not a reproducible bug report or a larger feature request.
-          required: true
+          required: false
         - label: I searched existing issues and did not find a duplicate.
-          required: true
+          required: false


### PR DESCRIPTION
## Summary

Makes the issue templates quicker to fill by cutting required fields down to the minimum.

## Changes

- Each template now requires only one essential text field: "What happened?" (bug), "Proposed solution" (feature), "What should change?" (chore), "What needs to be configured?" (config).
- Removed the categorization dropdowns (area, kind, target environment, configuration category).
- Made repro steps, environment, acceptance criteria, and other sections optional.
- Kept only one required checkbox per template: the "no secrets" check on bug reports and config requests. Duplicate-search and triage checkboxes are now optional.

## Testing

No code changes; template YAML only. Not run: test suite, CI (not applicable).

## Docs

No documentation updates needed.