### PR TITLE
fix: remove SF partner CTA and keep partner ads at the top of the right column

### DIFF
--- a/static/biocum/date/css/homepage.css
+++ b/static/biocum/date/css/homepage.css
@@ -169,9 +169,7 @@
     grid-template-columns: 1fr 850px 350px 1fr;
     grid-template-rows: auto;
     grid-template-areas: 
-      ". news sidebar ."
-      ". news sidebar ."
-      ". ig-scroll ig-scroll .";
+      ". news sidebar .";
     grid-column-gap: 3vw;
     align-items: start;
 }

--- a/static/kk/date/css/homepage.css
+++ b/static/kk/date/css/homepage.css
@@ -119,11 +119,14 @@
     grid-template-columns: 1fr 850px 350px 1fr;
     grid-template-rows: auto;
     grid-template-areas: 
-      ". news events ."
-      ". news logos ."
+      ". news sidebar ."
       ". ig-scroll ig-scroll .";
     grid-column-gap: 3vw;
     align-items: start;
+}
+
+.sidebar-container {
+    grid-area: sidebar;
 }
 
 .text-size{
@@ -538,6 +541,10 @@ div.scroll-content img{
           ". news ."
           ". logos ."
           ". ig-scroll .";
+    }
+
+    .sidebar-container {
+        display: contents;
     }
 
 }

--- a/static/sf/date/css/homepage.css
+++ b/static/sf/date/css/homepage.css
@@ -175,12 +175,13 @@
     grid-template-columns: 1fr 850px 350px 1fr;
     grid-template-rows: auto;
     grid-template-areas: 
-      ". news events ."
-      ". news extras ."
-      ". news logos ."
-      ". ig-scroll ig-scroll .";
+      ". news sidebar .";
     grid-column-gap: 3vw;
     align-items: start;
+}
+
+.sidebar-container {
+    grid-area: sidebar;
 }
 
 .text-size{
@@ -647,6 +648,10 @@ div.calendar-container a {
           ". extras ."
           ". logos ."
           ". ig-scroll .";
+    }
+
+    .sidebar-container {
+        display: contents;
     }
 
     .partner-sidebar {

--- a/static/sf/date/css/homepage.css
+++ b/static/sf/date/css/homepage.css
@@ -600,18 +600,6 @@ div.calendar-container a {
     object-fit: contain;
 }
 
-.partner-cta {
-    display: block;
-    color: var(--linkColorDark);
-    margin-top: 0.9rem;
-    text-align: center;
-    font-weight: 600;
-}
-
-.partner-cta:hover {
-    color: var(--linkColorDarkHover);
-}
-
 /*Logos end*/
 
 /* Generic animations*/

--- a/templates/kk/date/start.html
+++ b/templates/kk/date/start.html
@@ -26,8 +26,10 @@
     <section id="news" class="news-events">
       <div id="main" class="main-container">
         {% include "date/components/news.html" %}
-        {% include "date/components/events.html" %}
-        {% include "date/components/partners.html" %}
+        <div class="sidebar-container">
+          {% include "date/components/events.html" %}
+          {% include "date/components/partners.html" %}
+        </div>
         {% include "date/components/instagram.html" %}
       </div>
     </section>

--- a/templates/sf/date/components/partners.html
+++ b/templates/sf/date/components/partners.html
@@ -1,4 +1,4 @@
-{% load static i18n localized_urls %}
+{% load static i18n %}
 <aside class="logo-container partner-sidebar"
        aria-labelledby="partner-heading">
   <h3 id="partner-heading" class="header-border-bottom">{% trans "Samarbetspartners" %}</h3>
@@ -23,6 +23,4 @@
       {% endif %}
     {% endfor %}
   </div>
-  <a class="partner-cta"
-     href="{{ '/pages/foretagssamarbete/'|localized_url }}">{% trans "Vill du samarbeta med SF-klubben?" %}</a>
 </aside>

--- a/templates/sf/date/start.html
+++ b/templates/sf/date/start.html
@@ -36,9 +36,11 @@
     <section id="news" class="news-events">
       <div id="main" class="main-container">
         {% include "date/components/news.html" %}
-        {% include "date/components/events.html" %}
-        {% include "date/components/extras.html" %}
-        {% include "date/components/partners.html" %}
+        <div class="sidebar-container">
+          {% include "date/components/events.html" %}
+          {% include "date/components/extras.html" %}
+          {% include "date/components/partners.html" %}
+        </div>
       </div>
     </section>
     <section id="reklam" class="text-size">


### PR DESCRIPTION
## Summary

Two fixes:

1. **Remove SF partner CTA**: drops the "Vill du samarbeta med SF-klubben?" link from the SF homepage partners box, along with the now-unused `.partner-cta` CSS rules.

2. **Keep partner ads at the top of the right column on desktop**: on SF, kk, and biocum the partner ads sit in the right column but render very low on the page. The `news` item spans multiple grid rows, so CSS grid distributes the tall news content across those rows and each row grows to a share of it, pushing `extras`/`logos` (and their ads) far down. The right column is now wrapped in a `sidebar-container` (the same pattern demo and biocum already use) so events, extras, and partner ads stack compactly at the top of the row, next to the news feed. On mobile, `display: contents` restores the original per-item grid areas, so mobile layout is unchanged.

## Changes

- `templates/sf/date/components/partners.html`: removed CTA link and unused `localized_urls` load
- `static/sf/date/css/homepage.css`: removed `.partner-cta` rules; desktop grid now `. news sidebar .`; `.sidebar-container` added with `display: contents` on mobile
- `templates/sf/date/start.html`, `templates/kk/date/start.html`: right-column includes wrapped in `sidebar-container`
- `static/kk/date/css/homepage.css`: desktop grid now `. news sidebar .` + ig-scroll row; `.sidebar-container` with `display: contents` on mobile
- `static/biocum/date/css/homepage.css`: desktop grid reduced to a single `. news sidebar .` row (ig-scroll row removed; no such element exists)

The full-width bottom-strip associations (date, demo, impuls, pulterit) are intentionally unchanged.

## Checks

- `djlint --check` on changed templates: pass
- `git diff --check`: pass
- Reviewed by review agent: approve