### PR TITLE
k8s: make ASGI and Celery optional per association

### DIFF
--- a/charts/date-website/templates/deployment-asgi.yaml
+++ b/charts/date-website/templates/deployment-asgi.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.asgi.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -125,3 +126,4 @@ spec:
           {{- end }}
           {{- include "date-website.mediaVolumeMount" . | nindent 10 }}
       {{- include "date-website.mediaVolume" . | nindent 6 }}
+{{- end }}

--- a/charts/date-website/templates/deployment-celery.yaml
+++ b/charts/date-website/templates/deployment-celery.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.celery.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,3 +114,4 @@ spec:
           {{- end }}
           {{- include "date-website.mediaVolumeMount" . | nindent 10 }}
       {{- include "date-website.mediaVolume" . | nindent 6 }}
+{{- end }}

--- a/charts/date-website/templates/httproute.yaml
+++ b/charts/date-website/templates/httproute.yaml
@@ -18,6 +18,7 @@ spec:
     - {{ .host | quote }}
     {{- end }}
   rules:
+    {{- if .Values.asgi.enabled }}
     - matches:
         - path:
             type: PathPrefix
@@ -25,6 +26,7 @@ spec:
       backendRefs:
         - name: {{ include "date-website.fullname" . }}-asgi
           port: {{ .Values.asgi.service.port }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
     {{- range .paths }}
     - matches:

--- a/charts/date-website/templates/ingress.yaml
+++ b/charts/date-website/templates/ingress.yaml
@@ -22,6 +22,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+          {{- if $.Values.asgi.enabled }}
           - path: {{ $.Values.asgi.wsPath | quote }}
             pathType: Prefix
             backend:
@@ -29,6 +30,7 @@ spec:
                 name: {{ include "date-website.fullname" $ }}-asgi
                 port:
                   name: http
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}

--- a/charts/date-website/templates/service-asgi.yaml
+++ b/charts/date-website/templates/service-asgi.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.asgi.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
   selector:
     {{- include "date-website.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: asgi
+{{- end }}

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -244,6 +244,9 @@
     "asgi": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "replicaCount": {
           "type": "integer",
           "minimum": 0
@@ -260,6 +263,9 @@
     "celery": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "replicaCount": {
           "type": "integer",
           "minimum": 0

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -182,6 +182,9 @@ web:
       maxUnavailable: 0
       maxSurge: 1
 asgi:
+  # Disable for associations that do not use event WebSockets; the WS
+  # ingress/gateway route is omitted too.
+  enabled: true
   replicaCount: 1
   service:
     type: ClusterIP
@@ -194,6 +197,9 @@ asgi:
       maxUnavailable: 0
       maxSurge: 1
 celery:
+  # Disable for associations that cannot enqueue tasks (no email/alumni
+  # flows); queued work would otherwise accumulate silently.
+  enabled: true
   replicaCount: 1
   concurrency: 2
   logLevel: info


### PR DESCRIPTION
Closes #1084

asgi.enabled / celery.enabled (default true): disabling drops the deployment, service, and the WS route from ingress/gateway. For variants without event WebSockets or task enqueueing. Schema + values updated; helm lint passes; render with both disabled yields no asgi/celery resources.