### PR TITLE
k8s: bound the migration Job name to 63 bytes (tag + short hash suffix)

### DIFF
--- a/.github/workflows/helm_chart.yaml
+++ b/.github/workflows/helm_chart.yaml
@@ -61,6 +61,27 @@ jobs:
             exit 1
           fi
 
+      - name: Check migration Job name stays under 63 bytes
+        run: |
+          set -euo pipefail
+          # Kubernetes copies the Job name into a pod-template label
+          # (batch.kubernetes.io/job-name); label values are capped at
+          # 63 bytes, so an over-long name renders but is rejected by the
+          # API server (2026-08-29 regression caught on the cluster).
+          name="$(
+            helm template ci "${CHART_PATH}" \
+              -f "${CHART_PATH}/values-hetzner.yaml" \
+              --set secret.existingSecret=ci-secrets \
+              --set gateway.https.secretName=ci-tls \
+              --set database.external.host=db.internal \
+              --set-string image.tag=prod \
+              --set-string image.digest=sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+              | awk '/kind: Job/{getline; getline; gsub(/^  name: /, ""); print; exit}'
+          )"
+          len="${#name}"
+          echo "migration Job name: ${name} (${len} bytes)"
+          [ "${len}" -le 63 ] || { echo "migration Job name exceeds 63 bytes"; exit 1; }
+
       - name: Package chart
         id: package
         run: |

--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.3.11
+version: 0.3.12
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/job-migrate.yaml
+++ b/charts/date-website/templates/job-migrate.yaml
@@ -6,13 +6,22 @@
   Job stays as desired state, so the name must change whenever the image
   changes, or the next sync fails with "field is immutable" (Job pod
   templates are immutable). Helm's Release.Revision does NOT work under
-  Argo CD (it always renders as 1). Suffix with the pinned tag + digest
-  instead: a fresh name per image, stable across no-op re-syncs.
+  Argo CD (it always renders as 1).
+  Suffix with the sanitized tag + a short hash of the raw tag|digest pair:
+  deterministic per image, fresh on image change, collision-safe for tags
+  that differ only in characters sanitization collapses (v1.9.4 vs
+  v1-9-4). The whole name must stay <= 63 bytes: Kubernetes copies the
+  Job name into a pod-template label (batch.kubernetes.io/job-name), and
+  label values are capped at 63 bytes. Fall back to just the suffix if the
+  fullname would overflow.
 */ -}}
-{{- $suffix := .Values.image.tag -}}
-{{- if .Values.image.digest }}{{ $suffix = printf "%s-%s" $suffix .Values.image.digest }}{{ end -}}
-{{- $suffix = regexReplaceAll "[^a-z0-9-]" (lower $suffix) "-" -}}
+{{- $raw := printf "%s|%s" .Values.image.tag .Values.image.digest -}}
+{{- $hash := substr 0 12 (sha256sum $raw) -}}
+{{- $tagPart := trimAll "-" (regexReplaceAll "[^a-z0-9-]" (lower .Values.image.tag) "-") -}}
+{{- if gt (len $tagPart) 12 }}{{ $tagPart = substr 0 12 $tagPart }}{{ end -}}
+{{- $suffix := printf "%s-%s" $tagPart $hash -}}
 {{- $jobName = printf "%s-%s" $jobName $suffix -}}
+{{- if gt (len $jobName) 63 }}{{ $jobName = printf "migrate-%s" $suffix }}{{ end -}}
 {{- end -}}
 apiVersion: batch/v1
 kind: Job

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -302,7 +302,8 @@ migrations:
     enabled: false
     # Helm hook lifecycle (post-install,post-upgrade), or empty for a plain
     # Job tracked by GitOps. Plain Jobs get a name suffixed with the pinned
-    # image tag + digest and run under Argo sync waves, which guarantees
+    # image tag + a short hash of the tag/digest pair and run under Argo
+    # sync waves, which guarantees
     # migration completion before application pods start; they must NOT set
     # ttlSecondsAfterFinished, because Argo keeps the completed Job as
     # desired state. (Helm's Release.Revision is NOT usable here: Argo CD

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -82,11 +82,13 @@ Migrations run as a single migration Job per release. Two modes:
   `migrations.job.annotations`, with `argocd.argoproj.io/sync-wave: "1"` on
   the web/asgi/celery Deployments (`.Values.<component>.annotations`).
   Argo then runs migrations to completion before rolling the application.
-  The Job gets a name suffixed with the pinned image tag + digest, stays
-  completed as desired state (no TTL), and the previous image's Job is
-  pruned on the next sync. (Helm's Release.Revision cannot suffix the name:
-  Argo CD renders it as 1, so the name would never change and the second
-  sync would fail on the immutable Job pod template.)
+  The Job gets a name suffixed with the sanitized tag + a short hash of the
+  tag/digest pair (kept under 63 bytes: Kubernetes mirrors the Job name
+  into a pod-template label), stays completed as desired state (no TTL),
+  and the previous image's Job is pruned on the next sync. (Helm's
+  Release.Revision cannot suffix the name: Argo CD renders it as 1, so the
+  name would never change and the second sync would fail on the immutable
+  Job pod template.)
 
 Never enable `web.migrateOnStartup` in production: it couples schema
 mutation to pod readiness, re-runs on every pod restart, and races when the


### PR DESCRIPTION
## Problem

The 0.3.11 migration Job name (sanitized tag + full 64-hex digest) exceeds the **63-byte limit for pod-template label values**: Kubernetes mirrors the Job name into `batch.kubernetes.io/job-name`, so the API server rejects the Job and every Argo sync fails with `must be no more than 63 bytes`. Caught live at the 0.3.11 rollout on 2026-08-29.

## Fix

`<fullname>-migrate-<sanitized tag, max 12 chars>-<12 hex chars of sha256(tag|digest)>`

- Fresh Job name per image (digest or tag change), deterministic across no-op re-syncs
- Collision-safe for tags that sanitize identically (`v1.9.4` vs `v1-9-4` vs `QA` vs `qa` produce different hashes)
- Bounded: falls back to the bare suffix if the fullname would overflow 63 bytes
- Example: `pulterit-date-website-migrate-prod-e01db08107dc` (47 bytes)

Also adds a CI check in helm_chart.yaml that renders the Job and asserts the name is ≤ 63 bytes (helm lint does not validate k8s name constraints, which is how this slipped through). Chart bumped to 0.3.12.