### PR TITLE
k8s: validate projectName and extraEnv, add sf/impuls examples

### DIFF
--- a/charts/date-website/values-impuls.example.yaml
+++ b/charts/date-website/values-impuls.example.yaml
@@ -1,0 +1,33 @@
+# Example per-association values for Impuls.
+# Use after values-hetzner.yaml and values-backblaze-b2.example.yaml.
+#
+# Placeholders: replace the host/domain examples, and set the real SITE_URL
+# in core/settings/impuls.py CONTENT_VARIABLES (it is a settings value, not
+# an env var).
+
+django:
+  projectName: impuls
+  allowedHosts:
+    - impuls.example.org
+  allowedOrigins:
+    - https://impuls.example.org
+
+ingress:
+  hosts:
+    - host: impuls.example.org
+      paths:
+        - path: /
+          pathType: Prefix
+
+media:
+  s3:
+    bucketName: "impuls-website-media"
+    privateBucketName: "impuls-website-private"
+    publicBucketName: "impuls-website-public"
+    privateLocation: "impuls/media"
+    publicLocation: "impuls/public"
+
+backups:
+  objectStorage:
+    bucketName: "impuls-website-backups"
+    prefix: "impuls-website/postgresql"

--- a/charts/date-website/values-sf.example.yaml
+++ b/charts/date-website/values-sf.example.yaml
@@ -1,0 +1,33 @@
+# Example per-association values for Studerandeföreningen.
+# Use after values-hetzner.yaml and values-backblaze-b2.example.yaml.
+#
+# Placeholders: replace the host/domain examples, and set the real SITE_URL
+# in core/settings/sf.py CONTENT_VARIABLES (it is a settings value, not an
+# env var).
+
+django:
+  projectName: sf
+  allowedHosts:
+    - sf.example.org
+  allowedOrigins:
+    - https://sf.example.org
+
+ingress:
+  hosts:
+    - host: sf.example.org
+      paths:
+        - path: /
+          pathType: Prefix
+
+media:
+  s3:
+    bucketName: "sf-website-media"
+    privateBucketName: "sf-website-private"
+    publicBucketName: "sf-website-public"
+    privateLocation: "sf/media"
+    publicLocation: "sf/public"
+
+backups:
+  objectStorage:
+    bucketName: "sf-website-backups"
+    prefix: "sf-website/postgresql"

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "extraEnv": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "image": {
       "type": "object",
       "properties": {
@@ -41,7 +47,15 @@
       "properties": {
         "projectName": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "date",
+            "kk",
+            "biocum",
+            "demo",
+            "pulterit",
+            "sf",
+            "impuls"
+          ]
         },
         "secretKey": {
           "type": "string"


### PR DESCRIPTION
Closes #1100 (partial: schema + examples; media-prefix derivation left to operator values, as today)

- django.projectName now constrained to the seven known variants.
- Root extraEnv validated (string map) - it is wired to the configmap; no mismatch.
- New values-sf.example.yaml / values-impuls.example.yaml; both note SITE_URL is a settings value (CONTENT_VARIABLES), not env.