### PR TITLE
refactor: capability-driven URL builder, remove pulterit positional insert

### DIFF
--- a/core/tests/test_url_route_parity.py
+++ b/core/tests/test_url_route_parity.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import sys
+
+from django.test import SimpleTestCase
+
+EXPECTED_PREFIXES = {
+    "date": ["/news/", "/archive/", "/ctf/", "/alumni/", "/publications/"],
+    "kk": ["/lucia/", "/publications/", "/alumni/"],
+    "biocum": ["/publications/"],
+    "pulterit": ["/publications/", "/archive/"],
+    "sf": ["/klotterplanket/", "/publications/"],
+    "impuls": ["/alumni/", "/publications/"],
+    "demo": ["/news/"],
+}
+
+CODE = """
+import importlib
+import os
+import sys
+
+variant = sys.argv[1]
+os.environ.setdefault("PROJECT_NAME", variant)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", f"core.settings.{variant}")
+import django
+
+django.setup()
+
+module = importlib.import_module(f"core.urls.{variant}")
+paths = {str(p.pattern) for p in module.urlpatterns}
+for prefix in sys.argv[2].split(","):
+    if prefix not in paths:
+        print(f"MISSING {prefix}")
+        raise SystemExit(1)
+print("OK")
+"""
+
+
+class VariantRouteParityTests(SimpleTestCase):
+    """Each variant must expose its expected route prefixes (regression guard
+    for the route-key rewrite). Runs in a fresh process so the variant's own
+    INSTALLED_APPS are active."""
+
+    def test_variant_route_parity(self):
+        for variant, prefixes in EXPECTED_PREFIXES.items():
+            with self.subTest(variant=variant):
+                result = subprocess.run(
+                    [sys.executable, "-c", CODE, variant, ",".join(prefixes)],
+                    capture_output=True,
+                    text=True,
+                    env={**os.environ, "PROJECT_NAME": variant},
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/core/tests/test_url_route_parity.py
+++ b/core/tests/test_url_route_parity.py
@@ -4,14 +4,148 @@ import sys
 
 from django.test import SimpleTestCase
 
+COMMON_PREFIXES = ["healthz/", "readyz/"]
+TRAILING_PREFIXES = ["set_lang/", "jsi18n/", "_uploads/sign/"]
+
 EXPECTED_PREFIXES = {
-    "date": ["news/", "archive/", "ctf/", "alumni/", "publications/"],
-    "kk": ["lucia/", "publications/", "alumni/"],
-    "biocum": ["publications/"],
-    "pulterit": ["publications/", "archive/"],
-    "sf": ["klotterplanket/", "publications/"],
-    "impuls": ["alumni/", "publications/"],
-    "demo": ["news/"],
+    "date": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "ctf/",
+        "admin/",
+        "ckeditor5/",
+        "publications/",
+        "alumni/",
+        *TRAILING_PREFIXES,
+    ],
+    "kk": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "lucia/",
+        "admin/",
+        "ckeditor5/",
+        "publications/",
+        "alumni/",
+        *TRAILING_PREFIXES,
+    ],
+    "biocum": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "admin/",
+        "ckeditor5/",
+        "publications/",
+        *TRAILING_PREFIXES,
+    ],
+    "pulterit": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "admin/",
+        "ckeditor5/",
+        "publications/",
+        *TRAILING_PREFIXES,
+    ],
+    "sf": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "admin/",
+        "ckeditor5/",
+        "publications/",
+        "klotterplanket/",
+        *TRAILING_PREFIXES,
+    ],
+    "impuls": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "admin/",
+        "ckeditor5/",
+        "publications/",
+        "alumni/",
+        *TRAILING_PREFIXES,
+    ],
+    "demo": [
+        *COMMON_PREFIXES,
+        "",
+        "news/",
+        "members/",
+        "members/two-factor/",
+        "archive/",
+        "events/",
+        "pages/",
+        "ads/",
+        "social/",
+        "polls/",
+        "admin/",
+        "ckeditor5/",
+        *TRAILING_PREFIXES,
+    ],
+}
+
+EXPECTED_URL_NAMES = {
+    "date": ["news:index", "archive:years", "ctf:index", "publications:pdf_list", "alumni:alumni_signup"],
+    "kk": ["news:index", "lucia:index", "publications:pdf_list", "alumni:alumni_signup"],
+    "biocum": ["news:index", "archive:years", "publications:pdf_list"],
+    "pulterit": ["news:index", "archive:exams", "publications:pdf_list"],
+    "sf": ["news:index", "archive:years", "publications:pdf_list", "klotterplanket:index"],
+    "impuls": ["news:index", "archive:years", "publications:pdf_list", "alumni:alumni_signup"],
+    "demo": ["news:index", "archive:years"],
+}
+
+FORBIDDEN_URL_NAMES = {
+    "pulterit": ["archive:years"],
 }
 
 CODE = """
@@ -19,33 +153,61 @@ import importlib
 import os
 import sys
 
+from django.urls import NoReverseMatch, reverse
+
 variant = sys.argv[1]
 os.environ["PROJECT_NAME"] = variant
 os.environ["DJANGO_SETTINGS_MODULE"] = f"core.settings.{variant}"
+os.environ["DATE_DEBUG"] = "0"
 import django
 
 django.setup()
 
 module = importlib.import_module(f"core.urls.{variant}")
-paths = {str(p.pattern) for p in module.urlpatterns}
-for prefix in sys.argv[2].split(","):
-    if prefix not in paths:
-        print(f"MISSING {prefix}")
+expected_paths = sys.argv[2].split(",")
+actual_paths = [str(p.pattern) for p in module.urlpatterns]
+if actual_paths != expected_paths:
+    print(f"EXPECTED {expected_paths}")
+    print(f"ACTUAL {actual_paths}")
+    raise SystemExit(1)
+
+for name in sys.argv[3].split(","):
+    try:
+        reverse(name, urlconf=module)
+    except NoReverseMatch:
+        print(f"MISSING URL {name}")
         raise SystemExit(1)
+
+for name in filter(None, sys.argv[4].split(",")):
+    try:
+        reverse(name, urlconf=module)
+    except NoReverseMatch:
+        continue
+    print(f"UNEXPECTED URL {name}")
+    raise SystemExit(1)
 print("OK")
 """
 
 
 class VariantRouteParityTests(SimpleTestCase):
-    """Each variant must expose its expected route prefixes (regression guard
-    for the route-key rewrite). Runs in a fresh process so the variant's own
-    INSTALLED_APPS are active."""
+    """Each variant must expose its complete route inventory and named URLs.
+
+    Runs in a fresh process so the variant's own INSTALLED_APPS are active.
+    """
 
     def test_variant_route_parity(self):
         for variant, prefixes in EXPECTED_PREFIXES.items():
             with self.subTest(variant=variant):
                 result = subprocess.run(
-                    [sys.executable, "-c", CODE, variant, ",".join(prefixes)],
+                    [
+                        sys.executable,
+                        "-c",
+                        CODE,
+                        variant,
+                        ",".join(prefixes),
+                        ",".join(EXPECTED_URL_NAMES[variant]),
+                        ",".join(FORBIDDEN_URL_NAMES.get(variant, [])),
+                    ],
                     capture_output=True,
                     text=True,
                     env={**os.environ, "PROJECT_NAME": variant},

--- a/core/tests/test_url_route_parity.py
+++ b/core/tests/test_url_route_parity.py
@@ -5,13 +5,13 @@ import sys
 from django.test import SimpleTestCase
 
 EXPECTED_PREFIXES = {
-    "date": ["/news/", "/archive/", "/ctf/", "/alumni/", "/publications/"],
-    "kk": ["/lucia/", "/publications/", "/alumni/"],
-    "biocum": ["/publications/"],
-    "pulterit": ["/publications/", "/archive/"],
-    "sf": ["/klotterplanket/", "/publications/"],
-    "impuls": ["/alumni/", "/publications/"],
-    "demo": ["/news/"],
+    "date": ["news/", "archive/", "ctf/", "alumni/", "publications/"],
+    "kk": ["lucia/", "publications/", "alumni/"],
+    "biocum": ["publications/"],
+    "pulterit": ["publications/", "archive/"],
+    "sf": ["klotterplanket/", "publications/"],
+    "impuls": ["alumni/", "publications/"],
+    "demo": ["news/"],
 }
 
 CODE = """
@@ -20,8 +20,8 @@ import os
 import sys
 
 variant = sys.argv[1]
-os.environ.setdefault("PROJECT_NAME", variant)
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", f"core.settings.{variant}")
+os.environ["PROJECT_NAME"] = variant
+os.environ["DJANGO_SETTINGS_MODULE"] = f"core.settings.{variant}"
 import django
 
 django.setup()

--- a/core/urls/biocum.py
+++ b/core/urls/biocum.py
@@ -1,32 +1,27 @@
-"""Biocum URL Configuration.
-
-The `urlpatterns` list routes URLs to views.
-"""
+"""URL configuration for the biocum site."""
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('archive/', include('archive.urls')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('publications/', include('publications.urls')),
-    path('admin/', admin_site.urls),
-    path("ckeditor5/", include('django_ckeditor_5.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'admin',
+    'ckeditor',
+    'publications',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/urls/common.py
+++ b/core/urls/common.py
@@ -1,15 +1,51 @@
-from django.urls import path
+from django.urls import include, path
 from django.views.i18n import JavaScriptCatalog
 
 from core import uploads as uploads_views
+from core.admin import admin_site
 from date import views as date_views
 
+# Shared canonical routes, keyed for capability-driven inclusion. Each entry
+# is a thunk: include() imports the app's URLconf eagerly, so only the routes
+# a variant requests are ever imported (apps not installed for a variant are
+# never loaded).
+ROUTES = {
+    'index': lambda: path('', date_views.index, name='index'),
+    'news': lambda: path('news/', include('news.urls')),
+    'members': lambda: path('members/', include('members.urls')),
+    'two_factor': lambda: path(
+        'members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')
+    ),
+    'archive': lambda: path('archive/', include('archive.urls')),
+    'archive_exams': lambda: path('archive/', include('exambank.archive_urls')),
+    'events': lambda: path('events/', include('events.urls')),
+    'pages': lambda: path('pages/', include('staticpages.urls')),
+    'ads': lambda: path('ads/', include('ads.urls')),
+    'social': lambda: path('social/', include('social.urls')),
+    'polls': lambda: path('polls/', include('polls.urls')),
+    'ctf': lambda: path('ctf/', include('ctf.urls')),
+    'admin': lambda: path('admin/', admin_site.urls),
+    'ckeditor': lambda: path('ckeditor5/', include('django_ckeditor_5.urls')),
+    'publications': lambda: path('publications/', include('publications.urls')),
+    'alumni': lambda: path('alumni/', include('alumni.urls')),
+    'lucia': lambda: path('lucia/', include('lucia.urls')),
+    'klotterplanket': lambda: path('klotterplanket/', include('klotterplanket.urls')),
+}
 
-def build_urlpatterns(*localized_patterns):
+
+def build_urlpatterns(*routes):
+    """Build the canonical URL patterns from ordered route keys.
+
+    Shared health/readiness/language/upload routes are always included around
+    the requested routes, so a shared route addition happens once.
+    """
+    unknown = set(routes) - set(ROUTES)
+    if unknown:
+        raise ValueError(f"Unknown route keys: {sorted(unknown)}")
     return [
         path("healthz/", date_views.healthz, name="healthz"),
         path("readyz/", date_views.readyz, name="readyz"),
-        *localized_patterns,
+        *(ROUTES[route]() for route in routes),
         path("set_lang/", date_views.set_language, name="set_lang"),
         path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
         path("_uploads/sign/", uploads_views.sign_upload, name="direct-upload-sign"),

--- a/core/urls/date.py
+++ b/core/urls/date.py
@@ -1,46 +1,29 @@
-"""date URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-# update
+"""URL configuration for the date site."""
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('archive/', include('archive.urls')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('ctf/', include('ctf.urls')),
-    path('admin/', admin_site.urls),
-    path("ckeditor5/", include('django_ckeditor_5.urls')),
-    path('publications/', include('publications.urls')),
-    path('alumni/', include('alumni.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'ctf',
+    'admin',
+    'ckeditor',
+    'publications',
+    'alumni',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/urls/demo.py
+++ b/core/urls/demo.py
@@ -1,43 +1,26 @@
-"""date URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-# update
+"""URL configuration for the demo site."""
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('archive/', include('archive.urls')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('admin/', admin_site.urls),
-    path("ckeditor5/", include('django_ckeditor_5.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'admin',
+    'ckeditor',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/urls/impuls.py
+++ b/core/urls/impuls.py
@@ -1,30 +1,28 @@
-"""Impuls URL configuration."""
+"""URL configuration for the impuls site."""
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('archive/', include('archive.urls')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('admin/', admin_site.urls),
-    path("ckeditor5/", include('django_ckeditor_5.urls')),
-    path('publications/', include('publications.urls')),
-    path('alumni/', include('alumni.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'admin',
+    'ckeditor',
+    'publications',
+    'alumni',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/urls/kk.py
+++ b/core/urls/kk.py
@@ -1,46 +1,29 @@
-"""date URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-# update
+"""URL configuration for the kk site."""
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('archive/', include('archive.urls')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('lucia/', include('lucia.urls')),
-    path('publications/', include('publications.urls')),
-    path('admin/', admin_site.urls),
-    path("ckeditor5/", include('django_ckeditor_5.urls')),
-    path('alumni/', include('alumni.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'lucia',
+    'admin',
+    'ckeditor',
+    'publications',
+    'alumni',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/urls/pulterit.py
+++ b/core/urls/pulterit.py
@@ -21,6 +21,7 @@ urlpatterns = build_urlpatterns(
     'polls',
     'admin',
     'ckeditor',
+    'publications',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/urls/pulterit.py
+++ b/core/urls/pulterit.py
@@ -2,33 +2,26 @@
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('admin/', admin_site.urls),
-    path('ckeditor5/', include('django_ckeditor_5.urls')),
-    path('publications/', include('publications.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive_exams' if not getattr(settings, 'ARCHIVE_ENABLED', True) else 'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'admin',
+    'ckeditor',
 )
-
-if getattr(settings, 'ARCHIVE_ENABLED', True):
-    urlpatterns.insert(6, path('archive/', include('archive.urls')))
-else:
-    urlpatterns.insert(6, path('archive/', include('exambank.archive_urls')))
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)  # type: ignore[arg-type]

--- a/core/urls/sf.py
+++ b/core/urls/sf.py
@@ -1,30 +1,28 @@
-"""SF URL Configuration."""
+"""URL configuration for the sf site."""
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
 
-from core.admin import admin_site
 from core.urls.common import build_urlpatterns
 from date import views as date
 
 app_name = 'core'
 
 urlpatterns = build_urlpatterns(
-    path('', date.index, name='index'),
-    path('news/', include('news.urls')),
-    path('members/', include('members.urls')),
-    path('members/two-factor/', include(('members.two_factor_urls', 'two_factor'), namespace='two_factor')),
-    path('archive/', include('archive.urls')),
-    path('events/', include('events.urls')),
-    path('pages/', include('staticpages.urls')),
-    path('ads/', include('ads.urls')),
-    path('social/', include('social.urls')),
-    path('polls/', include('polls.urls')),
-    path('admin/', admin_site.urls),
-    path("ckeditor5/", include('django_ckeditor_5.urls')),
-    path('publications/', include('publications.urls')),
-    path('klotterplanket/', include('klotterplanket.urls')),
+    'index',
+    'news',
+    'members',
+    'two_factor',
+    'archive',
+    'events',
+    'pages',
+    'ads',
+    'social',
+    'polls',
+    'admin',
+    'ckeditor',
+    'publications',
+    'klotterplanket',
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Closes #1091

- core/urls/common.py owns a ROUTES table keyed by capability; entries are lazy thunks so only the routes a variant requests are imported (uninstalled apps never load).
- Variant URLconfs become ordered route-key lists; pulterit's archive switch is explicit ('archive' vs 'archive_exams'), no positional insert.
- Unknown route keys fail loudly.
- Verified: manage.py check for all 7 variants, check_project_variants, full suite (548 tests).