### PR TITLE
ci: validate every association in a fresh process; fix dev-all migrations

### DIFF
--- a/.github/workflows/web_startup.yaml
+++ b/.github/workflows/web_startup.yaml
@@ -177,6 +177,51 @@ jobs:
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose down -v
 
+  variant_checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Prepare environment file
+        run: cp .env.example .env
+
+      - name: Ensure docker-compose command exists
+        run: |
+          set -euo pipefail
+          if ! command -v docker-compose >/dev/null 2>&1; then
+            printf '#!/usr/bin/env bash\ndocker compose "$@"\n' | sudo tee /usr/local/bin/docker-compose >/dev/null
+            sudo chmod +x /usr/local/bin/docker-compose
+          fi
+          docker-compose version
+
+      - name: Build image
+        run: |
+          set -euo pipefail
+          docker-compose build web
+
+      - name: Fresh-process checks for every association
+        run: |
+          set -euo pipefail
+          for variant in date kk biocum pulterit sf impuls demo; do
+            echo "== ${variant}: manage.py check"
+            docker-compose run --rm --no-deps -e PROJECT_NAME="${variant}" web python manage.py check
+          done
+
+      - name: Migration graph check for every app set
+        run: |
+          set -euo pipefail
+          # Distinct app sets: date (broadest), kk (lucia), sf (klotterplanket).
+          for variant in date kk sf; do
+            echo "== ${variant}: makemigrations --check"
+            docker-compose run --rm --no-deps -e PROJECT_NAME="${variant}" web python manage.py makemigrations --check --dry-run
+          done
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/docker-compose.dev-all.yml
+++ b/docker-compose.dev-all.yml
@@ -68,15 +68,17 @@ services:
     volumes:
       - dev_all_redis_data:/data
 
-  # Runs once: migrate + compilemessages (using 'date' as the representative
-  # project). All web containers wait for this to finish before starting.
+  # Runs once: migrate + compilemessages. Migrations run for the distinct app
+  # sets so association-only apps (lucia for kk, klotterplanket for sf) get
+  # their tables in the shared dev database; overlapping apps migrate once.
+  # All web containers wait for this to finish before starting.
   # collectstatic is skipped — WHITENOISE_USE_FINDERS=True (set when DEBUG) has
   # each container serve static files directly from its own STATICFILES_DIRS.
   init:
     env_file: .env
     build: .
     restart: "no"
-    command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python manage.py migrate --noinput && python manage.py compilemessages -l en -l fi -l sv --verbosity 0"
+    command: /bin/bash -c "./wait-for-postgres.sh db:5432 && for variant in date kk sf; do PROJECT_NAME=\${variant} python manage.py migrate --noinput || exit 1; done && python manage.py compilemessages -l en -l fi -l sv --verbosity 0"
     volumes:
       - .:/code
     environment:


### PR DESCRIPTION
Closes #1092

- New variant_checks job: fresh-process manage.py check for all seven variants + makemigrations --check for the three distinct app sets (date/kk/sf).
- dev-all init now migrates date, kk, and sf app sets so lucia/klotterplanket tables exist in the shared dev database.
- dev-all compose config validated.