### PR TITLE
sf: disable alumni module

### DIFF
--- a/core/settings/sf.py
+++ b/core/settings/sf.py
@@ -32,7 +32,6 @@ INSTALLED_APPS = get_installed_apps(
         'social',
         'staticpages',
         'publications',
-        'alumni',
         'billing',
         'klotterplanket',
     ]

--- a/core/urls/sf.py
+++ b/core/urls/sf.py
@@ -24,7 +24,6 @@ urlpatterns = build_urlpatterns(
     path('admin/', admin_site.urls),
     path("ckeditor5/", include('django_ckeditor_5.urls')),
     path('publications/', include('publications.urls')),
-    path('alumni/', include('alumni.urls')),
     path('klotterplanket/', include('klotterplanket.urls')),
 )
 


### PR DESCRIPTION
Removes the alumni app from the sf project (settings INSTALLED_APPS + URL include). The sf site was never wired with ALUMNI_SETTINGS and does not use the alumni/GSuite sync; /alumni/signup + /alumni/update currently render unconfigured forms. Rebuild triggers on merge to main (prod image tag); the cluster auto-update bot will pin and roll sf.