### PR TITLE
fix: Impuls harassment texts, drop joke section

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2111,21 +2111,19 @@ msgid "Rapportera trakasserier"
 msgstr "Report harassment"
 
 #: templates/impuls/social/harassment_form.html:3
-#, python-format
 msgid ""
 "Du kan rapportera trakasserier antingen anonymt eller ange din "
 "kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
 "att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
-"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
-"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
-"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+"alla medlemmar. Impuls trygghetspersoner behandlar alla rapporteringar av "
+"trakasserier och tar kontakt till Impuls styrelse och/eller ÅAS "
+"trakasseriombud om det så önskas."
 msgstr ""
 "You can report harassment anonymously or by providing your contact "
 "information. We take all forms of harassment seriously and will act to "
-"maintain a safe and respectful environment for all members. "
-"%(association_name)ss safety contacts handle all harassment reports and can "
-"contact the %(association_short)ss board and/or the student union harassment "
-"contacts if requested."
+"maintain a safe and respectful environment for all members. Impuls safety "
+"contacts handle all harassment reports and can contact Impuls board and/or "
+"the student union harassment contacts if requested."
 
 #: templates/common/social/harassment_form.html:26
 msgid "Ange din Email om du vill bli kontaktad"
@@ -2257,7 +2255,7 @@ msgstr ""
 
 #: templates/impuls/date/components/extras.html:6
 msgid ""
-"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+"Om du upplever trakasserier i samband med Impuls verksamhet, vänligen"
 msgstr ""
 "If you encounter harassment during the activity of Impuls, please"
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2106,6 +2106,27 @@ msgstr ""
 "and can contact the %(association_short)ss board and/or the student union "
 "harassment contacts if requested."
 
+#: templates/impuls/social/harassment_form.html:1
+msgid "Rapportera trakasserier"
+msgstr "Report harassment"
+
+#: templates/impuls/social/harassment_form.html:3
+#, python-format
+msgid ""
+"Du kan rapportera trakasserier antingen anonymt eller ange din "
+"kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
+"att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
+"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
+"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
+"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+msgstr ""
+"You can report harassment anonymously or by providing your contact "
+"information. We take all forms of harassment seriously and will act to "
+"maintain a safe and respectful environment for all members. "
+"%(association_name)ss safety contacts handle all harassment reports and can "
+"contact the %(association_short)ss board and/or the student union harassment "
+"contacts if requested."
+
 #: templates/common/social/harassment_form.html:26
 msgid "Ange din Email om du vill bli kontaktad"
 msgstr "Input your email in case you want to be contacted"
@@ -2233,6 +2254,12 @@ msgstr ""
 "this via the website. We take all forms of harrasment very seriously and "
 "will take the necessary steps for ensuring a safe and respectful environment "
 "for all members."
+
+#: templates/impuls/date/components/extras.html:6
+msgid ""
+"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+msgstr ""
+"If you encounter harassment during the activity of Impuls, please"
 
 #: templates/date/date/components/header.html:8
 msgid "Datateknologerna"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2122,21 +2122,20 @@ msgid "Rapportera trakasserier"
 msgstr "Ilmoita häirinnästä"
 
 #: templates/impuls/social/harassment_form.html:3
-#, python-format
 msgid ""
 "Du kan rapportera trakasserier antingen anonymt eller ange din "
 "kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
 "att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
-"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
-"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
-"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+"alla medlemmar. Impuls trygghetspersoner behandlar alla rapporteringar av "
+"trakasserier och tar kontakt till Impuls styrelse och/eller ÅAS "
+"trakasseriombud om det så önskas."
 msgstr ""
 "Voit ilmoittaa häirinnästä joko anonyymisti tai antamalla yhteystietosi. "
 "Suhtaudumme kaikkeen häirintään vakavasti ja ryhdymme toimiin turvallisen ja "
-"kunnioittavan ympäristön ylläpitämiseksi kaikille jäsenille. "
-"%(association_name)ss turvallisuushenkilöt käsittelevät kaikki "
-"häirintäilmoitukset ja ottavat haluttaessa yhteyttä %(association_short)ss "
-"hallitukseen ja/tai ÅAS:n häirintäyhdyshenkilöihin."
+"kunnioittavan ympäristön ylläpitämiseksi kaikille jäsenille. Impulssin "
+"turvallisuushenkilöt käsittelevät kaikki häirintäilmoitukset ja ottavat "
+"haluttaessa yhteyttä Impulssin hallitukseen ja/tai ÅAS:n "
+"häirintäyhdyshenkilöihin."
 
 #: templates/common/social/harassment_form.html:26
 msgid "Ange din Email om du vill bli kontaktad"
@@ -2269,7 +2268,7 @@ msgstr ""
 
 #: templates/impuls/date/components/extras.html:6
 msgid ""
-"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+"Om du upplever trakasserier i samband med Impuls verksamhet, vänligen"
 msgstr ""
 "Jos koet epäasiallista käytöstä Impulssin toiminnan aikana, voit"
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2117,6 +2117,27 @@ msgstr ""
 "haluttaessa yhteyttä %(association_short)ss hallitukseen ja/tai ÅAS:n "
 "häirintäyhdyshenkilöihin."
 
+#: templates/impuls/social/harassment_form.html:1
+msgid "Rapportera trakasserier"
+msgstr "Ilmoita häirinnästä"
+
+#: templates/impuls/social/harassment_form.html:3
+#, python-format
+msgid ""
+"Du kan rapportera trakasserier antingen anonymt eller ange din "
+"kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
+"att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
+"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
+"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
+"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+msgstr ""
+"Voit ilmoittaa häirinnästä joko anonyymisti tai antamalla yhteystietosi. "
+"Suhtaudumme kaikkeen häirintään vakavasti ja ryhdymme toimiin turvallisen ja "
+"kunnioittavan ympäristön ylläpitämiseksi kaikille jäsenille. "
+"%(association_name)ss turvallisuushenkilöt käsittelevät kaikki "
+"häirintäilmoitukset ja ottavat haluttaessa yhteyttä %(association_short)ss "
+"hallitukseen ja/tai ÅAS:n häirintäyhdyshenkilöihin."
+
 #: templates/common/social/harassment_form.html:26
 msgid "Ange din Email om du vill bli kontaktad"
 msgstr "Anna sähköpostiosoitteesi, jos haluat että sinuun otetaan yhteyttä"
@@ -2245,6 +2266,12 @@ msgstr ""
 "asiasta verkkosivumme kautta. Suhtaudumme kaikenlaisen epäasiallisen "
 "käytöksen kohtaan vakavasti ja ryhdymme toimiin ylläpitääksemme turvallista "
 "ja kunnioittavaa ympäristöä kaikille jäsenille."
+
+#: templates/impuls/date/components/extras.html:6
+msgid ""
+"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+msgstr ""
+"Jos koet epäasiallista käytöstä Impulssin toiminnan aikana, voit"
 
 #: templates/date/date/components/header.html:8
 msgid "Datateknologerna"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2110,6 +2110,27 @@ msgstr ""
 "kontakt till %(association_short)ss styrelse och/eller ÅAS trakasseriombud "
 "om det så önskas."
 
+#: templates/impuls/social/harassment_form.html:1
+msgid "Rapportera trakasserier"
+msgstr "Rapportera trakasserier"
+
+#: templates/impuls/social/harassment_form.html:3
+#, python-format
+msgid ""
+"Du kan rapportera trakasserier antingen anonymt eller ange din "
+"kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
+"att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
+"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
+"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
+"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+msgstr ""
+"Du kan rapportera trakasserier antingen anonymt eller ange din "
+"kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
+"att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
+"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
+"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
+"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+
 #: templates/common/social/harassment_form.html:26
 msgid "Ange din Email om du vill bli kontaktad"
 msgstr "Ange din Email om du vill bli kontaktad"
@@ -2241,6 +2262,12 @@ msgstr ""
 "detta via hemsidan. Vi tar alla former av trakasserier på allvar och kommer "
 "att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
 "alla medlemmar."
+
+#: templates/impuls/date/components/extras.html:6
+msgid ""
+"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+msgstr ""
+"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
 
 #: templates/date/date/components/header.html:8
 msgid "Datateknologerna"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2115,21 +2115,20 @@ msgid "Rapportera trakasserier"
 msgstr "Rapportera trakasserier"
 
 #: templates/impuls/social/harassment_form.html:3
-#, python-format
 msgid ""
 "Du kan rapportera trakasserier antingen anonymt eller ange din "
 "kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
 "att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
-"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
-"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
-"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+"alla medlemmar. Impuls trygghetspersoner behandlar alla rapporteringar av "
+"trakasserier och tar kontakt till Impuls styrelse och/eller ÅAS "
+"trakasseriombud om det så önskas."
 msgstr ""
 "Du kan rapportera trakasserier antingen anonymt eller ange din "
 "kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer "
 "att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för "
-"alla medlemmar. %(association_name)ss trygghetspersoner behandlar alla "
-"rapporteringar av trakasserier och tar kontakt till %(association_short)ss "
-"styrelse och/eller ÅAS trakasseriombud om det så önskas."
+"alla medlemmar. Impuls trygghetspersoner behandlar alla rapporteringar av "
+"trakasserier och tar kontakt till Impuls styrelse och/eller ÅAS "
+"trakasseriombud om det så önskas."
 
 #: templates/common/social/harassment_form.html:26
 msgid "Ange din Email om du vill bli kontaktad"
@@ -2265,9 +2264,9 @@ msgstr ""
 
 #: templates/impuls/date/components/extras.html:6
 msgid ""
-"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+"Om du upplever trakasserier i samband med Impuls verksamhet, vänligen"
 msgstr ""
-"Om du upplever trakasserier i samband med Impulss verksamhet, vänligen"
+"Om du upplever trakasserier i samband med Impuls verksamhet, vänligen"
 
 #: templates/date/date/components/header.html:8
 msgid "Datateknologerna"

--- a/templates/common/social/harassment_form.html
+++ b/templates/common/social/harassment_form.html
@@ -9,12 +9,18 @@
   <div class="container-md min-vh-100 container-margin-top">
     <div class="container-size text-center" style="max-width: 1000px;">
       <div class="content">
-        <h1>{% translate "Rapportera trakasserier och eventuella brister med jämlikhetsplanen" %}</h1>
+        <h1>
+          {% block harassment_title %}
+            {% translate "Rapportera trakasserier och eventuella brister med jämlikhetsplanen" %}
+          {% endblock %}
+        </h1>
         <p>
-          {% blocktranslate with association_name=ASSOCIATION_NAME association_short=ASSOCIATION_NAME_SHORT trimmed %}
-            Du kan rapportera trakasserier och brister i jämlikhetsplanen antingen anonymt eller ange din kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för alla medlemmar.
-            {{ association_name }}s trygghetspersoner behandlar alla rapporteringar av trakasserier och tar kontakt till {{ association_short }}s styrelse och/eller ÅAS trakasseriombud om det så önskas.
-          {% endblocktranslate %}
+          {% block harassment_intro %}
+            {% blocktranslate with association_name=ASSOCIATION_NAME association_short=ASSOCIATION_NAME_SHORT trimmed %}
+              Du kan rapportera trakasserier och brister i jämlikhetsplanen antingen anonymt eller ange din kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för alla medlemmar.
+              {{ association_name }}s trygghetspersoner behandlar alla rapporteringar av trakasserier och tar kontakt till {{ association_short }}s styrelse och/eller ÅAS trakasseriombud om det så önskas.
+            {% endblocktranslate %}
+          {% endblock %}
         </p>
         <form method="post">
           {% csrf_token %}

--- a/templates/impuls/date/components/extras.html
+++ b/templates/impuls/date/components/extras.html
@@ -5,7 +5,7 @@
     <a href="{{ '/social/harassment/'|localized_url }}">{% trans "Trakasseriombud" %}</a>
   </h5>
   <p>
-    {% trans "Om du upplever trakasserier i samband med Impulss verksamhet, vänligen" %}
+    {% trans "Om du upplever trakasserier i samband med Impuls verksamhet, vänligen" %}
     <a href="{% url 'social:harassment' %}">{% trans "rapportera" %}</a>
     {% trans "detta via hemsidan. Vi tar alla former av trakasserier på allvar och kommer att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för alla medlemmar." %}
   </p>

--- a/templates/impuls/date/components/extras.html
+++ b/templates/impuls/date/components/extras.html
@@ -5,10 +5,8 @@
     <a href="{{ '/social/harassment/'|localized_url }}">{% trans "Trakasseriombud" %}</a>
   </h5>
   <p>
-    {% trans "Om du upplever trakasserier i samband med Datateknologernas verksamhet, vänligen" %}
+    {% trans "Om du upplever trakasserier i samband med Impulss verksamhet, vänligen" %}
     <a href="{% url 'social:harassment' %}">{% trans "rapportera" %}</a>
     {% trans "detta via hemsidan. Vi tar alla former av trakasserier på allvar och kommer att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för alla medlemmar." %}
   </p>
-  <h5 id="joke-header">Joke</h5>
-  <p id="joke-string"></p>
 </div>

--- a/templates/impuls/date/components/scripts.html
+++ b/templates/impuls/date/components/scripts.html
@@ -98,31 +98,3 @@
         calendarPopups.init();
     });
 </script>
-<script>
-    if (document.querySelector("#joke-string")) {
-        async function getJoke() {
-            return await fetch("https://icanhazdadjoke.com", {
-                headers: {
-                    "Accept": "application/json"
-                }
-            })
-            .then(response => response.json())
-            .then(function(data) {
-                return data ? data.joke : ""
-            })
-            .catch(function(e) {
-                document.querySelectorAll("#joke-header")
-                    .forEach(function(elem) {
-                        elem.innerText = "";
-                    });
-                return ""
-            }) ||
-            "";
-        }
-        getJoke().then((joke) => {
-            document.querySelectorAll("#joke-string").forEach(function(elem) {
-                elem.innerText = joke;
-            })
-        })
-    }
-</script>

--- a/templates/impuls/social/harassment_form.html
+++ b/templates/impuls/social/harassment_form.html
@@ -4,8 +4,8 @@
   {% translate "Rapportera trakasserier" %}
 {% endblock %}
 {% block harassment_intro %}
-  {% blocktranslate with association_name=ASSOCIATION_NAME association_short=ASSOCIATION_NAME_SHORT trimmed %}
+  {% blocktranslate trimmed %}
     Du kan rapportera trakasserier antingen anonymt eller ange din kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för alla medlemmar.
-    {{ association_name }}s trygghetspersoner behandlar alla rapporteringar av trakasserier och tar kontakt till {{ association_short }}s styrelse och/eller ÅAS trakasseriombud om det så önskas.
+    Impuls trygghetspersoner behandlar alla rapporteringar av trakasserier och tar kontakt till Impuls styrelse och/eller ÅAS trakasseriombud om det så önskas.
   {% endblocktranslate %}
 {% endblock %}

--- a/templates/impuls/social/harassment_form.html
+++ b/templates/impuls/social/harassment_form.html
@@ -1,0 +1,11 @@
+{% extends 'social/harassment_form.html' %}
+{% load i18n %}
+{% block harassment_title %}
+  {% translate "Rapportera trakasserier" %}
+{% endblock %}
+{% block harassment_intro %}
+  {% blocktranslate with association_name=ASSOCIATION_NAME association_short=ASSOCIATION_NAME_SHORT trimmed %}
+    Du kan rapportera trakasserier antingen anonymt eller ange din kontaktinformation. Vi tar alla former av trakasserier på allvar och kommer att vidta åtgärder för att upprätthålla en trygg och respektfull miljö för alla medlemmar.
+    {{ association_name }}s trygghetspersoner behandlar alla rapporteringar av trakasserier och tar kontakt till {{ association_short }}s styrelse och/eller ÅAS trakasseriombud om det så önskas.
+  {% endblocktranslate %}
+{% endblock %}


### PR DESCRIPTION
Fixes for the Impuls site:

- Removed the joke section (h5 + p and the icanhazdadjoke fetch in scripts.html) from the Impuls homepage.
- The harassment sidebar text now refers to "Impuls" instead of "Datateknologerna".
- Added an Impuls-specific harassment form (templates/impuls/social/harassment_form.html) that drops the jämlikhetsplan mention, since Impuls does not have one. The common template gained harassment_title and harassment_intro blocks for the override.
- Added sv/en/fi catalog entries for the new strings.

Checks run: harassment tests, manage.py check, ruff, ruff format --check, djlint --check, compilemessages, validate_translations.py, and a render smoke test of the Impuls harassment form in sv/en/fi. mypy not run (no Python changes).