### PR TITLE
fix: keep PostgreSQL connections alive between requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ DATE_POSTGRESQL_VERSION=16
 # DB password
 DATE_DB_PASSWORD="password"
 
+# How long (seconds) a database connection is kept alive between requests.
+# 0 disables persistent connections.
+DB_CONN_MAX_AGE=600
+
 # [pgAdmin]
 
 # Optional Compose profiles. Set to "pgadmin" to include pgAdmin.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -21,6 +21,10 @@ DATE_IMG_TAG="vX.Y.Z"
 DATE_POSTGRESQL_VERSION=16
 DATE_DB_PASSWORD="replace-with-a-long-random-password"
 
+# How long (seconds) a database connection is kept alive between requests.
+# 0 disables persistent connections.
+DB_CONN_MAX_AGE=600
+
 # [Django]
 
 # Supported variants include: date, kk, biocum, demo, pulterit, sf, impuls

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -243,7 +243,7 @@ DATABASES = {
         # Keep PostgreSQL connections alive between requests to avoid
         # connection setup latency; must live inside the database config.
         'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 600),
-        # Re-verify pooled connections so they survive database restarts.
+        # Re-verify persistent connections so they survive database restarts.
         'CONN_HEALTH_CHECKS': True,
     }
 }

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -240,10 +240,13 @@ DATABASES = {
         'PASSWORD': env_alias('DATE_DB_PASSWORD', 'DB_PASSWORD', default=''),
         'HOST': env('DB_HOST', str, 'db'),
         'PORT': env('DB_PORT', int, 5432),
+        # Keep PostgreSQL connections alive between requests to avoid
+        # connection setup latency; must live inside the database config.
+        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 600),
+        # Re-verify pooled connections so they survive database restarts.
+        'CONN_HEALTH_CHECKS': True,
     }
 }
-
-CONN_MAX_AGE = 600
 
 # Caches
 # https://docs.djangoproject.com/en/5.2/topics/cache/

--- a/core/tests/test_database_settings.py
+++ b/core/tests/test_database_settings.py
@@ -1,0 +1,19 @@
+import importlib
+
+from django.test import SimpleTestCase
+
+
+class DatabaseSettingsTests(SimpleTestCase):
+    """Guards against CONN_MAX_AGE drifting back to a top-level setting.
+
+    Django only honors connection persistence inside each database
+    configuration, so the settings must be verified where they are defined.
+    """
+
+    def test_connection_settings_live_inside_default_database(self):
+        common = importlib.import_module("core.settings.common")
+        default_db = common.DATABASES["default"]
+
+        self.assertIn("CONN_MAX_AGE", default_db)
+        self.assertGreater(default_db["CONN_MAX_AGE"], 0)
+        self.assertTrue(default_db["CONN_HEALTH_CHECKS"])


### PR DESCRIPTION
Closes #1075

## What

`CONN_MAX_AGE` was defined as a top-level setting in `core/settings/common.py`, which Django ignores; it must live inside each database configuration. As written, Gunicorn workers were re-establishing PostgreSQL connections per request.

## Changes

- Move `CONN_MAX_AGE` into `DATABASES["default"]`, env-overridable via `DB_CONN_MAX_AGE` (default 600).
- Enable `CONN_HEALTH_CHECKS` so persistent connections survive database restarts.
- Document `DB_CONN_MAX_AGE` in `.env.example` and `.env.prod.example`.
- Add regression test `core/tests/test_database_settings.py` guarding the placement.

## Verification

- `manage.py check` passes; test suite subset (date app, 79 tests) passes.
- Ruff and mypy clean on changed files.
- Note: PostgreSQL connection headroom across web/ASGI/Celery should be spot-checked at deploy time per the issue; no load test was run in this change.