### PR TITLE
fix: show hamburger menu on SF mobile view

### DIFF
--- a/templates/sf/core/base.html
+++ b/templates/sf/core/base.html
@@ -26,6 +26,10 @@
           rel="stylesheet"
           integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
           crossorigin="anonymous">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"
+          integrity="sha384-EvBWSlnoFgZlXJvpzS+MAUEjvN7+gcCwH+qh7GRFOGgZO0PuwOFro7qPOJnLfe7l"
+          crossorigin="anonymous">
     {% block icon_head %}
       <link rel="preconnect" href="https://maxst.icons8.com">
       <link rel="stylesheet"


### PR DESCRIPTION
## What

The mobile header on the SF site renders the hamburger button, but the hamburger icon never showed up. The button was still present and tappable, just invisible.

## Why

The SF base template (`templates/sf/core/base.html`) is a standalone document that does not extend the common base template, and it only loaded the line-awesome icon font. The hamburger icon in the shared header (`templates/common/core/header.html`) uses `bi bi-list`, a Bootstrap Icons glyph, so `<i class="bi bi-list fa-2x"></i>` renders empty without that font.

## Change

Add the Bootstrap Icons 1.7.2 stylesheet to `templates/sf/core/base.html`, using the same CDN link, integrity hash, and crossorigin attribute as the common base template.

## Verification

- `uv run djlint --check templates/` passes.
- Rendered the SF base template through Django (`core.settings.sf`); the output contains both the hamburger button markup (`navbar-toggler` with `bi bi-list`) and the Bootstrap Icons stylesheet link.

## Note

Impuls and Pulterit were checked too: their base templates extend the common base template, so they already inherit the Bootstrap Icons link and render the hamburger correctly. SF is the only association with a standalone base template, which is why it was missing the link.