### PR TITLE
refactor: remove the stale CDN URL rewrite middleware

### DIFF
--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -204,7 +204,6 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'date.middleware.LangMiddleware',
     'date.middleware.HTCPCPMiddleware',
-    'date.middleware.CDNRewriteMiddleware',
 ]
 
 SERVER_TIMING_ENABLED = DEVELOP
@@ -590,13 +589,6 @@ LOGGING = {
 }
 
 EXPERIMENTAL_FEATURES = []
-
-
-# CDN settings
-CDN_URL_TRANSFORMATIONS = [
-    ("fra1.digitaloceanspaces.com/albin-storage/", "albin-storage.cdn.datateknologerna.org/"),
-    ("albin-storage.fra1.digitaloceanspaces.com/", "albin-storage.cdn.datateknologerna.org/"),
-]
 
 # Re-export every public name so that `from .common import *` in a
 # variant settings module brings along imported helpers (os, BASE_DIR,

--- a/date/middleware.py
+++ b/date/middleware.py
@@ -1,4 +1,3 @@
-import re
 import time
 from contextlib import ExitStack
 
@@ -83,46 +82,4 @@ class ServerTimingMiddleware:
             f"app;dur={total_duration:.1f}, "
             f'db;dur={db_timing['duration']:.1f};desc="{db_timing['count']} {query_label}"'
         )
-        return response
-
-
-class CDNRewriteMiddleware:
-    """
-    Middleware to rewrite URLs for static and media files to use a CDN if configured.
-    """
-
-    URL_BYTES_PATTERN = rb'[^"\'\s<>()]+'
-    PRESIGNED_S3_MARKERS = (b"X-Amz-Algorithm=", b"X-Amz-Signature=")
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-        self.cdn_url_transformations = getattr(settings, "CDN_URL_TRANSFORMATIONS", [])
-        self._cdn_patterns = []
-        for original, new in self.cdn_url_transformations:
-            if original and new:
-                self._cdn_patterns.append(
-                    (
-                        original.encode("utf-8"),
-                        new.encode("utf-8"),
-                        re.compile(re.escape(original.encode("utf-8")) + self.URL_BYTES_PATTERN),
-                    )
-                )
-
-    def __call__(self, request):
-        response = self.get_response(request)
-
-        if not getattr(response, "streaming", False):
-            for original, new, pattern in self._cdn_patterns:
-                # Keep presigned private-media URLs on their original host, since
-                # their signatures cover the request host and break if rewritten.
-                response.content = pattern.sub(
-                    lambda match, orig=original, repl=new: (
-                        match.group(0)
-                        if any(marker in match.group(0) for marker in self.PRESIGNED_S3_MARKERS)
-                        else match.group(0).replace(orig, repl, 1)
-                    ),
-                    response.content,
-                )
-        # Streaming responses do not expose a mutable `.content` buffer here.
-
         return response

--- a/docs/dev/date.md
+++ b/docs/dev/date.md
@@ -30,7 +30,6 @@
 
 ## Middleware Notes
 - `HTCPCPMiddleware` serves the custom `418` page for coffee-themed easter-egg routes.
-- `CDNRewriteMiddleware` rewrites known storage hostnames in non-streaming responses. If you introduce new public asset hostnames, add them to `CDN_URL_TRANSFORMATIONS` in settings.
 
 ## Extending
 - If more widgets are added to the home page, keep the aggregation work inside `index()` minimal; heavy data should be fetched via dedicated services or cached.


### PR DESCRIPTION
The middleware rewrote albin-storage hostnames in HTML responses to point at a CDN. That approach is retired: the storage backends now use CDN custom domains directly (`S3_PUBLIC_CUSTOM_DOMAIN` and friends), so media URLs are already CDN URLs when rendered. The transformations only matched the retired albin-storage hosts, making the middleware a never-matching regex scan on every HTML response.

Removes:

- `CDNRewriteMiddleware` from `date/middleware.py` (and its now-unused `re` import)
- The `MIDDLEWARE` entry and `CDN_URL_TRANSFORMATIONS` setting in `core/settings/common.py`
- The docs mention in `docs/dev/date.md`

The earlier optimization of this middleware (HTML-only gating, fast-path skip) is superseded by the removal; its tests are dropped with it. Issue #1088 is closed as not planned. `manage.py check` passes; ruff clean.