### PR TITLE
build: slim the runtime image and split the Instagram updater deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 # Stage 1: install dependencies (needs build tools for compiled extensions)
 FROM python:3.14-alpine AS builder
-RUN apk add --no-cache gcc musl-dev libffi-dev libldap libsasl libressl
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN apk add --no-cache gcc musl-dev libffi-dev
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /usr/local/bin/uv
 WORKDIR /code
 COPY pyproject.toml uv.lock ./
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
-RUN uv sync --frozen --no-dev --no-install-project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
 
-# Stage 2: lean runtime image (no build tools)
+# Stage 2: lean runtime image (no build tools). Native wheels bundle their
+# own libs (psycopg2, cryptography, pillow), so no LDAP/SASL/OpenSSL system
+# packages are needed at runtime.
 FROM python:3.14-alpine
-RUN apk add --no-cache libldap libsasl libressl bash gettext
+RUN apk add --no-cache bash gettext
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 PATH="/opt/venv/bin:$PATH"
 COPY --from=builder /opt/venv /opt/venv
-RUN mkdir /code
 WORKDIR /code
-ADD . /code/
+COPY . /code/
 RUN python manage.py compilemessages -l en -l fi -l sv

--- a/docs/dev/instagram.md
+++ b/docs/dev/instagram.md
@@ -8,7 +8,37 @@ The `instagram` app owns the Instagram post URLs used by the home page embed are
 
 ## Integrations
 - `date.views.index` reads `IgUrl` rows for the front page context.
-- `instagram/igupdate.py` keeps the existing scheduled updater entry point. `social/igupdate.py` remains as a thin compatibility import.
+- `instagram/igupdate.py` is the standalone Instagram updater: a long-running
+  scheduler that fetches the latest ~40 posts for the hardcoded
+  `kemistklubben` profile via instaloader once per day at 00:00 and rewrites
+  `IgUrl`. `social/igupdate.py` remains as a thin compatibility import.
+
+## Running the updater
+
+The updater is not part of the web/worker runtime: `instaloader` and
+`schedule` live in the optional `instagram` dependency group, so a default
+image cannot run it.
+
+```bash
+uv sync --extra instagram
+python instagram/igupdate.py
+```
+
+The script calls `django.setup()` itself and defaults to
+`core.settings.date`; set `PROJECT_NAME` (or `DJANGO_SETTINGS_MODULE`) when
+running it for another association.
+
+The current production runner lives outside this repository (operator
+deployment or host cron); it must install the `instagram` extra in whatever
+environment executes the script.
+
+Caveats:
+
+- The profile is hardcoded to `kemistklubben`; there is no configuration.
+- `IgUrl.objects.all().delete()` runs before the fetch, so a failed fetch
+  (rate limiting, 2FA, network) leaves the embed area empty until the next
+  successful run. The Celery task that replaced this script historically
+  replaced rows only on success; the standalone script does not.
 
 ## Migration Notes
 - Data was split out from `social.IgUrl` into `instagram.IgUrl`.

--- a/docs/dev/instagram.md
+++ b/docs/dev/instagram.md
@@ -28,9 +28,13 @@ The script calls `django.setup()` itself and defaults to
 `core.settings.date`; set `PROJECT_NAME` (or `DJANGO_SETTINGS_MODULE`) when
 running it for another association.
 
-The current production runner lives outside this repository (operator
-deployment or host cron); it must install the `instagram` extra in whatever
-environment executes the script.
+**As of 2026-08, no runner is wired anywhere**: the web/worker image excludes
+the `instagram` extra, and neither this repository (compose services, chart,
+Celery tasks, workflows) nor the operator infrastructure (CronJobs, host
+cron, systemd) starts the updater. The feed is refreshed only when someone
+runs the script manually. If the embed should stay fresh, wire a runner
+(e.g. a chart CronJob) that installs the `instagram` extra and executes
+`python instagram/igupdate.py` daily.
 
 Caveats:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,7 @@ dependencies = [
     "whitenoise",
     "channels",
     "channels-redis",
-    "websocket-client",
     "six",
-    "instaloader",
-    "schedule",
     "boto3",
     "django-storages",
     "django-tables2",
@@ -39,6 +36,14 @@ dependencies = [
     "twisted[tls]>=26.4.0",
     "defusedxml>=0.7.1",
     "pillow-heif>=1.5.0",
+]
+
+[project.optional-dependencies]
+# Standalone Instagram updater (instagram/igupdate.py); not part of the
+# web/worker runtime. Install with: uv sync --extra instagram
+instagram = [
+    "instaloader",
+    "schedule",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -480,17 +480,20 @@ dependencies = [
     { name = "gspread" },
     { name = "gunicorn" },
     { name = "icalendar" },
-    { name = "instaloader" },
     { name = "pillow" },
     { name = "pillow-heif" },
     { name = "psycopg2-binary" },
     { name = "python-dateutil" },
     { name = "requests" },
-    { name = "schedule" },
     { name = "six" },
     { name = "twisted", extra = ["tls"] },
-    { name = "websocket-client" },
     { name = "whitenoise" },
+]
+
+[package.optional-dependencies]
+instagram = [
+    { name = "instaloader" },
+    { name = "schedule" },
 ]
 
 [package.dev-dependencies]
@@ -529,18 +532,18 @@ requires-dist = [
     { name = "gspread" },
     { name = "gunicorn" },
     { name = "icalendar" },
-    { name = "instaloader" },
+    { name = "instaloader", marker = "extra == 'instagram'" },
     { name = "pillow" },
     { name = "pillow-heif", specifier = ">=1.5.0" },
     { name = "psycopg2-binary" },
     { name = "python-dateutil" },
     { name = "requests" },
-    { name = "schedule" },
+    { name = "schedule", marker = "extra == 'instagram'" },
     { name = "six" },
     { name = "twisted", extras = ["tls"], specifier = ">=26.4.0" },
-    { name = "websocket-client" },
     { name = "whitenoise" },
 ]
+provides-extras = ["instagram"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1747,15 +1750,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1094

## Changes

- Dockerfile: pin uv 0.12.1 (was :latest), BuildKit cache mount for uv downloads, COPY instead of ADD, drop redundant RUN mkdir, remove libldap/libsasl/libressl from both stages (native wheels bundle their libs).
- pyproject: instaloader + schedule moved to an optional 'instagram' dependency group (standalone updater script, not part of web/worker runtime); removed unused websocket-client.
- uv.lock regenerated.

## Verification

- Rebuilt image: manage.py check passes; TLS, psycopg2, pillow, twisted all load without the removed system libs.
- Full suite 548 tests pass; uv lock/sync clean.

## Notes

- Running the Instagram updater now needs uv sync --extra instagram (documented in pyproject).
- Non-root USER deferred: media PVCs are created root-owned, flipping the user would break uploads on existing volumes.