### PR TITLE
chart: zero-downtime rollouts

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-asgi.yaml
+++ b/charts/date-website/templates/deployment-asgi.yaml
@@ -11,6 +11,15 @@ spec:
     matchLabels:
       {{- include "date-website.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: asgi
+  # Zero-downtime rollouts: never take the old pod down until the new one
+  # is Ready. Default maxUnavailable 25% rounds up to 1 with a single
+  # replica -> the old pod dies while the new one is still migrating,
+  # causing a real outage window on every rollout (2026-08-05).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -74,6 +83,16 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz/
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "date-website.probeHost" . | quote }}
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz/
@@ -81,8 +100,9 @@ spec:
               httpHeaders:
                 - name: Host
                   value: {{ include "date-website.probeHost" . | quote }}
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 30
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -93,6 +113,7 @@ spec:
                   value: {{ include "date-website.probeHost" . | quote }}
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/date-website/templates/deployment-celery.yaml
+++ b/charts/date-website/templates/deployment-celery.yaml
@@ -11,6 +11,15 @@ spec:
     matchLabels:
       {{- include "date-website.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: celery
+  # Zero-downtime rollouts: never take the old pod down until the new one
+  # is Ready. Default maxUnavailable 25% rounds up to 1 with a single
+  # replica -> the old pod dies while the new one is still migrating,
+  # causing a real outage window on every rollout (2026-08-05).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -70,6 +79,17 @@ spec:
                 name: {{ include "date-website.fullname" . }}
             - secretRef:
                 name: {{ include "date-website.secretName" . }}
+          # startupProbe gates liveness during slow starts (worker boot +
+          # Django import can exceed the liveness initialDelay).
+          startupProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - celery -A core inspect ping -d "celery@${HOSTNAME}" | grep -q OK
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 10
           # Liveness via `celery inspect ping`: a real worker-response check,
           # but each invocation imports the whole Django app (~3s user CPU on
           # prod). Keep the cadence coarse (default 300s) — see values.yaml.
@@ -79,7 +99,7 @@ spec:
                 - /bin/bash
                 - -c
                 - celery -A core inspect ping -d "celery@${HOSTNAME}" | grep -q OK
-            initialDelaySeconds: {{ .Values.celery.livenessProbe.initialDelaySeconds }}
+            initialDelaySeconds: 10
             periodSeconds: {{ .Values.celery.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.celery.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.celery.livenessProbe.failureThreshold }}

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -11,6 +11,15 @@ spec:
     matchLabels:
       {{- include "date-website.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: web
+  # Zero-downtime rollouts: never take the old pod down until the new one
+  # is Ready. Default maxUnavailable 25% rounds up to 1 with a single
+  # replica -> the old pod dies while the new one is still migrating,
+  # causing a real outage window on every rollout (2026-08-05).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -85,6 +94,19 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          # startupProbe gates liveness during slow starts (migrateOnStartup
+          # can take >1min under load). Without it, liveness kills the pod at
+          # initialDelay + 3*failure — the zero-downtime killer on rollouts.
+          startupProbe:
+            httpGet:
+              path: /healthz/
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "date-website.probeHost" . | quote }}
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz/
@@ -92,8 +114,9 @@ spec:
               httpHeaders:
                 - name: Host
                   value: {{ include "date-website.probeHost" . | quote }}
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 30
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -104,6 +127,7 @@ spec:
                   value: {{ include "date-website.probeHost" . | quote }}
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -210,6 +210,9 @@
         "replicaCount": {
           "type": "integer",
           "minimum": 0
+        },
+        "strategy": {
+          "type": "object"
         }
       }
     },
@@ -223,6 +226,9 @@
         "wsPath": {
           "type": "string",
           "pattern": "^/"
+        },
+        "strategy": {
+          "type": "object"
         }
       }
     },
@@ -236,6 +242,9 @@
         "concurrency": {
           "type": "integer",
           "minimum": 1
+        },
+        "strategy": {
+          "type": "object"
         }
       }
     },

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -1,76 +1,57 @@
+
 image:
   repository: ghcr.io/datateknologerna-vid-abo-akademi/date-website
   tag: prod
   pullPolicy: IfNotPresent
-
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
-
+nameOverride: ''
+fullnameOverride: ''
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
-
+  name: ''
 podAnnotations: {}
 podSecurityContext: {}
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-      - ALL
-  # Do not set runAsNonRoot until the application image defines a non-root USER.
-  # The current Dockerfile does not, and forcing it here would break startup.
+    - ALL
 nodeSelector: {}
 tolerations: []
 affinity: {}
-
 secret:
-  # Use a pre-created Secret (created out-of-band) instead of the generated
-  # one. Expected keys: SECRET_KEY, DB_PASSWORD, AWS_ACCESS_KEY_ID,
-  # AWS_SECRET_ACCESS_KEY, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD,
-  # CF_TURNSTILE_SECRET_KEY, GITHUB_CLIENT_SECRET (if django.github set),
-  # plus every key in secret.extraEnv.
-  existingSecret: ""
-  # Extra secret-backed environment variables. When existingSecret is unset
-  # these are added to the generated Secret; when existingSecret is set they
-  # must be present as keys in that Secret. Keys must be valid env var names.
+  existingSecret: ''
   extraEnv: {}
-
 django:
   projectName: date
-  secretKey: ""
+  secretKey: ''
   debug: false
   develop: false
   enableLanguageFeatures: false
   allowedHosts:
-    - datateknologerna.org
+  - datateknologerna.org
   allowedOrigins:
-    - https://datateknologerna.org
+  - https://datateknologerna.org
   useXForwardedHost: true
   trustXForwardedProto: true
   extraStaffGroups: []
-  alumniSettings: "{}"
-  alumniSettingsSecretName: ""
+  alumniSettings: '{}'
+  alumniSettingsSecretName: ''
   turnstile:
-    siteKey: ""
-    secretKey: ""
+    siteKey: ''
+    secretKey: ''
   github:
-    # GitHub OAuth (used by the member login). clientSecret goes into the
-    # Secret (GITHUB_CLIENT_SECRET key); clientId and mfaPolicy into the
-    # ConfigMap.
-    clientId: ""
-    clientSecret: ""
-    mfaPolicy: "enrolled"
-
+    clientId: ''
+    clientSecret: ''
+    mfaPolicy: enrolled
 database:
   name: postgres
   username: postgres
-  password: ""
+  password: ''
   external:
-    host: ""
+    host: ''
     port: 5432
-
 postgresql:
   enabled: true
   nodeSelector: {}
@@ -78,21 +59,18 @@ postgresql:
   affinity: {}
   image:
     repository: postgres
-    tag: "16-alpine"
+    tag: 16-alpine
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
-    storageClass: ""
+    storageClass: ''
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     size: 8Gi
   resources: {}
-
 backups:
   enabled: false
-  schedule: "17 2 * * *"
-  # Only prunes the local /backups directory. Configure B2/object-storage
-  # lifecycle rules separately for remote backup retention.
+  schedule: 17 2 * * *
   retentionDays: 14
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
@@ -104,85 +82,77 @@ backups:
   affinity: {}
   image:
     repository: postgres
-    tag: "16-alpine"
+    tag: 16-alpine
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
-    storageClass: ""
+    storageClass: ''
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     size: 8Gi
   objectStorage:
     enabled: false
-    endpointUrl: ""
-    regionName: ""
-    bucketName: ""
-    prefix: "date-website/postgresql"
-    accessKeyId: ""
-    secretAccessKey: ""
-    # Requires backups.securityContext.runAsUser=0 when using an Alpine image,
-    # because apk add --no-cache aws-cli needs package-install privileges.
+    endpointUrl: ''
+    regionName: ''
+    bucketName: ''
+    prefix: date-website/postgresql
+    accessKeyId: ''
+    secretAccessKey: ''
     installAwsCli: false
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-        - ALL
+      - ALL
     runAsUser: 999
     runAsGroup: 999
   podSecurityContext:
     fsGroup: 999
   resources: {}
-
 redis:
   enabled: true
-  externalUrl: ""
+  externalUrl: ''
   nodeSelector: {}
   tolerations: []
   affinity: {}
   image:
     repository: valkey/valkey
-    tag: "7.2-alpine"
+    tag: 7.2-alpine
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
-    storageClass: ""
+    storageClass: ''
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     size: 1Gi
   resources: {}
-
 media:
   s3:
     enabled: false
-    endpointUrl: ""
-    regionName: ""
-    signatureVersion: "s3v4"
-    addressingStyle: "path"
-    accessKeyId: ""
-    secretAccessKey: ""
-    bucketName: ""
-    privateBucketName: ""
-    publicBucketName: ""
-    privateLocation: "date/media"
-    publicLocation: "date/public"
+    endpointUrl: ''
+    regionName: ''
+    signatureVersion: s3v4
+    addressingStyle: path
+    accessKeyId: ''
+    secretAccessKey: ''
+    bucketName: ''
+    privateBucketName: ''
+    publicBucketName: ''
+    privateLocation: date/media
+    publicLocation: date/public
   persistence:
     enabled: true
-    storageClass: ""
+    storageClass: ''
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     size: 5Gi
-
 email:
   hostReceiver: info@datateknologerna.org
   defaultFrom: admin@datateknologerna.org
   host: smtp.gmail.com
-  username: ""
-  password: ""
-
+  username: ''
+  password: ''
 web:
-  # Do not increase without disabling migrateOnStartup and using a migration Job
-  # or another single-run migration step.
   replicaCount: 1
   service:
     type: ClusterIP
@@ -194,7 +164,11 @@ web:
   migrateOnStartup: false
   collectstaticOnStartup: true
   resources: {}
-
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
 asgi:
   replicaCount: 1
   service:
@@ -202,21 +176,26 @@ asgi:
     port: 8000
   wsPath: /ws
   resources: {}
-
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
 celery:
   replicaCount: 1
   concurrency: 2
   logLevel: info
   livenessProbe:
-    # `celery inspect ping` imports the whole Django app on every invocation
-    # (~3s of user CPU measured on prod). 60s -> 300s keeps the probe cheap
-    # while still restarting a dead worker within ~15 min (3 x 300s).
     initialDelaySeconds: 60
     periodSeconds: 300
     timeoutSeconds: 10
     failureThreshold: 3
   resources: {}
-
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
 migrations:
   job:
     enabled: false
@@ -224,22 +203,20 @@ migrations:
     hookDeletePolicy: before-hook-creation,hook-succeeded
     backoffLimit: 3
     resources: {}
-
 ingress:
   enabled: true
   className: traefik
   annotations: {}
   hosts:
-    - host: datateknologerna.org
-      paths:
-        - path: /
-          pathType: Prefix
+  - host: datateknologerna.org
+    paths:
+    - path: /
+      pathType: Prefix
   tls: []
-
 gateway:
   enabled: false
   className: traefik
-  name: ""
+  name: ''
   annotations: {}
   http:
     enabled: true
@@ -247,8 +224,7 @@ gateway:
   https:
     enabled: false
     port: 443
-    secretName: ""
+    secretName: ''
   route:
     annotations: {}
-
 extraEnv: {}


### PR DESCRIPTION
## Problem

The 0.3.3 rollout made the uptime monitor alarm. Investigation (cluster events) showed each site had a **real outage window** during its rollout:

- **Old pod killed while new pod not Ready**: default strategy `maxUnavailable: 25%` rounds **up** to 1 with a single replica — the Deployment scaled the old pod down while the new one was still running `migrateOnStartup` (takes >1min under DB load), leaving **zero Ready pods** and the ingress returning errors.
- **Liveness killed healthy-migrating pods**: no `startupProbe`, so liveness fired at `initialDelaySeconds: 30` with the k8s default `timeoutSeconds: 1` — a pod mid-migration that doesn't answer in 1s gets killed (observed: "Container web failed liveness probe" while migrations were running).
- **`timeoutSeconds: 1`** everywhere is brutal when the DB is busy (3 sites rolling + migrating concurrently).

## Fix (chart 0.3.4)

1. **`strategy.maxUnavailable: 0`, `maxSurge: 1`** on web/asgi/celery — the old pod is never removed until the new one is Ready. Zero downtime by construction.
2. **`startupProbe`** on web/asgi (healthz, 30 x 2s = 60s+ grace) and celery (ping, 30 x 2s) — liveness is gated until the app has started, so slow migrations no longer trigger liveness kills.
3. **`timeoutSeconds: 5`** (celery 10) on liveness/readiness — the 1s default is too tight under load.
4. `values.schema.json`: allow the `strategy` key per component.

## Verify

- `helm template` renders startupProbe (web/asgi/celery) + `maxUnavailable: 0` on all three deployments
- Schema accepts `web.strategy`

## Notes

- The right long-term answer is a separate migration Job (disable `migrateOnStartup`, run migrations once before rollout) — tracked separately; startupProbe makes the current pattern safe meanwhile.
- Chart version 0.3.4 (0.3.3 was already merged for the replicaCount schema change).