### PR TITLE
fix: raise gunicorn worker timeout to 120s

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -73,6 +73,7 @@ spec:
               {{- end }}
               exec gunicorn \
                 -w {{ .Values.web.gunicorn.workers }} \
+                --timeout {{ .Values.web.gunicorn.timeout }} \
                 --max-requests {{ .Values.web.gunicorn.maxRequests }} \
                 --max-requests-jitter {{ .Values.web.gunicorn.maxRequestsJitter }} \
                 --bind=0.0.0.0:8000 \

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -166,6 +166,7 @@ web:
     port: 8000
   gunicorn:
     workers: 3
+    timeout: 120
     maxRequests: 1000
     maxRequestsJitter: 100
   migrateOnStartup: false

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,7 +17,7 @@ services:
     env_file: .env
     image: ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}
     restart: always
-    command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn -w 3 --max-requests 1000 --max-requests-jitter 100 --bind=0.0.0.0 core.wsgi"
+    command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn -w 3 --timeout 120 --max-requests 1000 --max-requests-jitter 100 --bind=0.0.0.0 core.wsgi"
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Summary
Prod log (2026-08-25, `POST /admin/gallery/album/944/change/`):
```
[CRITICAL] WORKER TIMEOUT (pid:23)
...
File ".../gunicorn/http/unreader.py", line 65, in chunk
    return self.sock.recv(self.mxchunk)
File ".../gunicorn/workers/base.py", line 198, in handle_abort
    sys.exit(1)
```
gunicorn's `--timeout` was never set anywhere (`docker-compose.prod.yml`, Helm chart), so it defaulted to 30s. A large/slow admin gallery multi-upload (nginx already allows up to 5000M bodies) exceeded that while gunicorn was still reading the multipart body off the socket — before Django's view or any image-processing code even ran — so the worker was SIGABRT'd mid-request. Same request retried 3 times in ~2 minutes, killing 3 successive workers the same way.

This is unrelated to the HEIC/corrupt-image handling fixed in #1064 — that fix only covers what happens once Pillow gets to decode the file; this happens earlier, purely in how long gunicorn will wait to receive the request body.

- `charts/date-website/values.yaml`: added `web.gunicorn.timeout: 120` (new, alongside existing `workers`/`maxRequests`/`maxRequestsJitter`)
- `charts/date-website/templates/deployment-web.yaml`: pass `--timeout {{ .Values.web.gunicorn.timeout }}` to gunicorn
- `docker-compose.prod.yml`: same `--timeout 120` for the self-hosted compose path
- `charts/date-website/Chart.yaml`: bumped `version: 0.3.5` → `0.3.6` per `docs/dev/kubernetes.md` (chart version must bump on any template/values change; deployments pin the immutable chart version)

120s is 4x the previous implicit 30s default — should comfortably cover large multi-photo admin uploads without masking a genuinely hung worker for too long. Happy to adjust if a different value is preferred.

## Test plan
- [x] `uv run ruff check .` / `uv run mypy .` — pass (no relevant docs/djlint targets touched)
- [ ] Manual: after this chart version ships and an association's Helm values pick it up, retry a large multi-photo admin gallery upload against `album/944` and confirm it no longer times out