### PR TITLE
fix: event signup row lock fails on Postgres, overlong test usernames

### DIFF
--- a/events/registration.py
+++ b/events/registration.py
@@ -49,7 +49,7 @@ def register_event_signup(event, cleaned_data):
     questions = get_registration_questions(event)
 
     with transaction.atomic():
-        event = event.__class__.objects.select_for_update().select_related('parent').get(pk=event.pk)
+        event = event.__class__.objects.select_for_update(of=('self',)).select_related('parent').get(pk=event.pk)
         _ensure_capacity(event, required_places)
         attendee = _create_attendee(
             event=event,

--- a/exambank/tests.py
+++ b/exambank/tests.py
@@ -278,9 +278,9 @@ class ExamArchiveAdminTests(TestCase):
     def test_access_settings_redirect_requires_settings_permission(self):
         staff_group = Group.objects.create(name='admin')
         staff_user = get_user_model().objects.create_user(
-            username='exam-staff-without-settings',
+            username='exam-staff-no-set',
             password='pwd',
-            email='exam-staff-without-settings@example.com',
+            email='exam-staff-no-set@example.com',
         )
         staff_user.groups.add(staff_group)
         self.client.force_login(staff_user)

--- a/publications/tests.py
+++ b/publications/tests.py
@@ -99,9 +99,9 @@ class PDFFileAdminTests(TestCase):
     def test_collection_access_endpoint_requires_publication_permission(self):
         staff_group = Group.objects.create(name="admin")
         staff_user = get_user_model().objects.create_user(
-            username="staff-without-publications",
+            username="staff-no-pubs",
             password="pwd",
-            email="staff-without-publications@example.com",
+            email="staff-no-pubs@example.com",
         )
         staff_user.groups.add(staff_group)
         self.client.force_login(staff_user)


### PR DESCRIPTION
## Problem

Event signups crash on PostgreSQL: `select_for_update().select_related('parent')` on the nullable self-referential `Event.parent` FK raises `FOR UPDATE cannot be applied to the nullable side of an outer join`, so every signup returns 500 in production. SQLite ignores `select_for_update`, so the CI test suite never caught it.

Two admin permission tests also created users with usernames longer than the 20-character `Member.username` limit. SQLite does not enforce varchar length; PostgreSQL does, raising `DataError`.

## Fix

- `events/registration.py`: lock only the event row with `select_for_update(of=('self',))`. The child-event capacity calculation uses `original_event`, so locking the child row still serializes concurrent signups.
- `publications/tests.py` + `exambank/tests.py`: shorten test usernames to fit `max_length=20`.

## Verification

- `events.tests`, `publications.tests`, `exambank.tests` pass against PostgreSQL (44 tests) - previously 26 errors.
- Full CI suite (`core.settings.test`, sqlite) passes.
- `manage.py check` clean, no migration needed.