### PR TITLE
chart: allow replicaCount 0 in schema

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -209,7 +209,7 @@
       "properties": {
         "replicaCount": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         }
       }
     },
@@ -218,7 +218,7 @@
       "properties": {
         "replicaCount": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "wsPath": {
           "type": "string",
@@ -231,7 +231,7 @@
       "properties": {
         "replicaCount": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "concurrency": {
           "type": "integer",


### PR DESCRIPTION
## Problem

Blue-green standbys are kept dormant at 0 replicas via `kubectl scale`, but the chart schema forbids `replicaCount: 0` (`minimum: 1`). Dormancy therefore exists only as live cluster state, and **any real Argo sync re-renders the chart default of 1** — a chart bump rolls every standby back to full replicas. Incident 2026-08-05: 6 sites + 6 standbys rolled at once, worker OOM-thrashed (load 302, ~75 pods vs ~31 steady).

## Fix

- `values.schema.json`: `web/asgi/celery.replicaCount` `minimum: 1 -> 0`
- Chart version 0.3.3

Now a standby can set `replicaCount: 0` in its values (in git), so Argo renders 0 replicas on every sync and dormancy is declarative + sync-proof. The deploy tooling toggles it via git (0 -> 1 for a deploy, 1 -> 0 after cutover).

## Verify

- `helm template` with `replicaCount: 0` renders `replicas: 0` (schema passes)
- `replicaCount: 1` still renders 1 (unchanged default)

## Checklist

- [x] Chart version bumped (0.3.3)
- [x] `helm template` validates both 0 and 1
- [x] No secrets