### PR TITLE
fix: gallery multi-upload in Django admin

### DIFF
--- a/docs/dev/gallery.md
+++ b/docs/dev/gallery.md
@@ -7,6 +7,7 @@ The `gallery` app owns photo albums and uploaded photos. It replaced the previou
 - `Album` stores the album title, publication date, and `hide_for_gulis` access flag.
 - `Photo` stores image files and compresses newly uploaded images to 1600px-wide JPEGs in `Photo.save()`.
 - Upload paths stay compatible with the previous archive layout: `<year>/<album>/<filename>`.
+- `AlbumAdminForm` creates multi-uploaded photos in its `save_m2m()` callback so new albums are inserted before their photos reference them.
 
 ## Migration Notes
 - `archive.0008_remove_picture_collection_delete_examcollection_and_more` copies legacy `archive.Collection(type="Pictures")` rows into `gallery_album` and related `archive.Picture` rows into `gallery_photo`.

--- a/gallery/forms.py
+++ b/gallery/forms.py
@@ -31,9 +31,8 @@ class AlbumAdminForm(forms.ModelForm):
         model = Album
         fields = '__all__'  # noqa: DJ007
 
-    def save(self, *args, **kwargs):
-        album = super().save(*args, **kwargs)
+    def _save_m2m(self):
+        super()._save_m2m()
         if hasattr(self.files, 'getlist'):
             for uploaded_file in self.files.getlist('images'):
-                Photo.objects.create(album=album, image=uploaded_file)
-        return album
+                Photo.objects.create(album=self.instance, image=uploaded_file)

--- a/gallery/tests.py
+++ b/gallery/tests.py
@@ -1,0 +1,51 @@
+import shutil
+import tempfile
+from io import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.utils.datastructures import MultiValueDict
+from PIL import Image
+
+from .forms import AlbumAdminForm
+from .models import Photo
+
+
+class AlbumAdminFormTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._media_root = tempfile.mkdtemp()
+        cls._media_override = override_settings(MEDIA_ROOT=cls._media_root)
+        cls._media_override.enable()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._media_override.disable()
+        shutil.rmtree(cls._media_root, ignore_errors=True)
+        super().tearDownClass()
+
+    def test_creates_multi_uploads_after_saving_new_album(self):
+        form = AlbumAdminForm(
+            data={'title': 'Admin album', 'pub_date': '2026-08-23 14:00:00'},
+            files=MultiValueDict({'images': [self._uploaded_image('admin-upload.jpg')]}),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        album = form.save(commit=False)
+        self.assertIsNone(album.pk)
+        self.assertEqual(Photo.objects.count(), 0)
+
+        album.save()
+        form.save_m2m()
+
+        photo = Photo.objects.get()
+        self.assertEqual(photo.album, album)
+        self.assertTrue(photo.image.name.endswith('admin-upload.jpg'))
+
+    def _uploaded_image(self, name):
+        image = Image.new('RGB', (100, 100), color=(25, 90, 140))
+        image_bytes = BytesIO()
+        image.save(image_bytes, format='JPEG')
+        image.close()
+        return SimpleUploadedFile(name=name, content=image_bytes.getvalue(), content_type='image/jpeg')


### PR DESCRIPTION
Summary: fixes the Django Admin 500 when creating a gallery album with the multi-upload field. Photo rows are now created from the ModelForm save_m2m() callback, after Django has saved the new album.

Validation:
- uv run python manage.py test gallery
- uv run ruff check gallery/forms.py gallery/tests.py
- uv run ruff format --check gallery/forms.py gallery/tests.py
- uv run python manage.py check