### PR TITLE
k8s: align self-hosted overlay docs and bound backup runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ Although Django 6 ships with the new Tasks framework, this project still uses Ce
 
 The Kubernetes deployment path uses the Helm chart in `charts/date-website/`. The current target is k3s on Hetzner Cloud with Traefik Gateway API, `hcloud-volumes` for persistent workloads when they run in-cluster, and Backblaze B2 through the S3-compatible API for media and PostgreSQL backups.
 
+The example below is the **self-hosted profile**: the chart owns the Gateway
+and the backup CronJob. Production instead runs one Argo CD release per
+association with an external cluster-level backup pipeline and externally
+managed ingress (see [docs/dev/kubernetes.md](docs/dev/kubernetes.md)); only
+one authoritative backup pipeline should own each database.
+
 Use these values files together:
 
 ```bash

--- a/charts/date-website/templates/cronjob-postgresql-backup.yaml
+++ b/charts/date-website/templates/cronjob-postgresql-backup.yaml
@@ -14,9 +14,18 @@ spec:
   concurrencyPolicy: {{ .Values.backups.concurrencyPolicy }}
   successfulJobsHistoryLimit: {{ .Values.backups.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.backups.failedJobsHistoryLimit }}
+  {{- if .Values.backups.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.backups.startingDeadlineSeconds }}
+  {{- end }}
+  {{- if .Values.backups.timeZone }}
+  timeZone: {{ .Values.backups.timeZone | quote }}
+  {{- end }}
   jobTemplate:
     spec:
       backoffLimit: {{ .Values.backups.backoffLimit }}
+      {{- if .Values.backups.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.backups.activeDeadlineSeconds }}
+      {{- end }}
       {{- if .Values.backups.ttlSecondsAfterFinished }}
       ttlSecondsAfterFinished: {{ .Values.backups.ttlSecondsAfterFinished }}
       {{- end }}

--- a/charts/date-website/values-hetzner.yaml
+++ b/charts/date-website/values-hetzner.yaml
@@ -1,3 +1,8 @@
+# Self-hosted / standalone profile for k3s on Hetzner Cloud (used by the
+# README example install). This is NOT the GitOps production layout:
+# production runs one Argo CD release per association with an external
+# backup pipeline and externally managed ingress, per docs/dev/kubernetes.md.
+# Here the chart owns the Gateway and the backup CronJob.
 ingress:
   enabled: false
 

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -76,6 +76,12 @@ backups:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   backoffLimit: 2
+  # Skip a run when the cluster was down past this deadline; abort a hung
+  # dump after this long.
+  startingDeadlineSeconds: 3600
+  activeDeadlineSeconds: 3600
+  # Empty uses the cluster's default timezone (UTC).
+  timeZone: Europe/Helsinki
   ttlSecondsAfterFinished: 86400
   nodeSelector: {}
   tolerations: []

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -157,6 +157,8 @@ standby migrates — not at cutover. Therefore:
   managed in restic.
 - The chart's backup CronJob is **not** used in production (the cluster-level
   pipeline supersedes it); it remains available for self-hosted installs.
+  It supports `startingDeadlineSeconds` / `activeDeadlineSeconds` /
+  `timeZone` to bound missed and hung runs.
 - Restore is a documented, tested drill in the operator repository.
 
 ## Operational notes


### PR DESCRIPTION
Closes #1098

- values-hetzner.yaml labeled as the self-hosted/standalone profile; README example clarified that production is Argo per-association with an external backup pipeline and ingress.
- Backup CronJob: startingDeadlineSeconds/activeDeadlineSeconds/timeZone (defaults Europe/Helsinki), documented in kubernetes.md.