### PR TITLE
feat: manage uploaded files in the upload widget

### DIFF
--- a/core/tests/test_smoke_uploads.py
+++ b/core/tests/test_smoke_uploads.py
@@ -19,6 +19,9 @@ class DirectUploadSmokeTests(TestCase):
         self.assertEqual(response.status_code, 200)
         html = response.content.decode()
         self.assertIn('data-uppy-widget="1"', html)
+        self.assertIn('data-uppy-mode="direct"', html)
+        self.assertIn('data-uppy-mount="1"', html)
+        self.assertIn('uploads/js/upload-init.js', html)
         self.assertIn('https://releases.transloadit.com/uppy/v5.2.4/uppy.min.js', html)
         self.assertIn('data-uppy-scope="gallery-admin"', html)
         self.assertIn('data-uppy-compress="true"', html)
@@ -30,6 +33,8 @@ class DirectUploadSmokeTests(TestCase):
         self.assertEqual(response.status_code, 200)
         html = response.content.decode()
         self.assertIn('data-uppy-widget="1"', html)
+        self.assertIn('data-uppy-mode="direct"', html)
+        self.assertIn('uploads/js/upload-init.js', html)
         self.assertIn('https://releases.transloadit.com/uppy/v5.2.4/uppy.min.js', html)
         self.assertIn('integrity="sha384-hl+zw0fpZ6cVAtnkwy96IFC3oGXSYqe8', html)
         self.assertIn('data-uppy-scope="gallery"', html)
@@ -67,11 +72,15 @@ class DirectUploadSmokeTests(TestCase):
             self.assertEqual(response.status_code, 200)
             html = response.content.decode()
             self.assertNotIn('uppy.min.js', html)
-            self.assertNotIn('data-uppy-widget', html)
+            self.assertIn('data-uppy-widget="1"', html)
+            self.assertIn('data-uppy-mode="classic"', html)
+            self.assertIn('uploads/js/upload-init.js', html)
+            self.assertNotIn('data-uppy-scope', html)
 
             admin_response = self.client.get(reverse('admin:gallery_album_add'))
             self.assertNotIn('uppy.min.js', admin_response.content.decode())
-            self.assertNotIn('data-uppy-widget', admin_response.content.decode())
+            self.assertIn('data-uppy-mode="classic"', admin_response.content.decode())
+            self.assertIn('uploads/js/upload-init.js', admin_response.content.decode())
 
 
 @override_settings(USE_S3=False, DIRECT_UPLOADS_ENABLED=False)
@@ -80,11 +89,14 @@ class ClassicModeSmokeTests(TestCase):
         self.user = Member.objects.create_superuser(username='smoke-admin2', password='pwd', email='b@example.com')
         self.client.force_login(self.user)
 
-    def test_upload_page_uses_classic_input_when_disabled(self):
+    def test_upload_page_uses_classic_widget_when_disabled(self):
         album_perm = Permission.objects.get(codename='add_album', content_type__app_label='gallery')
         self.user.user_permissions.add(album_perm)
         response = self.client.get(reverse('archive:upload'))
         self.assertEqual(response.status_code, 200)
         html = response.content.decode()
         self.assertIn('type="file"', html)
-        self.assertNotIn('data-uppy-widget', html)
+        self.assertIn('data-uppy-widget="1"', html)
+        self.assertIn('data-uppy-mode="classic"', html)
+        self.assertIn('data-uppy-selected="1"', html)
+        self.assertNotIn('data-uppy-scope', html)

--- a/core/tests/test_uploads.py
+++ b/core/tests/test_uploads.py
@@ -666,8 +666,47 @@ class DirectUploadFallbackTests(TestCase):
         self.assertIn('type="file"', html)
         self.assertIn('multiple="multiple"', html)
 
+    def test_direct_widget_renders_uploaded_list_container(self):
+        field = DirectUploadField(scope='gallery', multi=True)
+        html = field.widget.render('images', None)
+        self.assertIn('data-uppy-mode="direct"', html)
+        self.assertIn('data-uppy-mount="1"', html)
+        self.assertIn('data-uppy-uploaded="1"', html)
+
+    def test_direct_widget_round_trips_payload_value(self):
+        payload = json.dumps(
+            [
+                {'key': 'tmp/' + 'a' * 32 + '.jpg', 'name': 'photo.jpg', 'size': 100},
+            ]
+        )
+        field = DirectUploadField(scope='gallery', multi=True)
+        html = field.widget.render('images', payload)
+        self.assertIn('type="hidden"', html)
+        self.assertIn('name="images"', html)
+        self.assertIn(payload.replace('"', '&quot;'), html)
+
     def test_direct_widget_accepts_multipart_fallback(self):
         field = DirectUploadField(scope='gallery', multi=True)
         uploaded = SimpleUploadedFile('photo.jpg', JPEG_MAGIC + b'content', content_type='image/jpeg')
         value = field.widget.value_from_datadict({}, MultiValueDict({'images': [uploaded]}), 'images')
         self.assertEqual(field.clean(value), [uploaded])
+
+
+@override_settings(USE_S3=False, DIRECT_UPLOADS_ENABLED=False)
+class ClassicUploadWidgetTests(TestCase):
+    def test_classic_widget_renders_selected_list(self):
+        field = DirectUploadField(scope='gallery', multi=True)
+        html = field.widget.render('images', None)
+        self.assertIn('data-uppy-widget="1"', html)
+        self.assertIn('data-uppy-mode="classic"', html)
+        self.assertIn('data-uppy-selected="1"', html)
+        self.assertIn('type="file"', html)
+        self.assertIn('multiple="multiple"', html)
+        self.assertNotIn('type="hidden"', html)
+        self.assertNotIn('data-uppy-scope', html)
+
+    def test_classic_widget_single_file_has_no_multiple(self):
+        field = DirectUploadField(scope='gallery', multi=False)
+        html = field.widget.render('images', None)
+        self.assertIn('type="file"', html)
+        self.assertNotIn('multiple', html)

--- a/core/upload_widgets.py
+++ b/core/upload_widgets.py
@@ -1,15 +1,22 @@
-"""Form field/widget for direct browser-to-storage uploads (Uppy).
+"""Form field/widget for browser-to-storage uploads (Uppy).
 
 When direct uploads are enabled (``USE_S3`` + ``DIRECT_UPLOADS_ENABLED``) the
 widget renders a Uppy Dashboard container plus a hidden input holding the JSON
-payload of uploaded temp keys. On form save the app calls
+payload of uploaded temp keys, and a removable list of the files already
+uploaded to the temp prefix. On form save the app calls
 ``core.uploads.finalize_upload`` to move each temp object to its final key.
+The uploaded list is rehydrated from the hidden payload on every render, so
+files survive reloads and validation errors and can be removed individually.
 
-When direct uploads are disabled the widget degrades to a classic file input so
-behavior (and tests) stay unchanged for local/self-hosted setups. For upload
-scopes used by the Django admin (``admin``, ``gallery-admin``) the classic input
-is rendered through the admin file widget, keeping the Unfold upload styling and
-the broken-file safety from ``core.admin_widgets``.
+When direct uploads are disabled the widget degrades to a classic file input
+wrapped in a container that lists the selected files and lets the user remove
+them before submitting. For upload scopes used by the Django admin (``admin``,
+``gallery-admin``) the classic input is rendered through the admin file widget,
+keeping the Unfold upload styling and the broken-file safety from
+``core.admin_widgets``.
+
+The widget only manages temp uploads; files already attached to model rows are
+managed through the normal admin inlines.
 
 The mode is decided at render/clean time (not field construction) because form
 field instances are class attributes and Django settings may differ between
@@ -25,11 +32,13 @@ from django.utils.translation import gettext_lazy as _
 
 from .uploads import SCOPES, parse_uploaded_files, uploads_enabled
 
+# Always loaded wherever a DirectUploadField renders, so both modes get the
+# file-list behavior (Uppy assets are CDN-only and loaded on top when enabled).
+UPLOAD_WIDGET_CSS = ('uploads/css/upload-widget.css',)
+UPLOAD_WIDGET_JS = ('uploads/js/upload-init.js',)
+
 UPPY_MEDIA_CSS = ('https://releases.transloadit.com/uppy/v5.2.4/uppy.min.css',)
-UPPY_MEDIA_JS = (
-    'https://releases.transloadit.com/uppy/v5.2.4/uppy.min.js',
-    'uploads/js/uppy-init.js',
-)
+UPPY_MEDIA_JS = ('https://releases.transloadit.com/uppy/v5.2.4/uppy.min.js',)
 
 # Scopes used from Django admin change forms. Their classic-mode input keeps the
 # admin upload widget so the Unfold markup and safe-widget behavior are
@@ -70,7 +79,7 @@ class DirectUploadWidget(forms.Widget):
             from core.admin_widgets import SafeAdminMultipleFileWidget
 
             return SafeAdminMultipleFileWidget(attrs=attrs).render(name, None, renderer=renderer)
-        input_attrs = self.build_attrs(attrs, {'type': 'file', 'name': name})
+        input_attrs = self.build_attrs(attrs or {}, {'type': 'file', 'name': name})
         if self.multi:
             input_attrs['multiple'] = 'multiple'
         return format_html('<input{}>', self._attrs_html(input_attrs))
@@ -87,6 +96,7 @@ class DirectUploadWidget(forms.Widget):
             {
                 'class': 'django-uppy-widget',
                 'data-uppy-widget': '1',
+                'data-uppy-mode': 'direct',
                 'data-uppy-scope': self.scope,
                 'data-uppy-bucket': self.bucket,
                 'data-uppy-multi': 'true' if self.multi else 'false',
@@ -96,14 +106,26 @@ class DirectUploadWidget(forms.Widget):
                 'data-uppy-allowed-extensions': ','.join(self.allowed_extensions),
             }
         )
-        container = format_html('<div{}></div>', self._attrs_html(container_attrs))
+        container = format_html(
+            '<div{}><div data-uppy-mount="1"></div><ul class="django-uppy-files" data-uppy-uploaded="1"></ul></div>',
+            self._attrs_html(container_attrs),
+        )
         fallback = format_html('<noscript>{}</noscript>', self._classic_input(name, attrs))
         return format_html('{}{}{}', hidden, container, fallback)
+
+    def _classic_inputs(self, name, attrs=None, renderer=None):
+        container = format_html(
+            '<div class="django-uppy-widget" data-uppy-widget="1" data-uppy-mode="classic">'
+            '{}<ul class="django-uppy-files" data-uppy-selected="1"></ul>'
+            '</div>',
+            self._classic_input(name, attrs, renderer=renderer),
+        )
+        return container
 
     def render(self, name, value, attrs=None, renderer=None):
         if uploads_enabled():
             return self._direct_inputs(name, value, attrs)
-        return self._classic_input(name, attrs, renderer=renderer)
+        return self._classic_inputs(name, attrs, renderer=renderer)
 
     def value_from_datadict(self, data, files, name):
         if uploads_enabled():
@@ -165,14 +187,17 @@ class DirectUploadField(forms.Field):
 
 
 class DirectUploadAdminMediaMixin:
-    """Add the Uppy assets to an admin changeform only when direct uploads are
-    enabled. Admin Media classes are merged into ``ModelAdmin.media``; this
-    mixin appends the Uppy assets conditionally on top of whatever the admin
-    declares (e.g. flatpickr)."""
+    """Add the upload-widget assets to an admin changeform.
+
+    Admin Media classes are merged into ``ModelAdmin.media``; this mixin
+    appends the file-list behavior always (both upload modes need it) and the
+    Uppy CDN assets only when direct uploads are enabled, on top of whatever
+    the admin declares (e.g. flatpickr)."""
 
     @property
     def media(self):
         media = super().media
+        media += forms.Media(css={'all': UPLOAD_WIDGET_CSS}, js=UPLOAD_WIDGET_JS)
         if uploads_enabled():
             media += forms.Media(css={'all': UPPY_MEDIA_CSS}, js=UPPY_MEDIA_JS)
         return media

--- a/docs/admin/archive.md
+++ b/docs/admin/archive.md
@@ -6,7 +6,7 @@ Manage document archives and public files. Photo galleries are managed in **Gall
 ## Document Collections
 1. Open **Archive › Document collections**.
 2. Create a collection with title and publication date. The publication date uses the shared calendar/time picker.
-3. Use the multi-upload field to upload one or many files (drag-and-drop when direct uploads are enabled; classic file picker otherwise).
+3. Use the multi-upload field to upload one or many files (drag-and-drop when direct uploads are enabled; classic file picker otherwise). Uploaded files stay listed below the field until the form is saved, and can be removed individually; files already attached to the collection are managed in the inline table below.
 4. Save. Files are stored under `media/documents/<year>/<slug>/`.
 
 ## Public Files (S3 only)

--- a/docs/admin/exambank.md
+++ b/docs/admin/exambank.md
@@ -13,7 +13,7 @@ Use **Exam bank › Exam archives › Åtkomstinställningar** to choose how the
 ## Adding Exam Archives
 1. Visit **Exam bank › Exam archives**.
 2. Create an archive with a title and publication date. The publication date uses the shared calendar/time picker.
-3. Use the inline table or multi-upload field to upload exam files (drag-and-drop when direct uploads are enabled).
+3. Use the inline table or multi-upload field to upload exam files (drag-and-drop when direct uploads are enabled). Uploaded files stay listed below the field until the form is saved, and can be removed individually; files already attached to the archive are managed in the inline table below.
 4. Provide a descriptive **Namn** for each file.
 5. Save. Files are stored under `media/<year>/<slug>/`.
 

--- a/docs/admin/gallery.md
+++ b/docs/admin/gallery.md
@@ -10,7 +10,7 @@ Manage photo albums shown under `/archive/pictures/`.
    - **Namn**: gallery title, also used in media folder paths.
    - **Pub date**: determines which year bucket the gallery appears under and uses the shared calendar/time picker.
    - **Göm för gulisar**: hide sensitive albums from freshmen.
-4. Upload photos in the inline table or with the multi-upload field.
+4. Upload photos in the inline table or with the multi-upload field. Uploaded photos stay listed below the field until the form is saved, and can be removed individually; photos already in the album are managed in the inline table below.
 5. Save. With direct uploads enabled, images are compressed client-side before upload; otherwise the server compresses them to 1600px width for performance.
 
 ## Notes

--- a/docs/dev/uploads.md
+++ b/docs/dev/uploads.md
@@ -12,14 +12,17 @@ object from a temp key to its final key with a server-side copy.
 
 The feature uses the pinned Uppy 5.2.4 browser bundle from Transloadit's
 release CDN. The site-specific integration remains in
-`static/common/uploads/js/uppy-init.js`.
+`static/common/uploads/js/upload-init.js` (one file serving both the direct
+Uppy mode and the classic fallback) with shared styling in
+`static/common/uploads/css/upload-widget.css`.
 
 ## How it fits together
 
 1. Forms that upload files use `DirectUploadField` (see `core/upload_widgets.py`).
-   When enabled it renders a Uppy Dashboard container plus a hidden input;
-   when disabled it degrades to the classic multi-file input, so local and
-   self-hosted setups behave exactly as before.
+   When enabled it renders a Uppy Dashboard container plus a hidden input; when
+   disabled it degrades to a classic file input with a removable list of the
+   selected files, so local and self-hosted setups behave as before while
+   keeping the same file management UX.
 2. `POST /_uploads/sign/` (`core/uploads.py`, mounted by
    `core/urls/common.py` for every association) validates the request and
    returns a presigned PUT URL for a server-generated key under `tmp/`.
@@ -40,7 +43,15 @@ release CDN. The site-specific integration remains in
    Full file bodies never pass through the web process. Finalization reads up
    to 512 bytes for type validation.
 
-4. Gallery photos are compressed client-side (`@uppy/compressor`, 1600px,
+4. The widget only manages temp uploads. Below the Dashboard it renders the
+   list of files already uploaded to the temp prefix, rehydrated from the
+   hidden input on every page load, so uploaded files stay visible and
+   removable across reloads and validation errors; removing an entry drops it
+   from the payload (the temp object is left for the bucket lifecycle rule).
+   Files already attached to model rows are not listed: those are managed
+   through the admin inlines and the normal model delete flows.
+
+5. Gallery photos are compressed client-side (`@uppy/compressor`, 1600px,
    quality 60) before upload. Compression preserves the input format so the
    signed key extension continues to match the uploaded bytes. Compression and
    upload concurrency are sized to the device from `navigator.deviceMemory`
@@ -145,6 +156,9 @@ release CDN. The site-specific integration remains in
   are not accepted through the direct path.
 - The form blocks submission while uploads are pending or failed; failed
   files must be removed before saving.
+- Uploaded (temp) files are shown and removable in the widget; removing one
+  only drops it from the form payload, it does not delete the temp object
+  (the bucket lifecycle rule cleans it up).
 - Single-file admin fields (album thumbnails, publication PDFs, event and
   staticpage backgrounds, CKEditor inline images) still use the classic
   widget; the same machinery can be extended to them later.

--- a/docs/dev/uploads.md
+++ b/docs/dev/uploads.md
@@ -22,7 +22,9 @@ Uppy mode and the classic fallback) with shared styling in
    When enabled it renders a Uppy Dashboard container plus a hidden input; when
    disabled it degrades to a classic file input with a removable list of the
    selected files, so local and self-hosted setups behave as before while
-   keeping the same file management UX.
+   keeping the same file management UX. If the Uppy bundle fails to load, the
+   direct widget falls back to that classic input with a status message
+   instead of leaving the page silently unusable.
 2. `POST /_uploads/sign/` (`core/uploads.py`, mounted by
    `core/urls/common.py` for every association) validates the request and
    returns a presigned PUT URL for a server-generated key under `tmp/`.

--- a/static/common/uploads/css/upload-widget.css
+++ b/static/common/uploads/css/upload-widget.css
@@ -1,0 +1,45 @@
+/* File lists rendered by the upload widget (direct Uppy mode and classic mode). */
+
+.django-uppy-widget .django-uppy-files {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.django-uppy-file {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  font-size: 0.875rem;
+}
+
+.django-uppy-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.django-uppy-size {
+  flex-shrink: 0;
+  color: var(--color-base-600, #666);
+}
+
+.django-uppy-remove {
+  flex-shrink: 0;
+  margin-left: auto;
+  width: 1.5rem;
+  height: 1.5rem;
+  line-height: 1;
+  border: 0;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--color-base-600, #666);
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.django-uppy-remove:hover {
+  background: var(--color-danger-100, #fde2e1);
+  color: var(--color-danger-700, #b42318);
+}

--- a/static/common/uploads/js/upload-init.js
+++ b/static/common/uploads/js/upload-init.js
@@ -30,6 +30,12 @@
  * The selected-file list is kept in sync with the input through a DataTransfer
  * object so the browser submits exactly the files still listed.
  *
+ * Submit gating is coordinated once per form: every direct widget on the same
+ * form shares one submit listener, so an idle widget cannot permanently block
+ * the form while another widget still has pending or failed uploads. When the
+ * Uppy bundle fails to load, the widget falls back to a classic file input
+ * instead of leaving the form silently unusable.
+ *
  * The signing endpoint (POST /_uploads/sign/) enforces auth, extension
  * allowlist and size caps server-side; the restrictions below are UX only.
  */
@@ -37,6 +43,9 @@
   'use strict';
 
   var SIGN_URL = '/_uploads/sign/';
+
+  // One submit listener per form, coordinating all direct widgets on it.
+  var formStates = new WeakMap();
 
   function csrfToken() {
     var match = document.cookie.match(/csrftoken=([^;]+)/);
@@ -89,6 +98,62 @@
     }
   }
 
+  function showStatus(root, message) {
+    var status = root.querySelector('.django-uppy-status');
+    if (!status) {
+      status = document.createElement('div');
+      status.className = 'django-uppy-status';
+      status.setAttribute('role', 'status');
+      status.setAttribute('aria-live', 'polite');
+      root.appendChild(status);
+    }
+    status.textContent = message;
+  }
+
+  function submitButtons(form) {
+    return form.querySelectorAll('button[type="submit"], input[type="submit"]');
+  }
+
+  function formBlocking(state) {
+    return state.widgets.some(function (widget) {
+      return widget.pendingIds.size > 0 || widget.failedIds.size > 0;
+    });
+  }
+
+  function setFormSubmittable(state, enabled) {
+    submitButtons(state.form).forEach(function (button) {
+      button.disabled = !enabled;
+    });
+  }
+
+  function handleFormSubmit(event, state) {
+    if (state.submitted || formBlocking(state)) {
+      event.preventDefault();
+      if (!state.submitted) {
+        state.widgets.forEach(function (widget) {
+          if (widget.pendingIds.size > 0 || widget.failedIds.size > 0) {
+            widget.showStatus('Vänta tills uppladdningen är klar, eller åtgärda fel innan du sparar.');
+          }
+        });
+      }
+      return;
+    }
+    state.submitted = true;
+    setFormSubmittable(state, false);
+  }
+
+  function getFormState(form) {
+    var state = formStates.get(form);
+    if (!state) {
+      state = { form: form, widgets: [], submitted: false };
+      formStates.set(form, state);
+      form.addEventListener('submit', function (event) {
+        handleFormSubmit(event, state);
+      });
+    }
+    return state;
+  }
+
   function signFile(uppy, file, options) {
     var body = new URLSearchParams();
     body.append('scope', options.scope);
@@ -138,7 +203,7 @@
   function initDirect(root) {
     var form = root.closest('form');
     var name = root.dataset.uppyName;
-    if (!form || !name || typeof window.Uppy === 'undefined') return;
+    if (!form || !name) return;
 
     var hidden = form.elements[name];
     if (!hidden) return;
@@ -153,6 +218,16 @@
       multi: root.dataset.uppyMulti !== 'false',
       compress: root.dataset.uppyCompress === 'true',
     };
+
+    var missingPlugins =
+      !window.Uppy ||
+      !window.Uppy.AwsS3 ||
+      !window.Uppy.Dashboard ||
+      (options.compress && !window.Uppy.Compressor);
+    if (missingPlugins) {
+      classicFallback(root, 'Direktuppladdningen kunde inte laddas in, använd filväljaren nedan istället.');
+      return;
+    }
 
     var maxBytes = parseInt(root.dataset.uppyMaxBytes || '0', 10) || null;
     var allowedExtensions = (root.dataset.uppyAllowedExtensions || '')
@@ -205,20 +280,18 @@
     var uploaded = parsePayload(hidden.value);
     var pendingIds = new Set();
     var failedIds = new Set();
-    var submitting = false;
-
-    function submitButtons() {
-      return form.querySelectorAll('button[type="submit"], input[type="submit"]');
-    }
-
-    function setSubmittable(enabled) {
-      submitButtons().forEach(function (button) {
-        button.disabled = !enabled;
-      });
-    }
+    var state = getFormState(form);
+    var widget = {
+      pendingIds: pendingIds,
+      failedIds: failedIds,
+      showStatus: function (message) {
+        showStatus(root, message);
+      },
+    };
+    state.widgets.push(widget);
 
     function refresh() {
-      setSubmittable(pendingIds.size === 0 && failedIds.size === 0);
+      setFormSubmittable(state, !formBlocking(state));
     }
 
     function renderUploaded() {
@@ -251,18 +324,6 @@
       writePayload();
     }
 
-    function showStatus(message) {
-      var status = root.querySelector('.django-uppy-status');
-      if (!status) {
-        status = document.createElement('div');
-        status.className = 'django-uppy-status';
-        status.setAttribute('role', 'status');
-        status.setAttribute('aria-live', 'polite');
-        root.appendChild(status);
-      }
-      status.textContent = message;
-    }
-
     function payloadEntry(file) {
       return {
         key: file.meta.uploadKey,
@@ -278,8 +339,14 @@
     });
 
     uppy.on('file-added', function (file) {
+      if (!options.multi && uploaded.length > 0) {
+        // Single-file widget: a replacement upload drops the previous entry
+        // so the payload never holds two files.
+        uploaded = [];
+        writePayload();
+      }
       pendingIds.add(file.id);
-      showStatus('');
+      showStatus(root, '');
       refresh();
     });
 
@@ -299,7 +366,7 @@
     uppy.on('upload-error', function (file) {
       pendingIds.delete(file.id);
       failedIds.add(file.id);
-      showStatus('En fil kunde inte laddas upp. Ta bort den eller försök igen innan du sparar.');
+      showStatus(root, 'En fil kunde inte laddas upp. Ta bort den eller försök igen innan du sparar.');
       refresh();
     });
 
@@ -331,23 +398,40 @@
       writePayload();
       refresh();
       if (failedIds.size > 0) {
-        showStatus('Vissa filer kunde inte laddas upp. Ta bort dem eller försök igen innan du sparar.');
+        showStatus(root, 'Vissa filer kunde inte laddas upp. Ta bort dem eller försök igen innan du sparar.');
       }
-    });
-
-    form.addEventListener('submit', function (event) {
-      if (submitting || pendingIds.size > 0 || failedIds.size > 0) {
-        event.preventDefault();
-        if (!submitting) {
-          showStatus('Vänta tills uppladdningen är klar, eller åtgärda fel innan du sparar.');
-        }
-        return;
-      }
-      submitting = true;
-      setSubmittable(false);
     });
 
     renderUploaded();
+  }
+
+  function classicFallback(root, message) {
+    // Uppy assets failed to load (or plugins are missing): replace the empty
+    // dashboard with a classic file input so the form stays usable. The
+    // server already accepts multipart files from the direct widget.
+    var mount = root.querySelector('[data-uppy-mount]');
+    var uploadedList = root.querySelector('[data-uppy-uploaded]');
+    if (mount) mount.style.display = 'none';
+    if (uploadedList) uploadedList.style.display = 'none';
+
+    var input = document.createElement('input');
+    input.type = 'file';
+    input.name = root.dataset.uppyName;
+    input.className = 'django-uppy-fallback';
+    if (root.dataset.uppyMulti !== 'false') {
+      input.multiple = true;
+    }
+
+    var list = document.createElement('ul');
+    list.className = 'django-uppy-files';
+    list.dataset.uppySelected = '1';
+    root.appendChild(input);
+    root.appendChild(list);
+
+    if (message) {
+      showStatus(root, message);
+    }
+    initClassic(root);
   }
 
   function initClassic(root) {

--- a/static/common/uploads/js/upload-init.js
+++ b/static/common/uploads/js/upload-init.js
@@ -1,17 +1,34 @@
 /**
- * Uppy direct-to-storage upload wiring for DaTe Website.
+ * Upload widget wiring for DaTe Website (direct Uppy mode + classic mode).
  *
  * Expected DOM (rendered by core.upload_widgets.DirectUploadWidget):
  *
- *   <div class="django-uppy-widget" data-uppy-widget="1" data-uppy-scope="..."
- *        data-uppy-bucket="..." data-uppy-multi="true|false"
- *        data-uppy-compress="true|false" data-uppy-name="..." ...></div>
+ * Direct mode:
+ *
+ *   <div class="django-uppy-widget" data-uppy-widget="1" data-uppy-mode="direct"
+ *        data-uppy-scope="..." data-uppy-bucket="..." data-uppy-multi="true|false"
+ *        data-uppy-compress="true|false" data-uppy-name="..." ...>
+ *     <div data-uppy-mount="1"></div>
+ *     <ul class="django-uppy-files" data-uppy-uploaded="1"></ul>
+ *   </div>
  *   <input type="hidden" name="..." value="...">
  *
  * On upload completion the JSON payload [{key, name, size}, ...] is written
  * into the sibling hidden input; the Django form parses it on submit. The
  * payload is updated on success and removal, and the form is blocked while
- * uploads are pending or failed.
+ * uploads are pending or failed. The "uploaded" list is rehydrated from the
+ * hidden input on load, so already-uploaded temp files stay visible and
+ * removable across reloads and validation errors.
+ *
+ * Classic mode (direct uploads disabled):
+ *
+ *   <div class="django-uppy-widget" data-uppy-widget="1" data-uppy-mode="classic">
+ *     <input type="file" ...>
+ *     <ul class="django-uppy-files" data-uppy-selected="1"></ul>
+ *   </div>
+ *
+ * The selected-file list is kept in sync with the input through a DataTransfer
+ * object so the browser submits exactly the files still listed.
  *
  * The signing endpoint (POST /_uploads/sign/) enforces auth, extension
  * allowlist and size caps server-side; the restrictions below are UX only.
@@ -51,6 +68,27 @@
     return deviceMemoryGB() >= 4 ? Infinity : 3;
   }
 
+  function formatSize(bytes) {
+    if (!bytes && bytes !== 0) return '';
+    if (bytes < 1024) return bytes + ' B';
+    var units = ['KB', 'MB', 'GB'];
+    var i = -1;
+    do {
+      bytes /= 1024;
+      i += 1;
+    } while (bytes >= 1024 && i < units.length - 1);
+    return bytes.toFixed(1) + ' ' + units[i];
+  }
+
+  function parsePayload(raw) {
+    try {
+      var parsed = JSON.parse(raw || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      return [];
+    }
+  }
+
   function signFile(uppy, file, options) {
     var body = new URLSearchParams();
     body.append('scope', options.scope);
@@ -77,13 +115,37 @@
     });
   }
 
-  function initWidget(root) {
+  function fileRow(file) {
+    var li = document.createElement('li');
+    li.className = 'django-uppy-file';
+    var name = document.createElement('span');
+    name.className = 'django-uppy-name';
+    name.textContent = file.name;
+    var size = document.createElement('span');
+    size.className = 'django-uppy-size';
+    size.textContent = formatSize(file.size);
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'django-uppy-remove';
+    button.textContent = '\u00d7';
+    button.setAttribute('aria-label', 'Ta bort ' + file.name);
+    li.appendChild(name);
+    li.appendChild(size);
+    li.appendChild(button);
+    return li;
+  }
+
+  function initDirect(root) {
     var form = root.closest('form');
     var name = root.dataset.uppyName;
-    if (!form || !name) return;
+    if (!form || !name || typeof window.Uppy === 'undefined') return;
 
     var hidden = form.elements[name];
     if (!hidden) return;
+
+    var mount = root.querySelector('[data-uppy-mount]');
+    var uploadedList = root.querySelector('[data-uppy-uploaded]');
+    if (!mount || !uploadedList) return;
 
     var options = {
       scope: root.dataset.uppyScope || 'admin',
@@ -100,7 +162,7 @@
         return '.' + ext.trim();
       });
 
-    var Core = Uppy.Uppy || Uppy;
+    var Core = window.Uppy.Uppy || window.Uppy;
     var uppy = new Core({
       autoProceed: true,
       limit: uploadLimit(),
@@ -114,7 +176,7 @@
     if (options.compress) {
       // Matches the server-side behaviour gallery photos used to apply:
       // downscale to 1600px wide, JPEG quality 60, before upload.
-      uppy.use(Uppy.Compressor, {
+      uppy.use(window.Uppy.Compressor, {
         quality: 0.6,
         maxWidth: 1600,
         limit: compressionLimit(),
@@ -124,23 +186,23 @@
       });
     }
 
-    uppy.use(Uppy.AwsS3, {
+    uppy.use(window.Uppy.AwsS3, {
       shouldUseMultipart: false,
       getUploadParameters: function (file) {
         return signFile(uppy, file, options);
       },
     });
 
-    uppy.use(Uppy.Dashboard, {
+    uppy.use(window.Uppy.Dashboard, {
       inline: true,
-      target: root,
+      target: mount,
       height: options.multi ? 300 : 200,
       hideUploadButton: true,
       proudlyDisplayPoweredByUppy: false,
       showProgressDetails: true,
     });
 
-    var uploaded = [];
+    var uploaded = parsePayload(hidden.value);
     var pendingIds = new Set();
     var failedIds = new Set();
     var submitting = false;
@@ -159,8 +221,34 @@
       setSubmittable(pendingIds.size === 0 && failedIds.size === 0);
     }
 
+    function renderUploaded() {
+      uploadedList.textContent = '';
+      uploaded.forEach(function (entry) {
+        if (!entry || typeof entry !== 'object') return;
+        var li = fileRow(entry);
+        var button = li.querySelector('.django-uppy-remove');
+        button.dataset.uppyRemoveKey = entry.key;
+        li.dataset.uppyKey = entry.key;
+        uploadedList.appendChild(li);
+      });
+    }
+
     function writePayload() {
       hidden.value = JSON.stringify(uploaded);
+      renderUploaded();
+    }
+
+    function removeByKey(key) {
+      uploaded = uploaded.filter(function (entry) {
+        return entry.key !== key;
+      });
+      // Best effort: drop the matching in-dashboard file (if any) too.
+      uppy.getFiles().forEach(function (file) {
+        if (file.meta && file.meta.uploadKey === key) {
+          uppy.removeFile(file.id);
+        }
+      });
+      writePayload();
     }
 
     function showStatus(message) {
@@ -182,6 +270,12 @@
         size: file.size,
       };
     }
+
+    uploadedList.addEventListener('click', function (event) {
+      var button = event.target.closest('[data-uppy-remove-key]');
+      if (!button) return;
+      removeByKey(button.dataset.uppyRemoveKey);
+    });
 
     uppy.on('file-added', function (file) {
       pendingIds.add(file.id);
@@ -252,6 +346,48 @@
       submitting = true;
       setSubmittable(false);
     });
+
+    renderUploaded();
+  }
+
+  function initClassic(root) {
+    var input = root.querySelector('input[type="file"]');
+    var list = root.querySelector('[data-uppy-selected]');
+    if (!input || !list) return;
+
+    function renderSelected() {
+      list.textContent = '';
+      Array.prototype.forEach.call(input.files, function (file, index) {
+        var li = fileRow(file);
+        var button = li.querySelector('.django-uppy-remove');
+        button.dataset.uppyRemoveIndex = String(index);
+        list.appendChild(li);
+      });
+    }
+
+    list.addEventListener('click', function (event) {
+      var button = event.target.closest('[data-uppy-remove-index]');
+      if (!button || typeof window.DataTransfer === 'undefined') return;
+      var index = parseInt(button.dataset.uppyRemoveIndex, 10);
+      if (Number.isNaN(index)) return;
+      var dt = new DataTransfer();
+      Array.prototype.forEach.call(input.files, function (file, i) {
+        if (i !== index) dt.items.add(file);
+      });
+      input.files = dt.files;
+      renderSelected();
+    });
+
+    input.addEventListener('change', renderSelected);
+    renderSelected();
+  }
+
+  function initWidget(root) {
+    if (root.dataset.uppyMode === 'classic') {
+      initClassic(root);
+    } else {
+      initDirect(root);
+    }
   }
 
   function init() {

--- a/templates/common/archive/exam_upload.html
+++ b/templates/common/archive/exam_upload.html
@@ -10,9 +10,7 @@
   <link rel="stylesheet"
         href="{% static 'archive/css/document.css' %}"
         type="text/css">
-  {% if DIRECT_UPLOADS_ENABLED %}
-    {% include 'uploads/_uppy_assets.html' %}
-  {% endif %}
+  {% include 'uploads/_uppy_assets.html' %}
 {% endblock %}
 {% block content %}
   <div class="container-md min-vh-100 container-margin-top p-1">

--- a/templates/common/archive/upload.html
+++ b/templates/common/archive/upload.html
@@ -10,9 +10,7 @@
   <link rel="stylesheet"
         href="{% static 'archive/css/style.css' %}"
         type="text/css">
-  {% if DIRECT_UPLOADS_ENABLED %}
-    {% include 'uploads/_uppy_assets.html' %}
-  {% endif %}
+  {% include 'uploads/_uppy_assets.html' %}
 {% endblock %}
 {% block content %}
   <div class="container-md min-vh-100 container-margin-top">

--- a/templates/common/uploads/_uppy_assets.html
+++ b/templates/common/uploads/_uppy_assets.html
@@ -1,11 +1,16 @@
 {% load static %}
 <link rel="stylesheet"
-      href="https://releases.transloadit.com/uppy/v5.2.4/uppy.min.css"
-      integrity="sha384-NzIdpCBvjrLNO5q++7oATl82kfw2215yoGwNXl2rBMEJUgfDnr8ARb5Cun15j4Fl"
-      crossorigin="anonymous"
+      href="{% static 'uploads/css/upload-widget.css' %}"
       type="text/css">
-<script src="https://releases.transloadit.com/uppy/v5.2.4/uppy.min.js"
-        integrity="sha384-hl+zw0fpZ6cVAtnkwy96IFC3oGXSYqe8O8yMtUiSKhfHXST3vg5wvbieKwocAzM9"
+<script src="{% static 'uploads/js/upload-init.js' %}" defer></script>
+{% if DIRECT_UPLOADS_ENABLED %}
+  <link rel="stylesheet"
+        href="https://releases.transloadit.com/uppy/v5.2.4/uppy.min.css"
+        integrity="sha384-NzIdpCBvjrLNO5q++7oATl82kfw2215yoGwNXl2rBMEJUgfDnr8ARb5Cun15j4Fl"
         crossorigin="anonymous"
-        defer></script>
-<script src="{% static 'uploads/js/uppy-init.js' %}" defer></script>
+        type="text/css">
+  <script src="https://releases.transloadit.com/uppy/v5.2.4/uppy.min.js"
+          integrity="sha384-hl+zw0fpZ6cVAtnkwy96IFC3oGXSYqe8O8yMtUiSKhfHXST3vg5wvbieKwocAzM9"
+          crossorigin="anonymous"
+          defer></script>
+{% endif %}


### PR DESCRIPTION
## What

The upload widget now shows which files are already uploaded (direct mode) or selected (classic mode) and lets the user remove individual entries before saving. This fixes the confusing flow where files disappeared from view after being dropped into Uppy, and could not be managed after a reload or validation error.

## Changes

- **Direct mode**: the uploaded-file list is rehydrated from the hidden payload on every render, so temp uploads stay visible and removable across reloads and validation errors; removing an entry drops it from the payload (the temp object is left for the bucket lifecycle rule).
- **Classic mode** (sites without direct uploads): the file input is wrapped in a container that lists selected files with remove buttons, keeping `input.files` authoritative via `DataTransfer`.
- **Assets**: widget CSS/JS load on every page using `DirectUploadField`; the Uppy CDN bundle loads only when direct uploads are enabled.
- **Robustness**: submit gating is coordinated once per form across all widgets (an idle widget can no longer permanently block submission while another widget is uploading); if the Uppy bundle fails to load, the widget falls back to a classic file input with a status message.
- `uppy-init.js` becomes `upload-init.js` and serves both modes.

The widget only manages temp uploads; files already attached to model rows stay managed by the admin inlines.

## Tests

`core/tests/test_smoke_uploads.py` and `core/tests/test_uploads.py` updated/expanded (direct markup, payload round-trip, classic markup). Full suite: 547 tests pass. `ruff`, `ruff format --check`, `djlint`, `mypy` clean.

Client-side behavior (per-form gating, CDN-failure fallback) has no automated JS coverage; this repo has no JS test harness. Worth a manual smoke test on an admin album page and the public upload page.

## Docs

`docs/dev/uploads.md`, `docs/admin/{archive,exambank,gallery}.md` updated.