### PR TITLE
k8s: fix plain migration Job name under Argo CD (tag+digest suffix)

### DIFF
--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.10
+version: 0.3.11
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/job-migrate.yaml
+++ b/charts/date-website/templates/job-migrate.yaml
@@ -1,7 +1,18 @@
 {{- if .Values.migrations.job.enabled -}}
 {{- $jobName := printf "%s-migrate" (include "date-website.fullname" .) -}}
 {{- if not .Values.migrations.job.hook -}}
-{{- $jobName = printf "%s-%s" $jobName (printf "%d" .Release.Revision) -}}
+{{- /*
+  Plain Jobs are tracked by GitOps (Argo CD sync waves) and the completed
+  Job stays as desired state, so the name must change whenever the image
+  changes, or the next sync fails with "field is immutable" (Job pod
+  templates are immutable). Helm's Release.Revision does NOT work under
+  Argo CD (it always renders as 1). Suffix with the pinned tag + digest
+  instead: a fresh name per image, stable across no-op re-syncs.
+*/ -}}
+{{- $suffix := .Values.image.tag -}}
+{{- if .Values.image.digest }}{{ $suffix = printf "%s-%s" $suffix .Values.image.digest }}{{ end -}}
+{{- $suffix = regexReplaceAll "[^a-z0-9-]" (lower $suffix) "-" -}}
+{{- $jobName = printf "%s-%s" $jobName $suffix -}}
 {{- end -}}
 apiVersion: batch/v1
 kind: Job

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -301,10 +301,13 @@ migrations:
   job:
     enabled: false
     # Helm hook lifecycle (post-install,post-upgrade), or empty for a plain
-    # Job tracked by GitOps. Plain Jobs get a revision-suffixed name and run
-    # under Argo sync waves, which guarantees migration completion before
-    # application pods start; they must NOT set ttlSecondsAfterFinished,
-    # because Argo keeps the completed Job as desired state.
+    # Job tracked by GitOps. Plain Jobs get a name suffixed with the pinned
+    # image tag + digest and run under Argo sync waves, which guarantees
+    # migration completion before application pods start; they must NOT set
+    # ttlSecondsAfterFinished, because Argo keeps the completed Job as
+    # desired state. (Helm's Release.Revision is NOT usable here: Argo CD
+    # renders it as 1, so a revision-suffixed name never changes and the
+    # second sync fails on the immutable Job pod template.)
     hook: post-install,post-upgrade
     hookDeletePolicy: before-hook-creation,hook-succeeded
     backoffLimit: 3

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -82,8 +82,11 @@ Migrations run as a single migration Job per release. Two modes:
   `migrations.job.annotations`, with `argocd.argoproj.io/sync-wave: "1"` on
   the web/asgi/celery Deployments (`.Values.<component>.annotations`).
   Argo then runs migrations to completion before rolling the application.
-  The Job gets a revision-suffixed name, stays completed as desired state
-  (no TTL), and the previous revision's Job is pruned on the next sync.
+  The Job gets a name suffixed with the pinned image tag + digest, stays
+  completed as desired state (no TTL), and the previous image's Job is
+  pruned on the next sync. (Helm's Release.Revision cannot suffix the name:
+  Argo CD renders it as 1, so the name would never change and the second
+  sync would fail on the immutable Job pod template.)
 
 Never enable `web.migrateOnStartup` in production: it couples schema
 mutation to pod readiness, re-runs on every pod restart, and races when the


### PR DESCRIPTION
## Problem

The chart's plain migration Job (GitOps mode, `hook: ""`) names itself `<fullname>-migrate-<Release.Revision>`. Under Argo CD, Helm's `Release.Revision` always renders as **1**, so the Job name never changes between syncs. The second sync then tries to patch the completed Job's pod template and fails with `field is immutable` (hit on 2026-08-29: qa's re-sync failed; every subsequent digest change would fail the same way).

## Fix

Suffix the plain-mode Job name with the pinned image **tag + digest** instead:

- `tag: prod` + `digest: sha256:aa51…` → `migrate-prod-sha256-aa51…` (fresh name per image; no-op re-syncs keep the same name and spec)
- semver pins (`tag: v1.9.4`, no digest) → `migrate-v1-9-4`

Each image change creates a fresh Job; Argo prunes the previous one (prune: true). No-op re-syncs render an identical spec, so the immutable constraint is never hit. The suffix is sanitized to lowercase alphanumerics + dashes (Job name rules).

## Notes

- Hook mode (non-GitOps) keeps the `Release.Revision` suffix, where Helm increments it normally.
- Chart bumped to 0.3.11; the helm_chart.yaml workflow publishes it on merge.
- Verified with helm template: both name forms render as expected.