### PR TITLE
Fix release tag selection after duplicate tags

### DIFF
--- a/.github/workflows/release_tag.yaml
+++ b/.github/workflows/release_tag.yaml
@@ -48,8 +48,9 @@ jobs:
             exit 0
           fi
 
-          # Follow main's own history instead of picking the highest tag anywhere in the repo.
-          LAST_TAG="$(git describe --tags --abbrev=0 --first-parent --match 'v[0-9]*.[0-9]*.[0-9]*' main 2>/dev/null || true)"
+          # Use the highest release tag reachable from main. git describe can select an
+          # older tag when multiple release tags point to the same commit.
+          LAST_TAG="$(git tag --merged main --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1 || true)"
           if [ -z "${LAST_TAG}" ]; then
             LAST_TAG="none"
           fi


### PR DESCRIPTION
Summary: select the highest SemVer release tag reachable from main before calculating the next version. This prevents git describe from selecting an older tag when multiple release tags point to the same commit.

Validation: the release-tag selection command resolves v1.8.3 for current main; git diff --check passed.