### PR TITLE
feat: make SMTP TLS settings env-configurable

### DIFF
--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -451,11 +451,12 @@ if DEBUG:
 else:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
-EMAIL_USE_TLS = True
+EMAIL_USE_TLS = env('EMAIL_USE_TLS', bool, True)
+EMAIL_USE_SSL = env('EMAIL_USE_SSL', bool, False)
 EMAIL_HOST = env('EMAIL_HOST', str, '')
 EMAIL_HOST_USER = env('EMAIL_HOST_USER', str, '')
 EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', str, '')
-EMAIL_PORT = 587
+EMAIL_PORT = env('EMAIL_PORT', int, 587)
 
 DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', str, '')
 EMAIL_HOST_RECEIVER = env('EMAIL_HOST_RECEIVER', str, '')


### PR DESCRIPTION
Makes `EMAIL_PORT`, `EMAIL_USE_TLS` and `EMAIL_USE_SSL` read from the environment (defaults unchanged: 587 / True / False).

Needed so a site can switch to an implicit-TLS (465) SMTP submission endpoint, e.g. Cloudflare Email Service SMTP (smtp.mx.cloudflare.net:465, username `api_token`), for the sf site without a chart change.