### PR TITLE
docker: keep the source static dir for the release-time S3 upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,9 @@ RUN pids=""; \
     for pid in ${pids}; do wait "${pid}" || exit 1; done
 # The trees share ~99% of their files (common assets plus third-party static
 # such as CKEditor), so deduplicate identical files with hardlinks: ~350 MiB
-# of collected output collapses to ~55 MiB on disk. The source static/ dir is
-# then removed; it is only input for collectstatic, and prod serves the
-# collected trees (dev compose bind-mounts the repo). Any release-time static
-# upload (S3) must push these trees, not re-run collectstatic from sources.
-RUN python scripts/dedup_static.py /code/static-collected \
- && rm -rf static/
+# of collected output collapses to ~55 MiB on disk. The source static/ dir
+# stays in the image: it is the input for the release-time collectstatic
+# upload when a site serves static from S3 (STATIC_S3_ENABLED, migration Job
+# runs collectstatic before the app pods roll), and prod serves the collected
+# trees (dev compose bind-mounts the repo).
+RUN python scripts/dedup_static.py /code/static-collected


### PR DESCRIPTION
## Problem

`media.s3.staticEnabled` (static-on-S3, #1121) cannot be enabled: the
migration Job's release-time `collectstatic --noinput` sources files from
`STATICFILES_DIRS` (static/<variant> + static/common) and app dirs, but the
image deleted `static/` after the build-time collection. With the source
gone, only venv app statics (admin, unfold, ...) would be uploaded; every
variant asset (e.g. `date/css/homepage.css`, the whole common tree) would
404 from the bucket, breaking the site's CSS/JS.

## Fix

Keep `static/` in the image (it is ~12 MiB; the collected trees stay
deduplicated by hardlinks as before). The release-time collectstatic now
sources the full per-variant asset set exactly as the build-time
collection did.

## Verification

Local amd64 build + a MinIO stand-in for the bucket, running the
migration-Job-equivalent collectstatic with `STATIC_S3_ENABLED=True` and
`USE_UNFOLD=True` (matching the prod configmap):

- 731 objects uploaded, including `date/css/homepage.css`,
  `css/admin_translation_tabs.css`, `events/css/style.css`,
  `unfold/fonts/inter/styles.css` and `staticfiles.json`
- manifest written to the bucket (runtime lookups resolve via
  `StaticStorage.load_manifest`)

The settings change is intentionally reverted: Django's check E002 rejects
`STATIC_ROOT` inside `STATICFILES_DIRS` (the tree-as-source approach).