### PR TITLE
fix: improve admin upload controls

### DIFF
--- a/.github/workflows/web_startup.yaml
+++ b/.github/workflows/web_startup.yaml
@@ -120,6 +120,12 @@ jobs:
           docker-compose run --rm --no-deps web python manage.py compilemessages
           docker-compose run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test'
 
+      - name: Run tests with Unfold enabled
+        run: |
+          set -euo pipefail
+          export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
+          docker-compose run -e TEST=1 -e USE_UNFOLD=True web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test'
+
       - name: Build and run Docker Compose
         run: |
           set -euo pipefail

--- a/archive/admin.py
+++ b/archive/admin.py
@@ -13,6 +13,7 @@ from core.admin_widgets import (
     FLATPICKR_ADMIN_JS,
     FlatpickrDateTimeAdminMixin,
     SafeAdminFileWidget,
+    SafeAdminImageWidget,
 )
 
 from .forms import DocumentAdminForm, PublicAdminForm
@@ -44,7 +45,7 @@ class SafeFileInlineMixin:
     formfield_overrides = {
         **UNFOLD_FORMFIELD_OVERRIDES,
         models.FileField: {'widget': SafeAdminFileWidget},
-        models.ImageField: {'widget': SafeAdminFileWidget},
+        models.ImageField: {'widget': SafeAdminImageWidget},
     }
 
 

--- a/archive/forms.py
+++ b/archive/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from core.admin_widgets import SafeAdminMultipleFileWidget
+
 from .models import Collection, Document, PublicFile
 
 
@@ -22,7 +24,11 @@ class MultipleFileField(forms.FileField):
 
 
 class DocumentAdminForm(forms.ModelForm):
-    files = MultipleFileField(label="Ladda upp flera dokument", required=False)  # type: ignore[assignment]
+    files = MultipleFileField(
+        label="Ladda upp flera dokument",
+        required=False,
+        widget=SafeAdminMultipleFileWidget(),
+    )  # type: ignore[assignment]
 
     class Meta:
         model = Collection
@@ -39,7 +45,11 @@ class DocumentAdminForm(forms.ModelForm):
 
 
 class PublicAdminForm(forms.ModelForm):
-    files = MultipleFileField(label="Ladda upp flera filer", required=False)  # type: ignore[assignment]
+    files = MultipleFileField(
+        label="Ladda upp flera filer",
+        required=False,
+        widget=SafeAdminMultipleFileWidget(),
+    )  # type: ignore[assignment]
 
     class Meta:
         model = Collection

--- a/billing/admin.py
+++ b/billing/admin.py
@@ -94,7 +94,7 @@ class EventBillingConfigurationAdmin(ExtraChangeListLinksMixin, ModelAdmin):
     @admin.display(description="Exportera data")
     def ref_export(self, obj):
         return format_html(
-            '<a class="button" href="{}">Exportera data</a>&nbsp;',
+            '<a class="button admin-inline-action" href="{}">Exportera data</a>&nbsp;',
             reverse('admin:billing_ref_numbers', args=[obj.pk]),
         )
 

--- a/core/admin_base.py
+++ b/core/admin_base.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.utils import flatten_fieldsets
@@ -24,6 +25,7 @@ if getattr(settings, 'USE_UNFOLD', False):
     from unfold.widgets import (
         UnfoldAdminEmailInputWidget,
         UnfoldAdminIntegerFieldWidget,
+        UnfoldAdminPasswordToggleWidget,
         UnfoldAdminTextInputWidget,
         UnfoldAdminURLInputWidget,
     )
@@ -37,6 +39,7 @@ if getattr(settings, 'USE_UNFOLD', False):
         'URLInput': UnfoldAdminURLInputWidget,
         'EmailInput': UnfoldAdminEmailInputWidget,
         'NumberInput': UnfoldAdminIntegerFieldWidget,
+        'PasswordInput': UnfoldAdminPasswordToggleWidget,
     }
 else:
     ModelAdmin = admin.ModelAdmin
@@ -58,7 +61,13 @@ class UnfoldFormMixin:
         for field in self.fields.values():
             replacement = _WIDGET_MAP.get(type(field.widget).__name__)
             if replacement is not None:
-                field.widget = replacement()
+                if isinstance(field.widget, forms.PasswordInput):
+                    field.widget = replacement(
+                        attrs=field.widget.attrs,
+                        render_value=field.widget.render_value,
+                    )
+                else:
+                    field.widget = replacement()
 
 
 class PublicUrlAdminMixin:

--- a/core/admin_widgets.py
+++ b/core/admin_widgets.py
@@ -33,11 +33,11 @@ class _SafeAdminFileWidgetMixin:
             return False
 
 
-class SafeAdminFileWidget(_SafeAdminFileWidgetMixin, _SafeAdminFileWidgetBase):
+class SafeAdminFileWidget(_SafeAdminFileWidgetMixin, _SafeAdminFileWidgetBase):  # type: ignore[misc, valid-type]
     pass
 
 
-class SafeAdminImageWidget(_SafeAdminFileWidgetMixin, _SafeAdminImageWidgetBase):
+class SafeAdminImageWidget(_SafeAdminFileWidgetMixin, _SafeAdminImageWidgetBase):  # type: ignore[misc, valid-type]
     """Keep image fields on Unfold's image-specific upload widget."""
 
     pass

--- a/core/admin_widgets.py
+++ b/core/admin_widgets.py
@@ -1,6 +1,7 @@
 import logging
 
 from django import forms
+from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.utils import timezone
 from django.utils.html import format_html
@@ -9,7 +10,17 @@ from django.utils.translation import gettext_lazy as _
 logger = logging.getLogger("date")
 
 
-class SafeAdminFileWidget(admin_widgets.AdminFileWidget):
+if getattr(settings, "USE_UNFOLD", False):
+    from unfold.widgets import UnfoldAdminFileFieldWidget, UnfoldAdminImageFieldWidget
+
+    _SafeAdminFileWidgetBase = UnfoldAdminFileFieldWidget
+    _SafeAdminImageWidgetBase = UnfoldAdminImageFieldWidget
+else:
+    _SafeAdminFileWidgetBase = admin_widgets.AdminFileWidget
+    _SafeAdminImageWidgetBase = admin_widgets.AdminFileWidget
+
+
+class _SafeAdminFileWidgetMixin:
     """Avoid crashing admin forms when a stored file cannot resolve a URL."""
 
     def is_initial(self, value):
@@ -20,6 +31,22 @@ class SafeAdminFileWidget(admin_widgets.AdminFileWidget):
         except Exception as exc:
             logger.warning("Unable to resolve admin file widget URL: %s", exc)
             return False
+
+
+class SafeAdminFileWidget(_SafeAdminFileWidgetMixin, _SafeAdminFileWidgetBase):
+    pass
+
+
+class SafeAdminImageWidget(_SafeAdminFileWidgetMixin, _SafeAdminImageWidgetBase):
+    """Keep image fields on Unfold's image-specific upload widget."""
+
+    pass
+
+
+class SafeAdminMultipleFileWidget(SafeAdminFileWidget):
+    """Safe file widget that keeps the multi-file upload affordance visible."""
+
+    allow_multiple_selected = True
 
 
 # Flatpickr-based datetime input shared across admin forms (events, news, polls, ctf, lucia).

--- a/core/tests/test_admin_ui.py
+++ b/core/tests/test_admin_ui.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.conf import settings
 from django.contrib import admin as django_admin
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase, override_settings
@@ -12,6 +13,7 @@ from core.admin_ui import (
     get_sidebar_navigation,
     get_topbar_quick_create_links,
 )
+from core.admin_widgets import SafeAdminFileWidget, SafeAdminImageWidget, SafeAdminMultipleFileWidget
 from core.settings.common import _get_unfold_environment
 
 
@@ -175,7 +177,48 @@ class UnfoldFormMixinTests(TestCase):
 
         class _SampleForm(UnfoldFormMixin, forms.Form):
             name = forms.CharField()
+            password = forms.CharField(widget=forms.PasswordInput)
             url = forms.URLField()
 
-        form = _SampleForm(data={'name': 'test', 'url': 'https://example.com'})
+        form = _SampleForm(data={'name': 'test', 'password': 'secret', 'url': 'https://example.com'})
         self.assertTrue(form.is_valid())
+        if settings.USE_UNFOLD:
+            self.assertIn('Toggle password visibility', form['password'].as_widget())
+
+
+class AdminFileWidgetTests(TestCase):
+    def test_file_widget_renders_an_upload_control(self):
+        rendered = SafeAdminFileWidget().render('file', None, {'id': 'id_file'})
+
+        self.assertIn('type="file"', rendered)
+        if settings.USE_UNFOLD:
+            self.assertIn('file_upload', rendered)
+
+    def test_multiple_file_widget_preserves_multiple_selection(self):
+        rendered = SafeAdminMultipleFileWidget().render('files', None, {'id': 'id_files'})
+
+        self.assertIn('type="file"', rendered)
+        self.assertIn('multiple', rendered)
+
+    def test_image_widget_keeps_unfold_image_template(self):
+        rendered = SafeAdminImageWidget().render('image', None, {'id': 'id_image'})
+
+        self.assertIn('type="file"', rendered)
+        if settings.USE_UNFOLD:
+            self.assertIn('>upload<', rendered)
+
+    def test_public_multi_upload_forms_do_not_use_admin_markup(self):
+        from exambank.forms import ExamArchiveAdminForm, ExamUploadForm
+        from gallery.forms import AlbumAdminForm, AlbumUploadForm
+
+        public_widgets = (AlbumUploadForm()['images'].as_widget(), ExamUploadForm()['exam'].as_widget())
+        admin_widgets = (
+            AlbumAdminForm()['images'].as_widget(),
+            ExamArchiveAdminForm()['files'].as_widget(),
+        )
+
+        for widget in public_widgets:
+            self.assertNotIn('file_upload', widget)
+        if settings.USE_UNFOLD:
+            for widget in admin_widgets:
+                self.assertIn('file_upload', widget)

--- a/core/tests/test_admin_ux.py
+++ b/core/tests/test_admin_ux.py
@@ -54,6 +54,19 @@ class AdminUxLinkTests(TestCase):
         self.assertContains(response, reverse("admin:billing_eventinvoice_changelist"))
         self.assertContains(response, "All invoices")
         self.assertContains(response, "1 invoice")
+        self.assertContains(response, "admin-inline-action")
+
+    def test_event_changelist_action_uses_shared_admin_style(self):
+        Event.objects.create(
+            title="Registration Event",
+            slug="registration-event",
+            author=self.admin_user,
+        )
+
+        response = self.client.get(reverse("admin:events_event_changelist"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "admin-inline-action")
 
     def test_functionary_role_page_includes_assignments_inline(self):
         role = FunctionaryRole.objects.create(title="Treasurer", board=True)

--- a/date/static/date/css/admin.css
+++ b/date/static/date/css/admin.css
@@ -126,3 +126,97 @@
     background-color: rgba(255, 255, 255, 0.06) !important;
     border-color: rgba(255, 255, 255, 0.18) !important;
 }
+
+/* Keep native file inputs actionable if a form does not use Unfold's widget. */
+#main input[type=file] {
+    box-sizing: border-box;
+    max-width: 100%;
+    min-height: 2.375rem;
+    padding: 0.25rem;
+    border: 1px solid rgb(var(--color-base-300));
+    border-radius: var(--border-radius, 0.375rem);
+    background: rgb(var(--color-base-50));
+    color: rgb(var(--color-font-default-light, 15 23 42));
+    font: inherit;
+}
+
+#main input[type=file]::file-selector-button {
+    margin-right: 0.75rem;
+    padding: 0.45rem 0.75rem;
+    border: 0;
+    border-radius: calc(var(--border-radius, 0.375rem) - 1px);
+    background: rgb(var(--color-primary-600));
+    color: #fff;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    transition: background-color 0.15s;
+}
+
+#main input[type=file]::file-selector-button:hover {
+    background: rgb(var(--color-primary-700));
+}
+
+#main input[type=file]:focus-visible {
+    outline: 2px solid rgb(var(--color-primary-500));
+    outline-offset: 2px;
+}
+
+.dark #main input[type=file] {
+    border-color: rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.06);
+    color: rgb(var(--color-font-default-dark, 226 232 240));
+}
+
+.dark #main input[type=file]::file-selector-button {
+    background: rgb(var(--color-primary-500));
+}
+
+.dark #main input[type=file]::file-selector-button:hover {
+    background: rgb(var(--color-primary-400));
+}
+
+/* Give custom row and summary links the same affordance as admin buttons. */
+.admin-inline-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 2rem;
+    padding: 0.375rem 0.625rem;
+    border: 1px solid rgb(var(--color-base-200));
+    border-radius: var(--border-radius, 0.375rem);
+    background: #fff;
+    color: rgb(var(--color-font-default-light, 15 23 42));
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25;
+    text-decoration: none;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    transition: border-color 0.15s, background-color 0.15s, color 0.15s;
+}
+
+.admin-inline-action:hover,
+.admin-inline-action:focus-visible {
+    border-color: rgb(var(--color-primary-400));
+    background: rgb(var(--color-base-100));
+    color: rgb(var(--color-primary-700));
+    outline: none;
+}
+
+.admin-inline-action:focus-visible {
+    outline: 2px solid rgb(var(--color-primary-500));
+    outline-offset: 2px;
+}
+
+.dark .admin-inline-action {
+    border-color: rgb(var(--color-base-700));
+    background: transparent;
+    color: rgb(var(--color-font-default-dark, 226 232 240));
+}
+
+.dark .admin-inline-action:hover,
+.dark .admin-inline-action:focus-visible {
+    border-color: rgb(var(--color-primary-500));
+    background: rgb(var(--color-base-800));
+    color: rgb(var(--color-primary-300));
+}

--- a/events/admin.py
+++ b/events/admin.py
@@ -239,7 +239,8 @@ class EventAdmin(PublicUrlAdminMixin, TranslationCompletionAdminMixin, EventTran
     @admin.display(description="Deltagarlista")
     def account_actions(self, obj):
         return format_html(
-            '<a class="button" href="{}">Deltagarlista</a>&nbsp;', reverse('admin:registration_list', args=[obj.pk])
+            '<a class="button admin-inline-action" href="{}">Deltagarlista</a>&nbsp;',
+            reverse('admin:registration_list', args=[obj.pk]),
         )
 
     @admin.action(description="Delete all attendees for selected events")

--- a/events/forms.py
+++ b/events/forms.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from core.admin_base import UnfoldFormMixin
 from core.admin_widgets import (
     FLATPICKR_DATETIME_INPUT_FORMATS,
-    SafeAdminFileWidget,
+    SafeAdminImageWidget,
     flatpickr_datetime_field,
     flatpickr_datetime_widget,
 )
@@ -83,7 +83,7 @@ class EventCreationForm(UnfoldFormMixin, forms.ModelForm):
             self.fields['published_time'].help_text = _("Leave blank to keep the event hidden.")
         for field_name in ('image', 's3_image'):
             if field_name in self.fields:
-                self.fields[field_name].widget = SafeAdminFileWidget()
+                self.fields[field_name].widget = SafeAdminImageWidget()
         if 'require_registration_terms' in self.fields:
             if models.registration_terms_feature_enabled():
                 self.fields['require_registration_terms'].initial = True
@@ -175,7 +175,7 @@ class EventEditForm(UnfoldFormMixin, forms.ModelForm):
             self.fields['published_time'].help_text = _("Leave blank to keep the event hidden.")
         for field_name in ('image', 's3_image'):
             if field_name in self.fields:
-                self.fields[field_name].widget = SafeAdminFileWidget()
+                self.fields[field_name].widget = SafeAdminImageWidget()
         if 'require_registration_terms' in self.fields and not models.registration_terms_feature_enabled():
             self.fields.pop('require_registration_terms')
         if 'template' in self.fields:

--- a/exambank/forms.py
+++ b/exambank/forms.py
@@ -1,6 +1,9 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from core.admin_base import UnfoldFormMixin
+from core.admin_widgets import SafeAdminMultipleFileWidget
+
 from .models import ExamArchive, ExamBankAccessSettings, ExamFile
 
 
@@ -30,7 +33,11 @@ class ExamArchiveUploadForm(forms.Form):
 
 
 class ExamArchiveAdminForm(forms.ModelForm):
-    files = MultipleFileField(label="Ladda upp flera dokument", required=False)  # type: ignore[assignment]
+    files = MultipleFileField(
+        label="Ladda upp flera dokument",
+        required=False,
+        widget=SafeAdminMultipleFileWidget(),
+    )  # type: ignore[assignment]
 
     class Meta:
         model = ExamArchive
@@ -44,7 +51,7 @@ class ExamArchiveAdminForm(forms.ModelForm):
         return archive
 
 
-class ExamBankAccessSettingsAdminForm(forms.ModelForm):
+class ExamBankAccessSettingsAdminForm(UnfoldFormMixin, forms.ModelForm):
     PASSWORD_PLACEHOLDER = '********'  # noqa: S105
 
     password = forms.CharField(

--- a/gallery/admin.py
+++ b/gallery/admin.py
@@ -11,7 +11,7 @@ from core.admin_widgets import (
     FLATPICKR_ADMIN_CSS,
     FLATPICKR_ADMIN_JS,
     FlatpickrDateTimeAdminMixin,
-    SafeAdminFileWidget,
+    SafeAdminImageWidget,
 )
 
 from .forms import AlbumAdminForm
@@ -42,7 +42,7 @@ class PhotoInline(TabularInline):
     extra = 0
     formfield_overrides = {
         **UNFOLD_FORMFIELD_OVERRIDES,
-        models.ImageField: {'widget': SafeAdminFileWidget},
+        models.ImageField: {'widget': SafeAdminImageWidget},
     }
 
     def preview_image(self, obj):

--- a/gallery/forms.py
+++ b/gallery/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from core.admin_widgets import SafeAdminMultipleFileWidget
+
 from .models import Album, Photo
 
 
@@ -25,7 +27,7 @@ class AlbumUploadForm(forms.Form):
 
 
 class AlbumAdminForm(forms.ModelForm):
-    images = MultipleFileField(label="Ladda upp flera bilder", required=False)
+    images = MultipleFileField(label="Ladda upp flera bilder", required=False, widget=SafeAdminMultipleFileWidget())
 
     class Meta:
         model = Album

--- a/publications/admin.py
+++ b/publications/admin.py
@@ -19,16 +19,17 @@ from core.admin_base import (
     ModelAdmin,
     PublicUrlAdminMixin,
     TabularInline,
+    UnfoldFormMixin,
 )
 from core.admin_ui import AdminLink
-from core.admin_widgets import SafeAdminFileWidget
+from core.admin_widgets import SafeAdminFileWidget, SafeAdminImageWidget
 
 from .models import PDFFile, PublicationCollection
 
 logger = logging.getLogger('date')
 
 
-class PublicationCollectionAdminForm(forms.ModelForm):
+class PublicationCollectionAdminForm(UnfoldFormMixin, forms.ModelForm):
     password = forms.CharField(
         label='Password',
         required=False,
@@ -226,7 +227,7 @@ class PublicationInline(TabularInline):
     formfield_overrides = {
         **UNFOLD_FORMFIELD_OVERRIDES,
         models.FileField: {'widget': SafeAdminFileWidget},
-        models.ImageField: {'widget': SafeAdminFileWidget},
+        models.ImageField: {'widget': SafeAdminImageWidget},
     }
 
     def get_formset(self, request, obj=None, **kwargs):
@@ -409,7 +410,7 @@ class PDFFileAdmin(PublicUrlAdminMixin, PublicationAdminMixin, ModelAdmin):
         suffix = f" ({'; '.join(str(item) for item in extra)})" if extra else ''
         return format_html(
             '<div id="publication-collection-access-summary" data-url-template="{}">'
-            '<strong>{}</strong>: {}{} &nbsp; <a href="{}">{}</a>'
+            '<strong>{}</strong>: {}{} &nbsp; <a class="admin-inline-action" href="{}">{}</a>'
             '</div>',
             data_url,
             details['title'],

--- a/publications/admin.py
+++ b/publications/admin.py
@@ -410,7 +410,7 @@ class PDFFileAdmin(PublicUrlAdminMixin, PublicationAdminMixin, ModelAdmin):
         suffix = f" ({'; '.join(str(item) for item in extra)})" if extra else ''
         return format_html(
             '<div id="publication-collection-access-summary" data-url-template="{}">'
-            '<strong>{}</strong>: {}{} &nbsp; <a class="admin-inline-action" href="{}">{}</a>'
+            '<strong>{}</strong>: {}{} &nbsp; <a class="button admin-inline-action" href="{}">{}</a>'
             '</div>',
             data_url,
             details['title'],

--- a/publications/tests.py
+++ b/publications/tests.py
@@ -137,8 +137,10 @@ class PublicationCollectionAdminTests(TestCase):
         self.assertContains(response, "Access Control")
         self.assertContains(response, "Annual Magazine")
         self.assertContains(response, "id_publications-0-title")
-        self.assertContains(response, "id_publications-0-file")
-        self.assertContains(response, "disabled")
+        self.assertRegex(
+            response.content.decode(),
+            r'<input\b(?=[^>]*\bid="id_publications-0-file")(?=[^>]*\bdisabled\b)[^>]*>',
+        )
         self.assertContains(response, "Publication list")
 
     def test_changelist_uses_singular_publication_count_label(self):

--- a/publications/tests.py
+++ b/publications/tests.py
@@ -82,6 +82,7 @@ class PDFFileAdminTests(TestCase):
         self.assertContains(response, "Selected collection access")
         self.assertContains(response, "Password protected")
         self.assertContains(response, "Password configured")
+        self.assertContains(response, "admin-inline-action")
         self.assertContains(response, reverse("admin:publications_publicationcollection_change", args=[collection.pk]))
 
     def test_collection_access_endpoint_returns_selected_collection_details(self):
@@ -136,10 +137,8 @@ class PublicationCollectionAdminTests(TestCase):
         self.assertContains(response, "Access Control")
         self.assertContains(response, "Annual Magazine")
         self.assertContains(response, "id_publications-0-title")
-        self.assertRegex(
-            response.content.decode(),
-            r'<input type="file" name="publications-0-file" disabled id="id_publications-0-file">',
-        )
+        self.assertContains(response, "id_publications-0-file")
+        self.assertContains(response, "disabled")
         self.assertContains(response, "Publication list")
 
     def test_changelist_uses_singular_publication_count_label(self):

--- a/static/common/publications/js/admin-collection-access.js
+++ b/static/common/publications/js/admin-collection-access.js
@@ -28,7 +28,7 @@
     const editLink = document.createElement("a");
     editLink.href = details.edit_url;
     editLink.textContent = "Edit collection access";
-    editLink.className = "admin-inline-action";
+    editLink.className = "button admin-inline-action";
     container.append(editLink);
   }
 

--- a/static/common/publications/js/admin-collection-access.js
+++ b/static/common/publications/js/admin-collection-access.js
@@ -28,6 +28,7 @@
     const editLink = document.createElement("a");
     editLink.href = details.edit_url;
     editLink.textContent = "Edit collection access";
+    editLink.className = "admin-inline-action";
     container.append(editLink);
   }
 

--- a/templates/common/admin/core/change_list_with_extra_tools.html
+++ b/templates/common/admin/core/change_list_with_extra_tools.html
@@ -6,7 +6,7 @@
   {% for link in extra_links %}
     <li class="flex flex-row items-center">
       <a href="{{ link.href }}"
-         class="button border border-base-200 bg-white flex font-medium gap-2 items-center justify-center px-3 py-2 rounded-default shadow-xs text-sm text-font-default-light hover:bg-base-100/80 dark:bg-transparent dark:border-base-700 dark:text-font-default-dark dark:hover:bg-base-800/80">
+         class="button admin-inline-action border border-base-200 bg-white flex font-medium gap-2 items-center justify-center px-3 py-2 rounded-default shadow-xs text-sm text-font-default-light hover:bg-base-100/80 dark:bg-transparent dark:border-base-700 dark:text-font-default-dark dark:hover:bg-base-800/80">
         {% if link.icon %}<span class="material-symbols-outlined text-base">{{ link.icon }}</span>{% endif %}
         <span>{{ link.label }}</span>
       </a>


### PR DESCRIPTION
## Summary

- Use Unfold file and image widgets for safe admin uploads.
- Keep public multi-file forms on native public-page widgets.
- Improve dark-mode file inputs, password fields, and custom admin action links.
- Add regression coverage for classic and Unfold markup.

## Tests

- `uv run python manage.py test` (438 passed, 1 skipped)
- `USE_UNFOLD=True uv run python manage.py check`
- `USE_UNFOLD=True uv run python manage.py test core.tests.test_admin_ui core.tests.test_admin_ux publications.tests`
- Ruff and `git diff --check` passed.