### PR TITLE
refactor: shared template and static builders for association settings

### DIFF
--- a/core/settings/biocum.py
+++ b/core/settings/biocum.py
@@ -1,21 +1,6 @@
 from .common import *  # noqa
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/biocum',
-            'templates/date',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('biocum', parent_variants=('date',))
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -39,10 +24,7 @@ USE_ACCEPT_LANGUAGE_HEADER = False
 
 STAFF_GROUPS = get_staff_groups(['styrelse', 'admin', 'fotograf', 'rösträknare'])
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/biocum'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
+STATICFILES_DIRS = build_static_dirs('biocum')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://biologica.fi",

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -178,6 +178,43 @@ COMMON_TEMPLATE_DIRS = [
 ]
 
 
+def build_templates(variant, parent_variants=()):
+    """Template config for a variant, inheriting parent template dirs first.
+
+    The variant's own dir precedes its parents' dirs, then the shared
+    common dirs, matching Django template loader precedence.
+    """
+    return [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [
+                *[f'templates/{name}' for name in (variant, *parent_variants)],
+                *COMMON_TEMPLATE_DIRS,
+            ],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    *COMMON_CONTEXT_PROCESSORS,
+                    # Add project context processors here
+                ],
+            },
+        },
+    ]
+
+
+def build_static_dirs(variant, parent_variants=()):
+    """STATICFILES_DIRS for a variant.
+
+    Only the variant's own dir (plus explicitly listed parents) precedes the
+    shared common dir; template inheritance does not automatically extend to
+    static dirs.
+    """
+    return [
+        *[os.path.join(BASE_DIR, f'static/{name}') for name in (variant, *parent_variants)],
+        os.path.join(BASE_DIR, 'static/common'),
+    ]
+
+
 COMMON_CONTEXT_PROCESSORS = [
     'django.template.context_processors.debug',
     'django.template.context_processors.request',

--- a/core/settings/date.py
+++ b/core/settings/date.py
@@ -1,21 +1,6 @@
 from .common import *  # noqa
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/date',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-                # Add project context processors here
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('date')
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -52,11 +37,7 @@ LANGUAGES = (
 STAFF_GROUPS = get_staff_groups(['styrelse', 'admin', 'fotograf', 'rösträknare'])
 
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/date'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
-
+STATICFILES_DIRS = build_static_dirs('date')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://datateknologerna.org",

--- a/core/settings/demo.py
+++ b/core/settings/demo.py
@@ -1,21 +1,6 @@
 from .common import *  # noqa
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/demo',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-                # Add project context processors here
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('demo')
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -38,11 +23,7 @@ ROOT_URLCONF = 'core.urls.demo'
 STAFF_GROUPS = get_staff_groups(['styrelse', 'admin', 'fotograf', 'rösträknare'])
 
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/demo'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
-
+STATICFILES_DIRS = build_static_dirs('demo')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://demo.datateknologerna.org",

--- a/core/settings/impuls.py
+++ b/core/settings/impuls.py
@@ -1,21 +1,6 @@
 from .common import *  # noqa
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/impuls',
-            'templates/date',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('impuls', parent_variants=('date',))
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -50,10 +35,7 @@ LANGUAGES = (
 
 STAFF_GROUPS = get_staff_groups(['styrelse', 'admin', 'fotograf', 'rösträknare'])
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/impuls'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
+STATICFILES_DIRS = build_static_dirs('impuls')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://example.com",

--- a/core/settings/kk.py
+++ b/core/settings/kk.py
@@ -1,21 +1,6 @@
 from .common import *  # noqa
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/kk',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-                # Add project context processors here
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('kk')
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -43,11 +28,7 @@ USE_ACCEPT_LANGUAGE_HEADER = False
 STAFF_GROUPS = get_staff_groups(['styrelse', 'admin', 'fotograf', 'rösträknare'])
 
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/kk'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
-
+STATICFILES_DIRS = build_static_dirs('kk')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://kemistklubben.org",

--- a/core/settings/pulterit.py
+++ b/core/settings/pulterit.py
@@ -1,22 +1,7 @@
 from .common import *  # noqa
 
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/pulterit',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-                # Add project context processors here
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('pulterit')
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -41,11 +26,7 @@ MEMBERS_SIGNUP_ENABLED = False
 STAFF_GROUPS = get_staff_groups(['styrelse', 'admin', 'fotograf', 'rösträknare'])
 
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/pulterit'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
-
+STATICFILES_DIRS = build_static_dirs('pulterit')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://pulterit.org",

--- a/core/settings/sf.py
+++ b/core/settings/sf.py
@@ -1,22 +1,6 @@
 from .common import *  # noqa
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            'templates/sf',
-            'templates/date',
-            *COMMON_TEMPLATE_DIRS,
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                *COMMON_CONTEXT_PROCESSORS,
-                # Add project context processors here
-            ],
-        },
-    },
-]
+TEMPLATES = build_templates('sf', parent_variants=('date',))
 
 INSTALLED_APPS = get_installed_apps(
     [
@@ -79,11 +63,7 @@ SF_ROLE_PERMISSION_SCOPES = {
 }
 
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static/sf'),
-    os.path.join(BASE_DIR, 'static/common'),
-]
-
+STATICFILES_DIRS = build_static_dirs('sf')
 
 CONTENT_VARIABLES = {
     "SITE_URL": "https://example.com",

--- a/core/tests/test_settings_builders.py
+++ b/core/tests/test_settings_builders.py
@@ -1,0 +1,53 @@
+import importlib
+
+from django.test import SimpleTestCase
+
+
+class SettingsBuilderTests(SimpleTestCase):
+    """Guards the shared template/static builders' precedence rules."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.common = importlib.import_module("core.settings.common")
+
+    def test_plain_variant_dirs(self):
+        templates = self.common.build_templates("date")
+        self.assertEqual(
+            templates[0]["DIRS"],
+            ["templates/date", "templates/common", "templates/common/members"],
+        )
+        self.assertTrue(templates[0]["APP_DIRS"])
+
+    def test_parent_variants_precede_common(self):
+        templates = self.common.build_templates("biocum", parent_variants=("date",))
+        self.assertEqual(
+            templates[0]["DIRS"],
+            ["templates/biocum", "templates/date", "templates/common", "templates/common/members"],
+        )
+
+    def test_common_context_processors_are_preserved(self):
+        templates = self.common.build_templates("date")
+        self.assertEqual(templates[0]["OPTIONS"]["context_processors"], self.common.COMMON_CONTEXT_PROCESSORS)
+
+    def test_static_dirs_do_not_inherit_parents(self):
+        # Template inheritance must not leak into static dirs.
+        static_dirs = self.common.build_static_dirs("sf", parent_variants=("date",))
+        self.assertEqual(
+            static_dirs,
+            [
+                self.common.os.path.join(self.common.BASE_DIR, "static/sf"),
+                self.common.os.path.join(self.common.BASE_DIR, "static/date"),
+                self.common.os.path.join(self.common.BASE_DIR, "static/common"),
+            ],
+        )
+
+    def test_plain_static_dirs(self):
+        static_dirs = self.common.build_static_dirs("kk")
+        self.assertEqual(
+            static_dirs,
+            [
+                self.common.os.path.join(self.common.BASE_DIR, "static/kk"),
+                self.common.os.path.join(self.common.BASE_DIR, "static/common"),
+            ],
+        )

--- a/docs/dev/templates.md
+++ b/docs/dev/templates.md
@@ -2,19 +2,23 @@
 
 ## How Templates Are Loaded
 
-The project supports multiple site variants selected by `PROJECT_NAME`. Each variant has its own settings file under `core/settings/<variant>.py`, which controls the Django `TEMPLATES` `DIRS` list:
+The project supports multiple site variants selected by `PROJECT_NAME`. Each variant has its own settings file under `core/settings/<variant>.py`, which builds the Django `TEMPLATES` `DIRS` list with the shared helpers in `core/settings/common.py`:
 
 ```python
-TEMPLATES = [{
-    'DIRS': [
-        'templates/<association>',
-        *COMMON_TEMPLATE_DIRS,  # includes 'templates/common'
-    ],
-    ...
-}]
+# Variant with no inherited templates (date, kk, pulterit, demo):
+TEMPLATES = build_templates('date')
+
+# Variant inheriting another variant's templates (biocum, sf, impuls):
+TEMPLATES = build_templates('biocum', parent_variants=('date',))
 ```
 
-The association-specific directory is listed **first**, so Django finds association templates before falling back to `templates/common`.
+`build_templates(variant, parent_variants=())` puts the variant's own
+directory **first**, then the inherited parents, then the shared common
+dirs, so Django finds association templates before falling back to
+`templates/common`. Use the helpers when adding a variant; do not
+construct `TEMPLATES` by hand. Static dirs are built the same way with
+`build_static_dirs(variant)`; note that static dirs do **not** inherit
+parent variants.
 
 ## Override Pattern
 


### PR DESCRIPTION
Closes #1089 (phase 1: settings builders; the typed registry itself is tracked in the issue)

- build_templates(variant, parent_variants) / build_static_dirs(variant) in common.py encode the precedence rules once (variant dir, inherited parents, shared common dirs; static dirs do not inherit template parents).
- All seven variant settings modules rewritten onto the builders: -146 lines.
- Verified: manage.py check per variant, check_project_variants, full suite (548 tests).