### PR TITLE
perf: run dev migrations and translations once in an init service

### DIFF
--- a/.github/workflows/web_startup.yaml
+++ b/.github/workflows/web_startup.yaml
@@ -94,7 +94,7 @@ jobs:
           if [ "${logged_in}" -eq 1 ]; then
             for attempt in 1 2 3; do
               if docker pull "${CI_IMAGE}"; then
-                printf 'services:\n  web:\n    image: %s\n  celery:\n    image: %s\n' "${CI_IMAGE}" "${CI_IMAGE}" > docker-compose.ci.yml
+                printf 'services:\n  init:\n    image: %s\n  web:\n    image: %s\n  celery:\n    image: %s\n' "${CI_IMAGE}" "${CI_IMAGE}" "${CI_IMAGE}" > docker-compose.ci.yml
                 echo "compose_file=docker-compose.yml:docker-compose.ci.yml" >> "${GITHUB_OUTPUT}"
                 exit 0
               fi

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Once the aliases are registered, the `date-*` commands are the normal way to wor
 
 ## Database, migrations, and seed data
 
+- The dev stack runs migrations and translation compilation once in an `init` service when the stack is first created; the web container starts only after it succeeds. After pulling code with new migrations, run `date-migrate` (or recreate the stack) to apply them.
 - Use `date-makemigrations` and `date-migrate` for schema changes. Commit the generated migration files; do not rewrite published migrations.
 - `date-cleaninit` (alias for `./scripts/clean_init.sh`) drops and recreates the development database volumes, loads the local fixture set, generates sample media, and resets the `admin`, `freshman`, and `member` passwords to `admin`. **All local data will be deleted.**
 - If your shell does not expose aliases, run `/bin/bash ./scripts/clean_init.sh` directly.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Once the aliases are registered, the `date-*` commands are the normal way to wor
 
 ## Database, migrations, and seed data
 
-- The dev stack runs migrations and translation compilation once in an `init` service when the stack is first created; the web container starts only after it succeeds. After pulling code with new migrations, run `date-migrate` (or recreate the stack) to apply them.
+- The dev stack runs migrations and translation compilation once in an `init` service when the stack is first created; the web container starts only after it succeeds. After pulling code with new migrations, run `date-migrate` (or `docker compose down` followed by `date-start`, which recreates `init`) to apply them.
 - Use `date-makemigrations` and `date-migrate` for schema changes. Commit the generated migration files; do not rewrite published migrations.
 - `date-cleaninit` (alias for `./scripts/clean_init.sh`) drops and recreates the development database volumes, loads the local fixture set, generates sample media, and resets the `admin`, `freshman`, and `member` passwords to `admin`. **All local data will be deleted.**
 - If your shell does not expose aliases, run `/bin/bash ./scripts/clean_init.sh` directly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,19 +25,36 @@ services:
       - pgadmin_data:/var/lib/pgadmin
     depends_on:
       - db
+  # Runs once per stack creation: waits for PostgreSQL, migrates, and compiles
+  # translations. The web service starts only after this succeeds.
+  # collectstatic is skipped: debug mode serves static from STATICFILES_DIRS.
+  # After pulling code with new migrations, run `date-migrate` (or recreate the
+  # stack) to apply them.
+  init:
+    env_file: .env
+    build: .
+    restart: "no"
+    command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python manage.py migrate --noinput && python manage.py compilemessages -l en -l fi -l sv --verbosity 0"
+    volumes:
+      - .:/code
+    depends_on:
+      - db
   web:
     env_file: .env
     build: .
     restart: unless-stopped
-    #igSheduler startup command (nohup python /code/social/igupdate.py &) &&
-    command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && python manage.py compilemessages -l en -l fi -l sv && python manage.py collectstatic --noinput && python manage.py runserver 0.0.0.0:8000"
+    command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/code
     ports:
       - ${DATE_DJANGO_PORT}:8000
     depends_on:
-      - db
-      - redis
+      init:
+        condition: service_completed_successfully
+      db:
+        condition: service_started
+      redis:
+        condition: service_started
   celery:
     env_file: .env
     restart: unless-stopped

--- a/docs/dev/operations.md
+++ b/docs/dev/operations.md
@@ -93,13 +93,14 @@ date-all-cleaninit   # reset to fixture data against the dev-all stack
 
 #### How it works
 
-An `init` container runs once on startup — it waits for PostgreSQL, then runs `migrate`, `collectstatic`, and `compilemessages` using `PROJECT_NAME=date`. All web containers wait for `init` to complete before accepting requests.
+An `init` container runs once on startup — it waits for PostgreSQL, then runs `migrate` and `compilemessages` using `PROJECT_NAME=date`. All web containers wait for `init` to complete before accepting requests. `collectstatic` is intentionally skipped: debug mode serves static files directly from each association's `STATICFILES_DIRS` via the WhiteNoise finder.
 
 The `web` service (port 8002) is named `web` specifically so `clean_init.sh` can target it when running `date-all-cleaninit`.
 
 #### Notes
 
-- Static files are collected once by `init` at startup. If you change CSS or JS, restart with `date-all-start` to pick up the changes.
+- Static files are served from source, so CSS/JS edits are picked up without a restart.
+- After pulling code with new migrations, run `date-all-manage migrate` (or `date-migrate` against the standard stack) or recreate the stack, since `init` does not re-run once it has succeeded.
 - The `date-all-cleaninit` alias passes `COMPOSE_FILE_PATH=docker-compose.dev-all.yml` directly to `clean_init.sh` so it targets the dev-all stack.
 
 ## Backups and Database Upgrades

--- a/scripts/clean_init.sh
+++ b/scripts/clean_init.sh
@@ -121,7 +121,7 @@ docker_compose exec -T db psql -U postgres -c "DROP DATABASE temp;"
 echo "Database cleared."
 
 echo "Running migrations and loading fixtures..."
-docker_compose run --rm web /bin/bash -c "
+docker_compose run --rm --no-deps web /bin/bash -c "
     ./wait-for-postgres.sh db:5432 && \
     python /code/manage.py migrate --noinput && \
     ./scripts/load_all_fixtures.sh && \


### PR DESCRIPTION
Closes #1078

## What

Every dev web start ran `wait-for-postgres` + `migrate` + `compilemessages` (3 languages) + `collectstatic` before `runserver`. With bind-mounted source, tracked `.mo` files, and debug-mode WhiteNoise finders, most of that is wasted work on every restart and `.env` iteration.

## Changes

- `docker-compose.yml`: new one-shot `init` service (wait for db, `migrate`, `compilemessages`); `web` depends on `init` completing successfully and runs only `runserver`.
- `collectstatic` removed from dev startup entirely (debug finders serve source static).
- `README.md`: note about `init` and `date-migrate` after pulling new migrations.
- `docs/dev/operations.md`: corrected dev-all docs that claimed `init` runs `collectstatic` and that CSS changes need a restart.

## Verification

- `docker compose config` valid; stack recreated with new layout: `init` exits 0 after migrating, `web` command is plain runserver, homepage returns 200.