### PR TITLE
devx: single-lifecycle clean_init that leaves the stack running

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Once the aliases are registered, the `date-*` commands are the normal way to wor
 ## Database, migrations, and seed data
 
 - Use `date-makemigrations` and `date-migrate` for schema changes. Commit the generated migration files; do not rewrite published migrations.
-- `date-cleaninit` (alias for `./scripts/clean_init.sh`) drops and recreates the development database volumes, loads the local fixture set, generates sample media, and resets the `admin`, `freshman`, and `member` passwords to `admin`. **All local data will be deleted.**
+- `date-cleaninit` (alias for `./scripts/clean_init.sh`) drops and recreates the development database, loads the local fixture set, generates sample media, resets the `admin`, `freshman`, and `member` passwords to `admin`, and leaves the stack running (pass `--no-start` to only reset). **All local data will be deleted.**
 - If your shell does not expose aliases, run `/bin/bash ./scripts/clean_init.sh` directly.
 - To inspect data manually, open a shell in the container: `docker compose run --rm web python manage.py shell`.
 - Re-run `date-createsuperuser` after resetting the database so you keep admin access.

--- a/scripts/clean_init.sh
+++ b/scripts/clean_init.sh
@@ -102,26 +102,29 @@ if [[ "$DELETE_MEDIA" == "true" ]]; then
     echo "Media files deleted."
 fi
 
-echo "Shutting down containers..."
+echo "Stopping the stack (keeps volumes)..."
 docker_compose down --remove-orphans
 
-echo "Building required images and starting database container..."
-docker_compose build db web
+echo "Building the web image and starting the database container..."
+docker_compose build web
 docker_compose up -d db
 
 wait_for_db
 
 echo "Recreating database..."
-docker_compose exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS temp;" 2>/dev/null || true
-docker_compose exec -T db psql -U postgres -c "CREATE DATABASE temp;"
-docker_compose exec -T db psql -U postgres -d temp -c "DROP DATABASE postgres;"
-docker_compose exec -T db psql -U postgres -d temp -c "CREATE DATABASE postgres;"
-docker_compose exec -T db psql -U postgres -c "DROP DATABASE temp;"
+docker_compose exec -T db psql -U postgres -v ON_ERROR_STOP=1 <<'SQL'
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'postgres' AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS temp;
+CREATE DATABASE temp;
+DROP DATABASE postgres;
+CREATE DATABASE postgres;
+DROP DATABASE temp;
+SQL
 
 echo "Database cleared."
 
 echo "Running migrations and loading fixtures..."
-docker_compose run --rm web /bin/bash -c "
+docker_compose run --rm --no-deps web /bin/bash -c "
     ./wait-for-postgres.sh db:5432 && \
     python /code/manage.py migrate --noinput && \
     ./scripts/load_all_fixtures.sh && \
@@ -135,8 +138,6 @@ print('Passwords set for all users.')
 \"
 "
 
-docker_compose down --remove-orphans
-
 echo ""
 echo "============================================"
 echo "Clean init completed successfully!"
@@ -147,6 +148,15 @@ echo "  - admin (superuser)    password: admin"
 echo "  - freshman             password: admin"
 echo "  - member               password: admin"
 echo ""
+echo "Starting the stack..."
 echo "Login at: http://localhost:8000/admin"
 echo ""
-echo "Run 'date-start' or 'docker compose up -d' to start the server."
+
+# Leave the stack running: start (no rebuild; the image was built above)
+# unless the caller only wanted the reset (--no-start).
+if [[ "$*" != *"--no-start"* ]]; then
+    docker_compose up -d
+    echo "Stack started. Web: http://localhost:8000"
+else
+    echo "--no-start given; run 'date-start' or 'docker compose up -d' to start."
+fi


### PR DESCRIPTION
Closes #1102

- Stop once (volumes kept), build only the web image, recreate the DB in a single psql session, migrate + fixtures with --no-deps, then start the stack.
- --no-start keeps the old reset-only behavior.
- README updated; bash -n passes.