### PR TITLE
fix: keep readonly fields excluded from the attendees inline formset

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -128,9 +128,15 @@ class EventAttendeesFormInline(AvecAwareMixin, OrderableAdmin, EventTranslationI
         return readonly_fields
 
     def get_formset(self, request, obj=None, **kwargs):
+        # Note: the exclude list passed via kwargs ends up overriding the
+        # readonly-field exclusion Django computes in
+        # InlineModelAdmin.get_formset (the kwargs dict is applied after the
+        # defaults). Include readonly fields here explicitly, otherwise they
+        # stay on the form as required fields and any save fails validation.
+        exclude = [*kwargs.get('exclude', []), *self.get_readonly_fields(request, obj)]
         if not self._event_uses_avec(obj):
-            kwargs.setdefault('exclude', [])
-            kwargs['exclude'] = [*kwargs['exclude'], 'avec_for']
+            exclude.append('avec_for')
+        kwargs['exclude'] = exclude
         return super().get_formset(request, obj, **kwargs)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):

--- a/events/tests.py
+++ b/events/tests.py
@@ -15,7 +15,7 @@ from django.utils.formats import date_format
 from django.utils.translation import gettext
 from django_ckeditor_5.widgets import CKEditor5Widget
 
-from events.admin import EventRegistrationFormSet
+from events.admin import EventAttendeesFormInline, EventRegistrationFormSet
 from events.forms import EventCreationForm, EventEditForm
 from events.models import Event, EventAttendees, EventRegistrationForm
 from events.routing import websocket_urlpatterns
@@ -674,6 +674,24 @@ class EventAdminTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'column-original_event')
+
+    @patch("modeltranslation.admin.TranslationInlineModelAdmin.get_formset")
+    def test_attendees_inline_formset_passes_complete_exclude_list(self, get_formset):
+        """The dynamic avec exclusion must preserve readonly exclusions.
+
+        Production runs without translation inlines, so the exclude list our
+        override passes up reaches Django's InlineModelAdmin.get_formset,
+        which applies kwargs after its defaults and would otherwise drop the
+        readonly-field exclusion and leave time_registered required.
+        """
+        request = RequestFactory().get("/admin/events/event/change/")
+        request.user = self.admin_user
+        inline = EventAttendeesFormInline(Event, admin.site)
+
+        inline.get_formset(request, obj=self.event)
+
+        _, kwargs = get_formset.call_args
+        self.assertCountEqual(kwargs["exclude"], ["time_registered", "avec_for"])
 
     def test_change_page_hides_hide_for_avec_when_avec_is_disabled(self):
         EventRegistrationForm.objects.create(


### PR DESCRIPTION
## Problem

Saving an event that has any attendees in the Django admin fails with the
Swedish form-errors banner ("Var god rätta felen nedan.") even when nothing
was changed. Events without attendees save fine.

## Root cause

`EventAttendeesFormInline.get_formset` (events/admin.py) passes its dynamic
exclude list (`avec_for`, when the event does not use avec) up the chain via
kwargs. Django's `InlineModelAdmin.get_formset` builds its defaults and then
applies `**kwargs` on top, so the readonly-field exclusion computed from
`get_readonly_fields()` is dropped. `time_registered` (and `original_event`
for events with children) then remain on the generated formset as required
fields. Any event with at least one attendee therefore fails validation on
every admin save.

## Fix

Include `get_readonly_fields()` in the exclude list passed up, alongside the
existing dynamic `avec_for` exclusion, so the complete exclude contract
survives to `inlineformset_factory`.

## Testing

- New regression test `test_attendees_inline_formset_passes_complete_exclude_list`
  pins the exact exclude list the override passes up; it fails without the
  fix and passes with it.
- Full `events` test suite: 110 tests, all green.