### PR TITLE
fix: handle undecodable gallery uploads and support HEIC

### DIFF
--- a/docs/admin/gallery.md
+++ b/docs/admin/gallery.md
@@ -16,3 +16,5 @@ Manage photo albums shown under `/archive/pictures/`.
 ## Notes
 - Public URLs remain `/archive/pictures/<year>/...`.
 - The **Städa upp media** admin link still points to the shared archive cleanup route.
+- iPhone photos (HEIC/HEIF) are supported and get converted to JPEG like any other upload.
+- If a file can't be read as an image (corrupted upload, unsupported format), it's skipped and a warning naming the file is shown after saving — the rest of the uploaded photos still save normally.

--- a/docs/dev/gallery.md
+++ b/docs/dev/gallery.md
@@ -8,6 +8,8 @@ The `gallery` app owns photo albums and uploaded photos. It replaced the previou
 - `Photo` stores image files and compresses newly uploaded images to 1600px-wide JPEGs in `Photo.save()`.
 - Upload paths stay compatible with the previous archive layout: `<year>/<album>/<filename>`.
 - `AlbumAdminForm` creates multi-uploaded photos in its `save_m2m()` callback so new albums are inserted before their photos reference them.
+- `compress_image()` (`gallery/models.py`) raises `ImageProcessingError` for uploads Pillow can't decode (corrupt files, unsupported formats, decompression bombs) instead of letting the exception crash the request. Both `AlbumAdminForm._save_m2m()` and the public `gallery.views.upload` view catch it per file, skip the bad upload, and keep the rest of the batch; skipped filenames are surfaced via `django.contrib.messages` (admin: `AlbumAdmin.save_related`, public view: a warning message shown on redirect) and `form.skipped_images` for tests.
+- `pillow-heif` is registered via `GalleryConfig.ready()` (`gallery/apps.py`), so `PIL.Image.open()` — and therefore `compress_image()` and Django's own `ImageField` validation — can decode HEIC/HEIF uploads (the default photo format on iPhones).
 
 ## Migration Notes
 - `archive.0008_remove_picture_collection_delete_examcollection_and_more` copies legacy `archive.Collection(type="Pictures")` rows into `gallery_album` and related `archive.Picture` rows into `gallery_photo`.

--- a/gallery/admin.py
+++ b/gallery/admin.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.db import models
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -74,6 +74,16 @@ class AlbumAdmin(FlatpickrDateTimeAdminMixin, GalleryAdminMixin, ModelAdmin):
     ordering = ('-pub_date',)
     date_hierarchy = 'pub_date'
     flatpickr_datetime_fields = ('pub_date',)
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        skipped = getattr(form, 'skipped_images', None)
+        if skipped:
+            messages.warning(
+                request,
+                _('Kunde inte bearbeta följande bilder, de laddades inte upp: %(files)s')
+                % {'files': ', '.join(skipped)},
+            )
 
     legacy_permission_map = {
         'view': 'archive.view_picturecollection',

--- a/gallery/apps.py
+++ b/gallery/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class GalleryConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
     name = 'gallery'
+
+    def ready(self):
+        import pillow_heif
+
+        pillow_heif.register_heif_opener()

--- a/gallery/forms.py
+++ b/gallery/forms.py
@@ -1,8 +1,12 @@
+import logging
+
 from django import forms
 
 from core.admin_widgets import SafeAdminMultipleFileWidget
 
-from .models import Album, Photo
+from .models import Album, ImageProcessingError, Photo
+
+logger = logging.getLogger('date')
 
 
 class MultipleFileInput(forms.ClearableFileInput):
@@ -35,6 +39,11 @@ class AlbumAdminForm(forms.ModelForm):
 
     def _save_m2m(self):
         super()._save_m2m()
+        self.skipped_images = []
         if hasattr(self.files, 'getlist'):
             for uploaded_file in self.files.getlist('images'):
-                Photo.objects.create(album=self.instance, image=uploaded_file)
+                try:
+                    Photo.objects.create(album=self.instance, image=uploaded_file)
+                except ImageProcessingError as exc:
+                    logger.warning(str(exc))
+                    self.skipped_images.append(uploaded_file.name)

--- a/gallery/models.py
+++ b/gallery/models.py
@@ -16,6 +16,10 @@ from PIL import Image
 logger = logging.getLogger('date')
 
 
+class ImageProcessingError(Exception):
+    """Raised when an uploaded file cannot be decoded/processed as an image."""
+
+
 def upload_to(instance, filename):
     filename_base, filename_ext = os.path.splitext(filename)
     return "{year}/{album}/{filename}{extension}".format(
@@ -28,13 +32,16 @@ def upload_to(instance, filename):
 
 def compress_image(uploaded_image):
     basewidth = 1600
-    img = Image.open(uploaded_image)
-    output_io_stream = BytesIO()
-    img = img.convert('RGB')
-    wpercent = basewidth / float(img.size[0])
-    hsize = int(float(img.size[1]) * float(wpercent))
-    img = img.resize((basewidth, hsize), Image.LANCZOS)
-    img.save(output_io_stream, format='JPEG', quality=60)
+    try:
+        img = Image.open(uploaded_image)
+        img = img.convert('RGB')
+        wpercent = basewidth / float(img.size[0])
+        hsize = int(float(img.size[1]) * float(wpercent))
+        img = img.resize((basewidth, hsize), Image.LANCZOS)
+        output_io_stream = BytesIO()
+        img.save(output_io_stream, format='JPEG', quality=60)
+    except (OSError, Image.DecompressionBombError) as exc:
+        raise ImageProcessingError(f"Could not process image '{uploaded_image.name}': {exc}") from exc
     output_io_stream.seek(0)
     return InMemoryUploadedFile(
         output_io_stream,

--- a/gallery/tests.py
+++ b/gallery/tests.py
@@ -4,15 +4,55 @@ from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pillow_heif
 from django.contrib import admin
+from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
 from django.utils.datastructures import MultiValueDict
 from PIL import Image
 
+from members.models import ORDINARY_MEMBER, Member, MembershipType
+
 from .admin import AlbumAdmin, PhotoInline
 from .forms import AlbumAdminForm
-from .models import Album, Photo
+from .models import Album, ImageProcessingError, Photo, compress_image
+
+
+def _uploaded_image(name='upload.jpg'):
+    image = Image.new('RGB', (100, 100), color=(25, 90, 140))
+    image_bytes = BytesIO()
+    image.save(image_bytes, format='JPEG')
+    image.close()
+    return SimpleUploadedFile(name=name, content=image_bytes.getvalue(), content_type='image/jpeg')
+
+
+def _uploaded_heic_image(name='iphone-photo.heic'):
+    image = Image.new('RGB', (100, 100), color=(90, 25, 140))
+    heif_file = pillow_heif.from_pillow(image)
+    image_bytes = BytesIO()
+    heif_file.save(image_bytes, quality=50)
+    return SimpleUploadedFile(name=name, content=image_bytes.getvalue(), content_type='image/heic')
+
+
+def _corrupt_upload(name='broken.jpg'):
+    return SimpleUploadedFile(name=name, content=b'not-actually-an-image', content_type='image/jpeg')
+
+
+class CompressImageTests(TestCase):
+    def test_raises_image_processing_error_for_undecodable_upload(self):
+        with self.assertRaises(ImageProcessingError):
+            compress_image(_corrupt_upload())
+
+    def test_compresses_heic_upload_to_jpeg(self):
+        result = compress_image(_uploaded_heic_image())
+
+        self.assertTrue(result.name.endswith('.jpg'))
+        self.assertEqual(result.content_type, 'image/jpeg')
+        result.seek(0)
+        decoded = Image.open(result)
+        self.assertEqual(decoded.format, 'JPEG')
 
 
 class AlbumAdminFormTests(TestCase):
@@ -32,7 +72,7 @@ class AlbumAdminFormTests(TestCase):
     def test_creates_multi_uploads_after_saving_new_album(self):
         form = AlbumAdminForm(
             data={'title': 'Admin album', 'pub_date': '2026-08-23 14:00:00'},
-            files=MultiValueDict({'images': [self._uploaded_image('admin-upload.jpg')]}),
+            files=MultiValueDict({'images': [_uploaded_image('admin-upload.jpg')]}),
         )
 
         self.assertTrue(form.is_valid(), form.errors)
@@ -47,12 +87,36 @@ class AlbumAdminFormTests(TestCase):
         self.assertEqual(photo.album, album)
         self.assertTrue(photo.image.name.endswith('admin-upload.jpg'))
 
-    def _uploaded_image(self, name):
-        image = Image.new('RGB', (100, 100), color=(25, 90, 140))
-        image_bytes = BytesIO()
-        image.save(image_bytes, format='JPEG')
-        image.close()
-        return SimpleUploadedFile(name=name, content=image_bytes.getvalue(), content_type='image/jpeg')
+    def test_creates_heic_upload_as_photo(self):
+        form = AlbumAdminForm(
+            data={'title': 'HEIC album', 'pub_date': '2026-08-23 14:00:00'},
+            files=MultiValueDict({'images': [_uploaded_heic_image()]}),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        album = form.save(commit=False)
+        album.save()
+        form.save_m2m()
+
+        photo = Photo.objects.get()
+        self.assertEqual(photo.album, album)
+        self.assertTrue(photo.image.name.endswith('.jpg'))
+        self.assertEqual(form.skipped_images, [])
+
+    def test_skips_unprocessable_image_and_keeps_valid_ones(self):
+        form = AlbumAdminForm(
+            data={'title': 'Mixed album', 'pub_date': '2026-08-23 14:00:00'},
+            files=MultiValueDict({'images': [_uploaded_image('good.jpg'), _corrupt_upload('bad.jpg')]}),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        album = form.save(commit=False)
+        album.save()
+        form.save_m2m()
+
+        self.assertEqual(Photo.objects.count(), 1)
+        self.assertTrue(Photo.objects.get().image.name.endswith('good.jpg'))
+        self.assertEqual(form.skipped_images, ['bad.jpg'])
 
 
 class GalleryLegacyAdminPermissionTests(TestCase):
@@ -84,3 +148,57 @@ class GalleryLegacyAdminPermissionTests(TestCase):
         self.assertTrue(inline.has_add_permission(self.request))
         self.assertTrue(inline.has_change_permission(self.request))
         self.assertTrue(inline.has_delete_permission(self.request))
+
+
+class GalleryUploadViewTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._media_root = tempfile.mkdtemp()
+        cls._media_override = override_settings(MEDIA_ROOT=cls._media_root)
+        cls._media_override.enable()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._media_override.disable()
+        shutil.rmtree(cls._media_root, ignore_errors=True)
+        super().tearDownClass()
+
+    @classmethod
+    def setUpTestData(cls):
+        membership_type = MembershipType.objects.get(pk=ORDINARY_MEMBER)
+        cls.member = Member.objects.create_user(
+            username='gallery_uploader',
+            password='pwd',
+            membership_type=membership_type,
+        )
+        cls.member.user_permissions.add(Permission.objects.get(codename='add_album', content_type__app_label='gallery'))
+
+    def setUp(self):
+        self.client.force_login(self.member, backend='members.backends.AuthBackend')
+
+    def test_skips_unprocessable_image_and_keeps_valid_ones(self):
+        response = self.client.post(
+            reverse('archive:upload'),
+            data={'album': 'Mixed upload', 'images': [_uploaded_image('good.jpg'), _corrupt_upload('bad.jpg')]},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        album = Album.objects.get(title='Mixed upload')
+        self.assertEqual(Photo.objects.filter(album=album).count(), 1)
+        self.assertTrue(Photo.objects.get(album=album).image.name.endswith('good.jpg'))
+
+        response = self.client.get(reverse('archive:years'))
+        warnings = [m.message for m in response.context['messages']]
+        self.assertTrue(any('bad.jpg' in message for message in warnings))
+
+    def test_accepts_heic_upload(self):
+        response = self.client.post(
+            reverse('archive:upload'),
+            data={'album': 'HEIC upload', 'images': [_uploaded_heic_image()]},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        album = Album.objects.get(title='HEIC upload')
+        photo = Photo.objects.get(album=album)
+        self.assertTrue(photo.image.name.endswith('.jpg'))

--- a/gallery/views.py
+++ b/gallery/views.py
@@ -1,14 +1,16 @@
 import logging
 
+from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Count, OuterRef, Subquery
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
+from django.utils.translation import gettext as _
 
 from .forms import AlbumUploadForm
-from .models import Album, Photo
+from .models import Album, ImageProcessingError, Photo
 
 logger = logging.getLogger('date')
 
@@ -129,8 +131,19 @@ def upload(request):
             if not request.FILES.getlist('images'):
                 return redirect('archive:years')
             album = Album.objects.create(title=form['album'].value())
+            skipped = []
             for uploaded_file in request.FILES.getlist('images'):
-                Photo.objects.create(image=uploaded_file, album=album)
+                try:
+                    Photo.objects.create(image=uploaded_file, album=album)
+                except ImageProcessingError as exc:
+                    logger.warning(str(exc))
+                    skipped.append(uploaded_file.name)
+            if skipped:
+                messages.warning(
+                    request,
+                    _('Kunde inte bearbeta följande bilder, de laddades inte upp: %(files)s')
+                    % {'files': ', '.join(skipped)},
+                )
         return redirect('archive:years')
 
     return render(request, 'archive/upload.html', {'picture_form': AlbumUploadForm})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "gspread",
     "twisted[tls]>=26.4.0",
     "defusedxml>=0.7.1",
+    "pillow-heif>=1.5.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -482,6 +482,7 @@ dependencies = [
     { name = "icalendar" },
     { name = "instaloader" },
     { name = "pillow" },
+    { name = "pillow-heif" },
     { name = "psycopg2-binary" },
     { name = "python-dateutil" },
     { name = "requests" },
@@ -530,6 +531,7 @@ requires-dist = [
     { name = "icalendar" },
     { name = "instaloader" },
     { name = "pillow" },
+    { name = "pillow-heif", specifier = ">=1.5.0" },
     { name = "psycopg2-binary" },
     { name = "python-dateutil" },
     { name = "requests" },
@@ -1213,6 +1215,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
+name = "pillow-heif"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/6ab7a469ced899fbdbbc27b00067e4da02c21ff1ce7e9c6110f14e8fea6c/pillow_heif-1.5.0.tar.gz", hash = "sha256:16b11a37b762ff42da2d36527bb5cb14bd9194c24c389ee911155d6e23c53065", size = 17114105, upload-time = "2026-07-22T14:27:50.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/51/9b5a9352b86b7d82ad62969a84e3b4f998f6b5dc0320cec3e2d54d74d754/pillow_heif-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8d96783ca1648ba8384e66b888128ca3a48d769c0e3593acf84c40ce0c791629", size = 4743156, upload-time = "2026-07-22T14:27:15.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/10/dc89bec0edf37df5d7609d76ce125a2f8d1e901b2d34944d64d05f497bef/pillow_heif-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5c50626e77510f38cb11aacb3b4bba56eff17ce39a9d85b7ee210bd81387a083", size = 4264368, upload-time = "2026-07-22T14:27:17.198Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/54/837e9077784df4a0ba69d3e76e9f29a4e52929c84f0e1b0d29a13437a5cc/pillow_heif-1.5.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fb15135733626ee3fd4d7104bde1e54d4370f9f8b697a5d239b8b552b73fc7b", size = 6346432, upload-time = "2026-07-22T14:27:18.55Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/90/42f392c0513bf351ba2bca1350c457b0d7bd94f12d0e5fa74d7a9deae336/pillow_heif-1.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:646ddad98c8f9c5e637dbb84b6b7db905e565994e9fd6a496a36adff36ae28b3", size = 5602088, upload-time = "2026-07-22T14:27:20.112Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4d/8070974a2e695f83fb10883b7d83c3eda635561f99993623bf111a55a984/pillow_heif-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b9803c1291c7c598134f16016a071ec8d9dce268ab1806c8541450c4e3972893", size = 7374543, upload-time = "2026-07-22T14:27:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/78/9a5abfb163b0fb44a4f624146de142ba4887e5011f965442af2c997db6bc/pillow_heif-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1ad925299422d4592e4b5344c03e25b27dc7a5130447603a89404d7d138b746c", size = 6633558, upload-time = "2026-07-22T14:27:23.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bc/7bae1c1efcec25dfdca950fe1a10cd723c544269db73203019e965394015/pillow_heif-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:cfd5f8a8a7b65f2ded217c5bde4dd9365b6b67187657a121b05224841a1b92c0", size = 6703549, upload-time = "2026-07-22T14:27:25.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8d/fff074683f96eb004d7159228d2fc9e2e9fe8afd899d53aa695c622487d8/pillow_heif-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:6759febf63ea31fd00756e4a828cd643d0b9f98c93f5814b0ce5baa036da50e4", size = 4017234, upload-time = "2026-07-22T14:27:27.443Z" },
+    { url = "https://files.pythonhosted.org/packages/57/04/fa5727a62b2fc37b611c7a172fc10c6719530d27bc9126de8456fac69346/pillow_heif-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:e2c3f47eac33d8368ea5779eb7bd8c736e7048b5897474d7e1799c073c9505e3", size = 4744030, upload-time = "2026-07-22T14:27:29.047Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6f/afaccf55774c1084e5beba83f0ac201d315096f6a95d003696376184a7a3/pillow_heif-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d0881c82752d676fbe054cb0258100790ead94946fbb075ffa041bb9ae579b11", size = 4265061, upload-time = "2026-07-22T14:27:30.703Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a6/c90f9fffd5cb56e213753f22a9a955525d5ad99816481ae2392ab6c7ccd8/pillow_heif-1.5.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d5810606f70d3432b55987a5e44aa26fb7598fea565d8645b017f7ed935f5e99", size = 6351671, upload-time = "2026-07-22T14:27:32.231Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b3/e15933817e71b9fcd8865e3b64171995ed26f5ca329bf4d03f3571213c52/pillow_heif-1.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e737d326410e733868566c045f651b5371086a4ec294c40d39e129481d024bef", size = 5606028, upload-time = "2026-07-22T14:27:34.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/55/2665f6c781b90bb5a25595c58ede1955125f0ad2c7d81bf3c153c9e9c9d8/pillow_heif-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:522719e5dd56eae6f9f48828c08eefe0e5c02dd92f5a07780e6f3c04bdbcf880", size = 7379667, upload-time = "2026-07-22T14:27:35.883Z" },
+    { url = "https://files.pythonhosted.org/packages/54/77/0f0487b9f6cb1f5dff629b42ad08a7ae1997886048c4c2671e17079ad5d6/pillow_heif-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f1d281b2efee954ef78c0a473a41498d0548a32290d7250b4879ddd2480dffb8", size = 6637581, upload-time = "2026-07-22T14:27:37.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b7/c65adbcab1b1c99c886c55b97b144b3092c432e7b0fedb91501c479cebe4/pillow_heif-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:65b3d619cea2d1f758cd039cddb331cb44d63768c355606ea9100cfee4421eb4", size = 6704174, upload-time = "2026-07-22T14:27:39.32Z" },
+    { url = "https://files.pythonhosted.org/packages/17/53/2a52f64f399717adae560068e9b0ae12ae3e43be2c64991e246af5aedc3f/pillow_heif-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:508fc9dd8fb4df933b666c30b60b0930270d9e072fcd90b75990166050e44656", size = 4017728, upload-time = "2026-07-22T14:27:41.102Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `compress_image()` (`gallery/models.py`) unconditionally called `Image.open()`/`.convert()`/`.resize()`/`.save()` with no error handling. Any file Pillow couldn't decode — a corrupt upload, or (most commonly) an iPhone HEIC/HEIF photo, since stock Pillow doesn't support HEIC — crashed the request with an unhandled 500 on both the admin multi-upload and the public `archive:upload` view.
- `compress_image()` now catches decode/processing failures and raises `ImageProcessingError`. Both upload call sites (`AlbumAdminForm._save_m2m`, `gallery.views.upload`) catch it per file, skip the bad upload, and keep saving the rest of the batch instead of failing the whole request. Skipped filenames are surfaced via a `django.contrib.messages` warning (admin: `AlbumAdmin.save_related`; public view: warning shown on redirect) and exposed as `form.skipped_images` for tests.
- Added `pillow-heif` and registered its opener in `GalleryConfig.ready()`, so HEIC/HEIF uploads decode correctly instead of failing at all — this also benefits Django's own `ImageField` validation elsewhere (e.g. the inline photo/thumbnail fields), not just `compress_image()`.
- Updated `docs/dev/gallery.md` and `docs/admin/gallery.md` to document the new behavior.

Scope is intentionally narrow — just the crash/error-handling fix and HEIC support. A few other, unrelated issues in this code path were found during investigation (a missing `AlbumUploadForm()` instantiation on GET, and silent file drops when the album-name field is blank) but are left out of this PR.

## Test plan
- [x] `uv run python manage.py test` (470 tests, full suite) — pass
- [x] New tests in `gallery/tests.py`: `compress_image` raises `ImageProcessingError` on a corrupt upload; `compress_image` successfully compresses a HEIC upload to JPEG; admin form skips a bad file while keeping a good one (`form.skipped_images`); admin form accepts HEIC; public upload view skips a bad file while keeping a good one and shows a warning message; public upload view accepts HEIC.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy .` — pass
- [x] `uv run python manage.py check` — pass