### PR TITLE
fix: use Uppy.Uppy, not Uppy.Core, from the 5.2.4 CDN bundle

### DIFF
--- a/static/common/uploads/js/uppy-init.js
+++ b/static/common/uploads/js/uppy-init.js
@@ -100,7 +100,7 @@
         return '.' + ext.trim();
       });
 
-    var Core = Uppy.Core || Uppy;
+    var Core = Uppy.Uppy || Uppy;
     var uppy = new Core({
       autoProceed: true,
       limit: uploadLimit(),


### PR DESCRIPTION
The Uppy 5.2.4 release bundle exposes `Uppy` as a namespace object; the class lives at `Uppy.Uppy`. `Uppy.Core` still exists in the bundle but as a stub that throws "Core has been renamed to Uppy" when constructed.

The init code used `Uppy.Core || Uppy`: since `Uppy.Core` is truthy (a function, just a throwing one), the fallback never ran and every direct-upload widget threw on construction. Symptom: the `.django-uppy-widget` container renders empty and no Uppy dashboard appears; the browser console shows `bundle.ts:9 Uncaught Error: Core has been renamed to Uppy`.

Verified against the pinned 5.2.4 bundle (releases.transloadit.com/uppy/v5.2.4/uppy.min.js): `new (Uppy.Uppy)(...)` constructs cleanly, `Uppy.Core` throws, plugins (Compressor, Dashboard, AwsS3) attach to the namespace as before.