### PR TITLE
fix: admin media static paths; parallelize build-time collectstatic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,21 +26,25 @@ RUN python manage.py compilemessages -l en -l fi -l sv
 # collection. Settings pick the tree matching the runtime PROJECT_NAME.
 ARG PROJECT_NAME=date
 ENV PROJECT_NAME=$PROJECT_NAME
-# Prod runs the unfold admin skin (USE_UNFOLD=True via extraEnv) on the date
-# (incl. qa), pulterit, sf and impuls variants; kk, biocum and demo keep the
-# stock admin. collectstatic only discovers app static dirs for apps in
-# INSTALLED_APPS, so unfold's files must be collected with USE_UNFOLD=True or
-# every unfold admin template render 500s on the missing manifest entry
-# (2026-08-30).
-RUN for variant in date kk pulterit biocum sf impuls demo; do \
+# Collect each variant's static concurrently into its own tree. Prod runs the
+# unfold admin skin (USE_UNFOLD=True via extraEnv) on the date (incl. qa),
+# pulterit, sf and impuls variants; kk and biocum keep the stock admin.
+# collectstatic only discovers app static dirs for apps in INSTALLED_APPS, so
+# unfold's files must be collected with USE_UNFOLD=True or every unfold admin
+# template render 500s on the missing manifest entry (2026-08-30). demo is a
+# dev-only variant and needs no collected tree in the image.
+RUN pids=""; \
+    for variant in date kk pulterit biocum sf impuls; do \
       echo "Collecting static for ${variant}"; \
       case "${variant}" in \
         date|pulterit|sf|impuls) UNFOLD=True ;; \
         *) UNFOLD=False ;; \
       esac; \
-      USE_UNFOLD="${UNFOLD}" PROJECT_NAME="${variant}" STATIC_ROOT="/code/static-collected/${variant}" \
-        python manage.py collectstatic --noinput --clear || exit 1; \
-    done
+      ( USE_UNFOLD="${UNFOLD}" PROJECT_NAME="${variant}" STATIC_ROOT="/code/static-collected/${variant}" \
+          python manage.py collectstatic --noinput --clear ) & \
+      pids="${pids} $!"; \
+    done; \
+    for pid in ${pids}; do wait "${pid}" || exit 1; done
 # The trees share ~99% of their files (common assets plus third-party static
 # such as CKEditor), so deduplicate identical files with hardlinks: ~350 MiB
 # of collected output collapses to ~55 MiB on disk. The source static/ dir is

--- a/core/admin.py
+++ b/core/admin.py
@@ -27,8 +27,8 @@ class LanguageTabbedTranslationAdmin(TranslationAdmin):
     """
 
     class Media:
-        css = {"all": ("common/css/admin_translation_tabs.css",)}
-        js = ("common/js/admin_translation_tabs.js",)
+        css = {"all": ("css/admin_translation_tabs.css",)}
+        js = ("js/admin_translation_tabs.js",)
 
 
 class ActiveLanguageTranslationAdminMixin:

--- a/core/tests/test_admin_ux.py
+++ b/core/tests/test_admin_ux.py
@@ -126,7 +126,7 @@ class AdminUxLinkTests(TestCase):
         self.assertContains(page_response, "/pages/about/")
         self.assertContains(page_response, "sv: 1/2; en: 0/2; fi: 0/2")
         self.assertEqual(page_change_response.status_code, 200)
-        self.assertContains(page_change_response, "common/js/admin_translation_tabs.js")
+        self.assertContains(page_change_response, "js/admin_translation_tabs.js")
         self.assertNotContains(page_change_response, "ajax.googleapis.com/ajax/libs/jqueryui")
         self.assertEqual(nav_response.status_code, 200)
         self.assertContains(nav_response, "About page")

--- a/core/tests/test_modeltranslation.py
+++ b/core/tests/test_modeltranslation.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from django.conf import settings
 from django.contrib import admin
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
@@ -5,6 +8,7 @@ from core.admin import LanguageTabbedTranslationAdmin
 from core.modeltranslation import get_translation_languages
 from functionaries.admin import FunctionaryRoleAdmin
 from functionaries.models import FunctionaryRole
+from publications.admin import PDFFileAdmin
 
 
 class ModeltranslationLanguageTests(SimpleTestCase):
@@ -21,6 +25,36 @@ class ModeltranslationLanguageTests(SimpleTestCase):
         self.assertIn('js/admin_translation_tabs.js', str(model_admin.media))
         self.assertNotIn('ajax.googleapis.com/ajax/libs/jqueryui', str(model_admin.media))
         self.assertEqual(model_admin.translation_status(FunctionaryRole(title_sv='Chair')), 'sv: 1/1; en: 0/1')
+
+    def test_admin_media_paths_resolve_in_the_static_layout(self):
+        """Admin Media paths must match the collected static layout.
+
+        STATICFILES_DIRS collects static/common contents without the common/
+        prefix (static/common/js/admin_translation_tabs.js is served as
+        js/admin_translation_tabs.js), and every template references common
+        assets unprefixed. A common/... Media reference (or a missing file)
+        makes the manifest lookup fail and 500s every admin page using that
+        Media class (2026-08-30).
+        """
+        common_static = Path(settings.BASE_DIR) / 'static/common'
+
+        for admin_class in (LanguageTabbedTranslationAdmin, PDFFileAdmin):
+            media = admin_class.Media
+            paths = [*getattr(media, 'js', ())]
+            for group in getattr(media, 'css', {}).values():
+                paths.extend(group)
+            self.assertTrue(paths, f'{admin_class.__name__}.Media declares no paths')
+            for path in paths:
+                self.assertFalse(
+                    path.startswith('common/'),
+                    f'{admin_class.__name__}.Media references {path} with the '
+                    'common/ prefix, which the static layout strips',
+                )
+                self.assertTrue(
+                    (common_static / path).is_file(),
+                    f'{admin_class.__name__}.Media references {path}, which '
+                    f'does not exist under {common_static}',
+                )
 
     @override_settings(ENABLE_LANGUAGE_FEATURES=False)
     def test_translation_coverage_is_hidden_when_language_features_are_disabled(self):

--- a/core/tests/test_modeltranslation.py
+++ b/core/tests/test_modeltranslation.py
@@ -18,7 +18,7 @@ class ModeltranslationLanguageTests(SimpleTestCase):
         self.assertIn('title_sv', form.base_fields)
         self.assertIn('title_en', form.base_fields)
         self.assertNotIn('title_fi', form.base_fields)
-        self.assertIn('common/js/admin_translation_tabs.js', str(model_admin.media))
+        self.assertIn('js/admin_translation_tabs.js', str(model_admin.media))
         self.assertNotIn('ajax.googleapis.com/ajax/libs/jqueryui', str(model_admin.media))
         self.assertEqual(model_admin.translation_status(FunctionaryRole(title_sv='Chair')), 'sv: 1/1; en: 0/1')
 

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -134,10 +134,11 @@ new pods can overlap during rollouts.
 
 ## Static files
 
-Every association's static is collected into the image at build time, one
-tree per variant under `/code/static-collected/<PROJECT_NAME>`. Settings
-pick the tree matching the runtime `PROJECT_NAME`, so every site serves
-build-time static and no web pod runs `collectstatic` at startup
+Every production association's static is collected into the image at build
+time, one tree per variant under `/code/static-collected/<PROJECT_NAME>`
+(the dev-only demo variant gets no tree). Settings pick the tree matching
+the runtime `PROJECT_NAME`, so every site serves build-time static and no
+web pod runs `collectstatic` at startup
 (`web.collectstaticOnStartup` defaults to false; keep it only for images
 built before this layout).
 

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -148,12 +148,14 @@ This keeps one generic image for all variants: no per-association images,
 no startup collection, no way for an image and its values to disagree on
 the variant.
 
-The build collects `django-unfold` static only for the variants that run the
-unfold admin skin (`USE_UNFOLD=True`: date incl. qa, pulterit, sf, impuls);
-kk, biocum and demo keep the stock admin. `collectstatic` only discovers app
-static dirs for apps in `INSTALLED_APPS`, so a variant collected without
-`USE_UNFOLD=True` renders the unfold admin with 500s on the missing
-`unfold/fonts/inter/styles.css` manifest entry (2026-08-30).
+The build collects each variant's static concurrently into its own tree, and
+collects `django-unfold` static only for the variants that run the unfold
+admin skin (`USE_UNFOLD=True`: date incl. qa, pulterit, sf, impuls); kk and
+biocum keep the stock admin and the dev-only demo variant gets no collected
+tree. `collectstatic` only discovers app static dirs for apps in
+`INSTALLED_APPS`, so a variant collected without `USE_UNFOLD=True` renders
+the unfold admin with 500s on the missing `unfold/fonts/inter/styles.css`
+manifest entry (2026-08-30).
 
 If static-on-S3 (see issue) lands, collection moves from the image build to
 a release-time upload into the existing per-association media bucket, and

--- a/publications/admin.py
+++ b/publications/admin.py
@@ -464,4 +464,4 @@ class PDFFileAdmin(PublicUrlAdminMixin, PublicationAdminMixin, ModelAdmin):
         return obj.collection.get_visibility_display()
 
     class Media:
-        js = ('common/publications/js/admin-collection-access.js',)
+        js = ('publications/js/admin-collection-access.js',)


### PR DESCRIPTION
## Problem

Admin pages that use translated-field tabs (staticpages nav, events, ...)
and the publications collection-access widget 500 when logged in:

```
ValueError: The file 'common/css/admin_translation_tabs.css' could not be found
```

The admin `Media` references pointed at `common/...` paths, but the
per-variant static layout (`static/<variant>` + `static/common` in
`STATICFILES_DIRS`) collects `static/common` contents without the prefix;
every template in the codebase uses the unprefixed form (e.g.
`events/css/style.css`). The errors were masked until the unfold static
fix (#1147) by the unfold 500, which fired first on every admin render.

## Changes

- `core/admin.py`, `publications/admin.py`: drop the `common/` prefix from
  the three Media references; update the two tests asserting the old path.
- `Dockerfile`: run the per-variant collectstatic loop in parallel and drop
  the dev-only `demo` variant (no collected tree needed in the prod image).

## Verification

- Local amd64 build: collectstatic step 69.7s (sequential, 7 variants) ->
  15.3s (parallel, 6 variants).
- Manifests: `css/admin_translation_tabs.css`,
  `publications/js/admin-collection-access.js` present on all variants;
  unfold keys only on date/pulterit/sf/impuls (36 each), none on kk/biocum.
- Runtime resolution of all previously broken paths returns hashed URLs.
- `core.tests.test_admin_ux`, `core.tests.test_modeltranslation`,
  `publications` tests: 36 tests pass.