### PR TITLE
k8s: migration Job name follow-up (effective tag in hash, hardened CI check)

### DIFF
--- a/.github/workflows/helm_chart.yaml
+++ b/.github/workflows/helm_chart.yaml
@@ -68,19 +68,42 @@ jobs:
           # (batch.kubernetes.io/job-name); label values are capped at
           # 63 bytes, so an over-long name renders but is rejected by the
           # API server (2026-08-29 regression caught on the cluster).
-          name="$(
+          job_name() { # job_name <args...> -> prints the migration Job name
             helm template ci "${CHART_PATH}" \
-              -f "${CHART_PATH}/values-hetzner.yaml" \
               --set secret.existingSecret=ci-secrets \
               --set gateway.https.secretName=ci-tls \
               --set database.external.host=db.internal \
               --set-string image.tag=prod \
               --set-string image.digest=sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+              "$@" \
               | awk '/kind: Job/{getline; getline; gsub(/^  name: /, ""); print; exit}'
-          )"
-          len="${#name}"
-          echo "migration Job name: ${name} (${len} bytes)"
-          [ "${len}" -le 63 ] || { echo "migration Job name exceeds 63 bytes"; exit 1; }
+          }
+          check_job_name() { # check_job_name <label> <args...>
+            local label="$1"; shift
+            local name
+            name="$(job_name "$@")"
+            [ -n "${name}" ] || { echo "${label}: no migration Job rendered"; exit 1; }
+            [[ "${name}" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] \
+              || { echo "${label}: Job name not a valid DNS subdomain: ${name}"; exit 1; }
+            [ "${#name}" -le 63 ] \
+              || { echo "${label}: migration Job name exceeds 63 bytes: ${name}"; exit 1; }
+            echo "${label}: ${name} (${#name} bytes)"
+          }
+          check_job_name "digest-pinned" \
+            -f "${CHART_PATH}/values-hetzner.yaml"
+          check_job_name "semver tag, no digest" \
+            -f "${CHART_PATH}/values-hetzner.yaml" \
+            --set-string image.tag=v1.9.4 --set-string image.digest=""
+          check_job_name "long fullname fallback" \
+            -f "${CHART_PATH}/values-hetzner.yaml" \
+            --set-string fullnameOverride=abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+          # tags that sanitize identically must still produce distinct names
+          # (base values: pinInProduction false accepts arbitrary tags)
+          a="$(job_name --set 'migrations.job.enabled=true' --set 'migrations.job.hook=' --set-string image.tag=v1.9.4 --set-string image.digest="")"
+          b="$(job_name --set 'migrations.job.enabled=true' --set 'migrations.job.hook=' --set-string image.tag=v1-9-4 --set-string image.digest="")"
+          [ -n "${a}" ] && [ -n "${b}" ] || { echo "collision render failed: '${a}' vs '${b}'"; exit 1; }
+          [ "${a}" != "${b}" ] || { echo "sanitization collision: ${a} == ${b}"; exit 1; }
+          echo "collision pair distinct: ${a} != ${b}"
 
       - name: Package chart
         id: package

--- a/charts/date-website/templates/job-migrate.yaml
+++ b/charts/date-website/templates/job-migrate.yaml
@@ -15,9 +15,10 @@
   label values are capped at 63 bytes. Fall back to just the suffix if the
   fullname would overflow.
 */ -}}
-{{- $raw := printf "%s|%s" .Values.image.tag .Values.image.digest -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $raw := printf "%s|%s" $tag .Values.image.digest -}}
 {{- $hash := substr 0 12 (sha256sum $raw) -}}
-{{- $tagPart := trimAll "-" (regexReplaceAll "[^a-z0-9-]" (lower .Values.image.tag) "-") -}}
+{{- $tagPart := trimAll "-" (regexReplaceAll "[^a-z0-9-]" (lower $tag) "-") -}}
 {{- if gt (len $tagPart) 12 }}{{ $tagPart = substr 0 12 $tagPart }}{{ end -}}
 {{- $suffix := printf "%s-%s" $tagPart $hash -}}
 {{- $jobName = printf "%s-%s" $jobName $suffix -}}


### PR DESCRIPTION
Follow-up corrections from the #1144 review that landed after the merge:

## 1. Effective tag in the Job name hash

`charts/date-website/templates/job-migrate.yaml`: the hash and sanitized suffix now use `image.tag | default .Chart.AppVersion` (what the image helper actually renders), instead of the raw `.Values.image.tag`. With `image.tag: ""` and no digest, an appVersion bump changes the deployed image and the Job name together, so the immutable-Job failure this naming exists to prevent stays unreachable.

## 2. Hardened CI length check (`helm_chart.yaml`)

- Asserts the rendered Job name is present (an empty extraction previously passed the length check with len=0) and is a valid DNS subdomain
- Covers digest-pinned, semver (no digest), long-fullname fallback (must stay ≤ 63 bytes), and verifies a sanitization-collision pair (`v1.9.4` vs `v1-9-4`) renders distinct names

No chart version bump needed (rendered output for real tags is unchanged); the helm_chart workflow only runs on main, so these checks execute on merge.