### PR TITLE
docker: collect django-unfold static for the unfold variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,19 @@ RUN python manage.py compilemessages -l en -l fi -l sv
 # collection. Settings pick the tree matching the runtime PROJECT_NAME.
 ARG PROJECT_NAME=date
 ENV PROJECT_NAME=$PROJECT_NAME
+# Prod runs the unfold admin skin (USE_UNFOLD=True via extraEnv) on the date
+# (incl. qa), pulterit, sf and impuls variants; kk, biocum and demo keep the
+# stock admin. collectstatic only discovers app static dirs for apps in
+# INSTALLED_APPS, so unfold's files must be collected with USE_UNFOLD=True or
+# every unfold admin template render 500s on the missing manifest entry
+# (2026-08-30).
 RUN for variant in date kk pulterit biocum sf impuls demo; do \
       echo "Collecting static for ${variant}"; \
-      PROJECT_NAME="${variant}" STATIC_ROOT="/code/static-collected/${variant}" \
+      case "${variant}" in \
+        date|pulterit|sf|impuls) UNFOLD=True ;; \
+        *) UNFOLD=False ;; \
+      esac; \
+      USE_UNFOLD="${UNFOLD}" PROJECT_NAME="${variant}" STATIC_ROOT="/code/static-collected/${variant}" \
         python manage.py collectstatic --noinput --clear || exit 1; \
     done
 # The trees share ~99% of their files (common assets plus third-party static

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -148,6 +148,13 @@ This keeps one generic image for all variants: no per-association images,
 no startup collection, no way for an image and its values to disagree on
 the variant.
 
+The build collects `django-unfold` static only for the variants that run the
+unfold admin skin (`USE_UNFOLD=True`: date incl. qa, pulterit, sf, impuls);
+kk, biocum and demo keep the stock admin. `collectstatic` only discovers app
+static dirs for apps in `INSTALLED_APPS`, so a variant collected without
+`USE_UNFOLD=True` renders the unfold admin with 500s on the missing
+`unfold/fonts/inter/styles.css` manifest entry (2026-08-30).
+
 If static-on-S3 (see issue) lands, collection moves from the image build to
 a release-time upload into the existing per-association media bucket, and
 pods stop carrying static entirely.


### PR DESCRIPTION
## Problem

Production sites running the django-unfold admin skin (`USE_UNFOLD=True`
via extraEnv: date incl. qa, pulterit, sf, impuls) 500 on every admin page
when logged in:

```
ValueError: The file 'unfold/fonts/inter/styles.css' could not be found
```

The build-time `collectstatic` loop never set `USE_UNFOLD`, so unfold was
not in `INSTALLED_APPS` during collection and its static files were missing
from the affected variants' collected trees and `staticfiles.json`
manifests. At runtime the template's `{% static %}` lookup then failed
(manifest entry absent, file absent from the collected root).

## Fix

Set `USE_UNFOLD` per variant in the Dockerfile collectstatic loop: `True`
for date/pulterit/sf/impuls, `False` for kk/biocum/demo (they keep the
stock admin and must not pick up unfold assets).

## Verification

Local amd64 build of this branch:

- date/pulterit/sf/impuls trees: 36 unfold manifest keys, `styles.css`
  present
- kk/biocum/demo trees: 0 unfold keys (unchanged)
- runtime resolution of the failing path in the built image:
  `staticfiles_storage.url("unfold/fonts/inter/styles.css")` returns the
  hashed URL instead of raising