### PR TITLE
test: run the test suite without db/redis services

### DIFF
--- a/.github/workflows/web_startup.yaml
+++ b/.github/workflows/web_startup.yaml
@@ -118,13 +118,14 @@ jobs:
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose run --rm --no-deps web python scripts/validate_translations.py
           docker-compose run --rm --no-deps web python manage.py compilemessages
-          docker-compose run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test'
+          # Test settings use in-memory SQLite/Channels/cache, so skip service startup.
+          docker-compose run --rm --no-deps -e TEST=1 web python /code/manage.py test
 
       - name: Run tests with Unfold enabled
         run: |
           set -euo pipefail
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
-          docker-compose run -e TEST=1 -e USE_UNFOLD=True web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test'
+          docker-compose run --rm --no-deps -e TEST=1 -e USE_UNFOLD=True web python /code/manage.py test
 
       - name: Build and run Docker Compose
         run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DaTe Website 2.0 powers [Datateknologerna vid Åbo Akademi rf](https://date.abo.
 - Docker 24+ plus the Docker Compose plugin (`docker compose`). Follow Docker's official guides for [Ubuntu](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) or [Debian](https://docs.docker.com/engine/install/debian/#install-using-the-repository) to install both the engine and the Compose plugin.
 - Bash-compatible shell (the helper script `env.sh` defines aliases such as `date-start`)
 - Access to `docker` without sudo (add yourself to the `docker` group if needed)
-- Local `django-admin` (e.g., via `pipx install django`) when editing translations outside the container
+- [uv](https://docs.astral.sh/uv/) for native test, lint, and translation commands outside Docker (install it via `pipx install uv` or the standalone installer). Run `uv sync` once after cloning, then `uv run python manage.py test` and `uv run django-admin makemessages ...` work without containers.
 
 > Windows developers should run the project inside WSL 2 to match the expected Linux tooling: sourcing `env.sh`, running Bash scripts, and keeping LF line endings all work reliably there. Follow Microsoft's [WSL installation guide](https://learn.microsoft.com/windows/wsl/install) first, then install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (which automatically connects Docker to your default WSL distro).
 
@@ -128,16 +128,27 @@ The fixture reset flow uses `scripts/load_all_fixtures.sh` and `scripts/generate
 
 ## Tests & QA
 
-The CI and reviewer expectation is that `python manage.py test` (or the `date-test` alias) passes before you open a pull request. The test settings mock external services, so no Redis or PostgreSQL on the host is required.
+The CI and reviewer expectation is that `python manage.py test` passes before you open a pull request. The test settings mock external services (in-memory SQLite, in-memory Channels, locmem cache), so no Redis or PostgreSQL is required on the host or in the test container.
+
+Two equivalent ways to run the suite:
+
+```bash
+uv sync                       # install dependencies once (native, no Docker)
+uv run python manage.py test  # fast native loop, no containers started
+date-test                     # container parity: same suite inside Docker
+```
 
 Examples:
 
 ```bash
 date-test                   # run the full suite inside Docker
 date-test members.tests     # run a specific module
+uv run python manage.py test events.tests   # specific module, native
 date-manage check           # static checks (migrations, settings sanity)
 uv run python scripts/check_project_variants.py
 ```
+
+The `date-test` alias runs with `--no-deps`, so it does not start the database or Redis services; `date-test` is useful as a parity check when native `uv` dependencies behave differently from the container build.
 
 Manually verify user-facing flows (forms, background jobs, Channels endpoints) when implementing a feature; a lot of work in this repo still benefits from a quick human smoke test after the automated checks pass.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The fixture reset flow uses `scripts/load_all_fixtures.sh` and `scripts/generate
 
 ## Tests & QA
 
-The CI and reviewer expectation is that `python manage.py test` passes before you open a pull request. The test settings mock external services (in-memory SQLite, in-memory Channels, locmem cache), so no Redis or PostgreSQL is required on the host or in the test container.
+The CI and reviewer expectation is that `python manage.py test` passes before you open a pull request. The test settings replace service-backed components with in-memory backends (SQLite, in-memory Channels, locmem cache), so no Redis or PostgreSQL is required on the host or in the test container.
 
 Two equivalent ways to run the suite:
 
@@ -345,7 +345,7 @@ To generate the translation file, called `django.po`
 is done by executing the following command **in the root directory of the project**
 
 ```bash
-$ django-admin makemessages -l en -l fi -l sv
+$ uv run django-admin makemessages -l en -l fi -l sv
 ```
 
 This creates/updates the `django.po` 
@@ -357,7 +357,7 @@ such as `Poedit`.
 To compile the translations to `django.mo`, use the following command
 
 ```bash
-$ django-admin compilemessages
+$ uv run django-admin compilemessages
 ``` 
 
 ### Django modeltranslations (translation of dynamic content)

--- a/docs/dev/translations.md
+++ b/docs/dev/translations.md
@@ -52,12 +52,12 @@ Locale files live here:
 - `locale/en/LC_MESSAGES/djangojs.po`
 - `locale/fi/LC_MESSAGES/djangojs.po`
 
-Common workflow:
+Common workflow (run natively with `uv run` after `uv sync`):
 
 ```bash
-django-admin makemessages -l sv -l en -l fi
-django-admin makemessages -l sv -l en -l fi -d djangojs -i "**/vendor/**" -i "core/static/**"
-django-admin compilemessages
+uv run django-admin makemessages -l sv -l en -l fi
+uv run django-admin makemessages -l sv -l en -l fi -d djangojs -i "**/vendor/**" -i "core/static/**"
+uv run django-admin compilemessages
 ```
 
 What this does:
@@ -258,11 +258,11 @@ When you change translation behavior, cover at least these cases:
 ### Translating static strings
 
 1. Mark strings with Django translation helpers.
-2. Depending on what you are translating, run one or both of:
-    - `django-admin makemessages -l sv -l en -l fi -d djangojs -i "**/vendor/**" -i "core/static/**"` for JavaScript code
-    - `django-admin makemessages -l sv -l en -l fi` for Python code/templates
+2. Depending on what you are translating, run one or both of (via `uv run` for native execution):
+    - `uv run django-admin makemessages -l sv -l en -l fi -d djangojs -i "**/vendor/**" -i "core/static/**"` for JavaScript code
+    - `uv run django-admin makemessages -l sv -l en -l fi` for Python code/templates
 3. Edit the `.po` files.
-4. Run `django-admin compilemessages`.
+4. Run `uv run django-admin compilemessages`.
 5. Smoke-test pages in Swedish and at least one non-default language on the same unprefixed URL.
 
 ### Translating existing model content

--- a/env.sh
+++ b/env.sh
@@ -216,5 +216,8 @@ date-setup() {
 date-test() {
     local project_dir
     project_dir="$(_date_website_project_dir)" || return
-    docker compose --project-directory "$project_dir" run -e TEST=1 web /bin/bash -c './wait-for-postgres.sh db:5432 && python /code/manage.py test "$@"' -- "$@"
+    # Test settings use in-memory SQLite/Channels/cache, so skip database and
+    # Redis service startup entirely. Use `uv run python manage.py test` for an
+    # even faster native loop; this alias is the container parity path.
+    docker compose --project-directory "$project_dir" run --rm --no-deps -e TEST=1 web python /code/manage.py test "$@"
 }


### PR DESCRIPTION
Closes #1076

## What

The test suite uses in-memory SQLite, in-memory Channels, and locmem cache (`core/settings/test.py`), but `date-test` and CI still started PostgreSQL and Redis and waited for the database on every invocation.

## Changes

- `env.sh`: `date-test` now runs `docker compose run --rm --no-deps`, no `wait-for-postgres.sh`.
- `.github/workflows/web_startup.yaml`: both test steps use `--no-deps` and drop the DB wait (translation/validation steps already did).
- `README.md`: document `uv run python manage.py test` as the native fast loop (no containers), `date-test` as container parity; replace the pipx django requirement with uv for translation commands.

## Verification

- `docker compose run --rm --no-deps -e TEST=1 web python /code/manage.py test date.tests`: 79 tests in 2.5s without service startup.