### PR TITLE
chart: 0.3.5 robust startupProbes

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-celery.yaml
+++ b/charts/date-website/templates/deployment-celery.yaml
@@ -89,7 +89,7 @@ spec:
                 - celery -A core inspect ping -d "celery@${HOSTNAME}" | grep -q OK
             failureThreshold: 30
             periodSeconds: 2
-            timeoutSeconds: 10
+            timeoutSeconds: 30
           # Liveness via `celery inspect ping`: a real worker-response check,
           # but each invocation imports the whole Django app (~3s user CPU on
           # prod). Keep the cadence coarse (default 300s) — see values.yaml.

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -95,8 +95,10 @@ spec:
               containerPort: 8000
               protocol: TCP
           # startupProbe gates liveness during slow starts (migrateOnStartup
-          # can take >1min under load). Without it, liveness kills the pod at
-          # initialDelay + 3*failure — the zero-downtime killer on rollouts.
+          # cold boot: wait-for-postgres + migrate + collectstatic can exceed
+          # 2 min under the web CPU limit; a 30x2s budget is too tight because
+          # refused probes fail instantly -> ~60s floor, see audit.md
+          # 2026-08-07 incident). 90x2s = ~180s floor.
           startupProbe:
             httpGet:
               path: /healthz/
@@ -104,7 +106,7 @@ spec:
               httpHeaders:
                 - name: Host
                   value: {{ include "date-website.probeHost" . | quote }}
-            failureThreshold: 30
+            failureThreshold: 90
             periodSeconds: 2
             timeoutSeconds: 5
           livenessProbe:

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -97,8 +97,8 @@ spec:
           # startupProbe gates liveness during slow starts (migrateOnStartup
           # cold boot: wait-for-postgres + migrate + collectstatic can exceed
           # 2 min under the web CPU limit; a 30x2s budget is too tight because
-          # refused probes fail instantly -> ~60s floor, see audit.md
-          # 2026-08-07 incident). 90x2s = ~180s floor.
+          # refused probes fail instantly -> ~60s floor). 90x2s = ~180s floor,
+          # measured after the 2026-08-07 worker-reboot incident.
           startupProbe:
             httpGet:
               path: /healthz/

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -188,7 +188,7 @@ celery:
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 300
-    timeoutSeconds: 10
+    timeoutSeconds: 30
     failureThreshold: 3
   resources: {}
   strategy:


### PR DESCRIPTION
Fixes the 2026-08-07 crash-loop that hit date + pulterit after a worker reboot (boot storm: all pods restart at once).

## What happened

date + pulterit run `web.migrateOnStartup: true`; a cold boot (wait-for-postgres + migrate + collectstatic) takes ~90-130s under the web container's 500m CPU limit. The web startupProbe in chart 0.3.4 had a ~40s budget (failureThreshold 3 x period 10s), so kubelet killed the pod before gunicorn came up, in an endless restart loop. Other sites do not run migrate at boot, so only those two were affected.

## Changes

- **web startupProbe: failureThreshold 30 -> 90 (period 2s)**. A 30x2s budget is still too tight: probes that fail with instant connection-refused (nothing listening yet) burn 2s each, giving only a ~60s floor. 90x2s = ~180s floor, proven adequate during the incident hotfix.
- **celery startup/liveness probe timeout 10s -> 30s**: `celery inspect ping` round-trip measured >25s after a node reboot (worker pidbox/reply latency); the 10s timeout crash-looped kk's celery even though the worker was ready and redis was healthy.

## Expected effect

Any node reboot (or resize, which requires a power cycle) restarts all pods; this change makes web/celery cold starts survive the probe budget instead of crash-looping.

Companion rollout PR in the infra repo (chart-0.3.5-rollout). Merge order: this PR first (helm_chart.yaml CI publishes 0.3.5 to GHCR on main), then the infra PR.