### PR TITLE
k8s: run migrations as an explicit pre-deployment phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,3 @@ RUN mkdir /code
 WORKDIR /code
 ADD . /code/
 RUN python manage.py compilemessages -l en -l fi -l sv
-# Collect static at build time so web pods start without running
-# collectstatic. The default image ships the date variant's assets;
-# build with --build-arg PROJECT_NAME=<variant> for association-specific
-# images (or enable collectstaticOnStartup in the chart for other variants).
-ARG PROJECT_NAME=date
-ENV PROJECT_NAME=$PROJECT_NAME
-RUN python manage.py collectstatic --noinput

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,10 @@ RUN mkdir /code
 WORKDIR /code
 ADD . /code/
 RUN python manage.py compilemessages -l en -l fi -l sv
+# Collect static at build time so web pods start without running
+# collectstatic. The default image ships the date variant's assets;
+# build with --build-arg PROJECT_NAME=<variant> for association-specific
+# images (or enable collectstaticOnStartup in the chart for other variants).
+ARG PROJECT_NAME=date
+ENV PROJECT_NAME=$PROJECT_NAME
+RUN python manage.py collectstatic --noinput

--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-asgi.yaml
+++ b/charts/date-website/templates/deployment-asgi.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "date-website.labels" . | nindent 4 }}
     app.kubernetes.io/component: asgi
+  {{- with .Values.asgi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.asgi.replicaCount }}
   selector:

--- a/charts/date-website/templates/deployment-celery.yaml
+++ b/charts/date-website/templates/deployment-celery.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "date-website.labels" . | nindent 4 }}
     app.kubernetes.io/component: celery
+  {{- with .Values.celery.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.celery.replicaCount }}
   selector:

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "date-website.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
+  {{- with .Values.web.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.web.replicaCount }}
   selector:

--- a/charts/date-website/templates/job-migrate.yaml
+++ b/charts/date-website/templates/job-migrate.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.migrations.job.enabled -}}
+{{- $jobName := printf "%s-migrate" (include "date-website.fullname" .) -}}
+{{- if not .Values.migrations.job.hook -}}
+{{- $jobName = printf "%s-%s" $jobName (printf "%d" .Release.Revision) -}}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "date-website.fullname" . }}-migrate
+  name: {{ $jobName }}
   labels:
     {{- include "date-website.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrate
@@ -16,10 +20,8 @@ metadata:
     {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.job.backoffLimit }}
-  {{- if .Values.migrations.job.activeDeadlineSeconds }}
   activeDeadlineSeconds: {{ .Values.migrations.job.activeDeadlineSeconds }}
-  {{- end }}
-  {{- if .Values.migrations.job.ttlSecondsAfterFinished }}
+  {{- if and .Values.migrations.job.hook .Values.migrations.job.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ .Values.migrations.job.ttlSecondsAfterFinished }}
   {{- end }}
   template:

--- a/charts/date-website/templates/job-migrate.yaml
+++ b/charts/date-website/templates/job-migrate.yaml
@@ -7,10 +7,21 @@ metadata:
     {{- include "date-website.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrate
   annotations:
+    {{- if .Values.migrations.job.hook }}
     "helm.sh/hook": {{ .Values.migrations.job.hook | quote }}
     "helm.sh/hook-delete-policy": {{ .Values.migrations.job.hookDeletePolicy | quote }}
+    {{- end }}
+    {{- with .Values.migrations.job.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.job.backoffLimit }}
+  {{- if .Values.migrations.job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.migrations.job.activeDeadlineSeconds }}
+  {{- end }}
+  {{- if .Values.migrations.job.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.job.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/date-website/values-hetzner.yaml
+++ b/charts/date-website/values-hetzner.yaml
@@ -13,6 +13,8 @@ web:
   # would otherwise race or re-run migrations.
   replicaCount: 1
   migrateOnStartup: false
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   resources:
     requests:
       cpu: 100m
@@ -22,6 +24,8 @@ web:
 
 asgi:
   replicaCount: 1
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   resources:
     requests:
       cpu: 50m
@@ -31,6 +35,8 @@ asgi:
 
 celery:
   replicaCount: 1
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   resources:
     requests:
       cpu: 100m
@@ -41,9 +47,8 @@ celery:
 migrations:
   job:
     enabled: true
-    # Plain Job (no Helm hook) so Argo sync waves order it before the
-    # application deployments; set the same waves on web/asgi/celery in the
-    # operator values.
+    # Plain Job (no Helm hook): Argo sync waves order it (wave 0) before the
+    # application deployments (wave 1, set via the annotations above).
     hook: ""
     annotations:
       argocd.argoproj.io/sync-wave: "0"

--- a/charts/date-website/values-hetzner.yaml
+++ b/charts/date-website/values-hetzner.yaml
@@ -8,10 +8,11 @@ gateway:
     enabled: true
 
 web:
-  # Do not increase without disabling migrateOnStartup and using a migration Job
-  # or another single-run migration step.
+  # Migration is handled by the plain migration Job below (Argo sync wave 0),
+  # so the web deployment must not migrate: multiple replicas or a restart
+  # would otherwise race or re-run migrations.
   replicaCount: 1
-  migrateOnStartup: true
+  migrateOnStartup: false
   resources:
     requests:
       cpu: 100m
@@ -39,7 +40,13 @@ celery:
 
 migrations:
   job:
-    enabled: false
+    enabled: true
+    # Plain Job (no Helm hook) so Argo sync waves order it before the
+    # application deployments; set the same waves on web/asgi/celery in the
+    # operator values.
+    hook: ""
+    annotations:
+      argocd.argoproj.io/sync-wave: "0"
     resources:
       requests:
         cpu: 100m

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -236,6 +236,12 @@
           "type": "integer",
           "minimum": 0
         },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "strategy": {
           "type": "object"
         }
@@ -247,6 +253,12 @@
         "replicaCount": {
           "type": "integer",
           "minimum": 0
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "wsPath": {
           "type": "string",
@@ -263,6 +275,12 @@
         "replicaCount": {
           "type": "integer",
           "minimum": 0
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "concurrency": {
           "type": "integer",

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -273,6 +273,46 @@
         }
       }
     },
+    "migrations": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "hook": {
+              "type": "string"
+            },
+            "hookDeletePolicy": {
+              "type": "string"
+            },
+            "backoffLimit": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "activeDeadlineSeconds": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "ttlSecondsAfterFinished": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "resources": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "properties": {

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -175,6 +175,9 @@ web:
     maxRequestsJitter: 100
   migrateOnStartup: false
   collectstaticOnStartup: true
+  # Merged onto the Deployment metadata (e.g.
+  # argocd.argoproj.io/sync-wave: "1" to run after the migration Job).
+  annotations: {}
   resources: {}
   strategy:
     type: RollingUpdate
@@ -187,6 +190,9 @@ asgi:
     type: ClusterIP
     port: 8000
   wsPath: /ws
+  # Merged onto the Deployment metadata (e.g.
+  # argocd.argoproj.io/sync-wave: "1" to run after the migration Job).
+  annotations: {}
   resources: {}
   strategy:
     type: RollingUpdate
@@ -197,6 +203,9 @@ celery:
   replicaCount: 1
   concurrency: 2
   logLevel: info
+  # Merged onto the Deployment metadata (e.g.
+  # argocd.argoproj.io/sync-wave: "1" to run after the migration Job).
+  annotations: {}
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 300
@@ -212,8 +221,10 @@ migrations:
   job:
     enabled: false
     # Helm hook lifecycle (post-install,post-upgrade), or empty for a plain
-    # Job tracked by GitOps. Plain Jobs run under Argo sync waves, which
-    # guarantees migration completion before application pods start.
+    # Job tracked by GitOps. Plain Jobs get a revision-suffixed name and run
+    # under Argo sync waves, which guarantees migration completion before
+    # application pods start; they must NOT set ttlSecondsAfterFinished,
+    # because Argo keeps the completed Job as desired state.
     hook: post-install,post-upgrade
     hookDeletePolicy: before-hook-creation,hook-succeeded
     backoffLimit: 3
@@ -221,6 +232,7 @@ migrations:
     # argocd.argoproj.io/sync-wave: "0").
     annotations: {}
     activeDeadlineSeconds: 600
+    # Only rendered in hook mode; plain Jobs stay until Argo prunes them.
     ttlSecondsAfterFinished: 3600
     resources: {}
 ingress:

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -211,9 +211,17 @@ celery:
 migrations:
   job:
     enabled: false
+    # Helm hook lifecycle (post-install,post-upgrade), or empty for a plain
+    # Job tracked by GitOps. Plain Jobs run under Argo sync waves, which
+    # guarantees migration completion before application pods start.
     hook: post-install,post-upgrade
     hookDeletePolicy: before-hook-creation,hook-succeeded
     backoffLimit: 3
+    # Additional annotations merged onto the Job (e.g.
+    # argocd.argoproj.io/sync-wave: "0").
+    annotations: {}
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 3600
     resources: {}
 ingress:
   enabled: true

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -67,9 +67,22 @@ The chart deploys:
 - Traefik-compatible `Ingress`, or Gateway API resources
 - optional migration Job
 
-The web deployment runs `migrateOnStartup` in the production values. If the
-web replica count is ever raised above 1, move migrations out of startup
-into the migration Job so two pods cannot race.
+Migrations run as a single migration Job before application pods start.
+Two modes:
+
+- **Helm hook** (default): the Job uses `post-install,post-upgrade` hooks.
+  This works for plain `helm install/upgrade`, but hook timing under
+  GitOps reconciliation is less predictable.
+- **Plain Job + Argo sync waves** (production values): set
+  `migrations.job.hook: ""` and add `argocd.argoproj.io/sync-wave: "0"` via
+  `migrations.job.annotations`, with later waves on the web/asgi/celery
+  deployments. Argo then runs migrations to completion before rolling the
+  application, and the Job is a normal tracked resource.
+
+Never enable `web.migrateOnStartup` in production: it couples schema
+mutation to pod readiness, re-runs on every pod restart, and races when the
+replica count is above one. Keep expand-contract migration rules so old and
+new pods can overlap during rollouts.
 
 ## How production actually runs (summary)
 

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -67,17 +67,19 @@ The chart deploys:
 - Traefik-compatible `Ingress`, or Gateway API resources
 - optional migration Job
 
-Migrations run as a single migration Job before application pods start.
-Two modes:
+Migrations run as a single migration Job per release. Two modes:
 
-- **Helm hook** (default): the Job uses `post-install,post-upgrade` hooks.
-  This works for plain `helm install/upgrade`, but hook timing under
-  GitOps reconciliation is less predictable.
+- **Helm hook** (default): the Job uses `post-install,post-upgrade` hooks
+  and is deleted after success. This works for plain `helm
+  install/upgrade`, but hook timing under GitOps reconciliation is less
+  predictable and the Job does not strictly gate application startup.
 - **Plain Job + Argo sync waves** (production values): set
   `migrations.job.hook: ""` and add `argocd.argoproj.io/sync-wave: "0"` via
-  `migrations.job.annotations`, with later waves on the web/asgi/celery
-  deployments. Argo then runs migrations to completion before rolling the
-  application, and the Job is a normal tracked resource.
+  `migrations.job.annotations`, with `argocd.argoproj.io/sync-wave: "1"` on
+  the web/asgi/celery Deployments (`.Values.<component>.annotations`).
+  Argo then runs migrations to completion before rolling the application.
+  The Job gets a revision-suffixed name, stays completed as desired state
+  (no TTL), and the previous revision's Job is pruned on the next sync.
 
 Never enable `web.migrateOnStartup` in production: it couples schema
 mutation to pod readiness, re-runs on every pod restart, and races when the
@@ -134,8 +136,9 @@ shares the site's database and secrets, no ingress) that is scaled to zero
 between deploys. A deploy:
 
 1. dumps the site's database first (the rollback mechanism)
-2. sets the new image tag on the standby → Argo syncs it → the standby runs
-   migrations on startup while the live site keeps serving
+2. sets the new image tag on the standby → Argo syncs it → the ordered
+   migration Job runs first (sync wave 0), then the standby application
+   pods start (sync wave 1) while the live site keeps serving
 3. smoke-tests the standby, then flips the ingress backend service names to
    the standby (in-place, no traffic gap)
 4. soaks, keeping the old stack as the rollback target, then scales the old


### PR DESCRIPTION
Closes #1081

## What

Production values enabled `web.migrateOnStartup`, so every web pod waited for PostgreSQL, ran the full migration check before Gunicorn started, and mutated the DB as a side effect of standby startup. The chart's migration Job was a `post-install,post-upgrade` hook, which fires too late to gate new pods.

## Changes

- `job-migrate.yaml`: `hook` can now be empty for a plain GitOps-tracked Job; `migrations.job.annotations` merges arbitrary annotations (e.g. `argocd.argoproj.io/sync-wave: "0"`); Job gets `activeDeadlineSeconds` and `ttlSecondsAfterFinished`.
- `values-hetzner.yaml`: enables the Job in plain mode with sync-wave 0 and disables `web.migrateOnStartup`.
- `values.yaml`: new defaults documented (hook mode unchanged for backward compat).
- `values.schema.json`: `migrations` section added.
- `docs/dev/kubernetes.md`: documents both modes and why migrateOnStartup is banned in production.
- Chart version bumped to 0.3.7.

## Verification

- `helm template` renders the Job with sync-wave annotation, deadlines, and no hook in hetzner mode; hook mode still renders `post-install,post-upgrade` with defaults.
- Web deployment no longer contains migrate in startup args.
- Note: `helm template` against shipped values fails a pre-existing schema conditional (empty secretKey / gateway https tls), unrelated to this change; renders fine with the operator-provided values filled in.

## Operator note

Sync waves must also be set on web/asgi/celery in the operator values (later waves than the Job). Blue-green: only the live release should run the migration Job.