### PR TITLE
fix: close DB connections per request under the ASGI handler (executor-thread middleware)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,10 @@ DATE_POSTGRESQL_VERSION=16
 DATE_DB_PASSWORD="password"
 
 # How long (seconds) a database connection is kept alive between requests.
-# 0 disables persistent connections.
-DB_CONN_MAX_AGE=600
+# 0 (default) closes it at request end: the web tier serves ASGI, where each
+# request runs on a per-request thread and persistent connections leak.
+# Long-lived processes (celery) may set a positive value.
+DB_CONN_MAX_AGE=0
 
 # [pgAdmin]
 

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -285,10 +285,17 @@ DATABASES = {
         'PASSWORD': env_alias('DATE_DB_PASSWORD', 'DB_PASSWORD', default=''),
         'HOST': env('DB_HOST', str, 'db'),
         'PORT': env('DB_PORT', int, 5432),
-        # Keep PostgreSQL connections alive between requests to avoid
-        # connection setup latency; must live inside the database config.
-        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 600),
-        # Re-verify persistent connections so they survive database restarts.
+        # Close the connection at the end of every request (0). The web tier
+        # serves ASGI (core.asgi), where each request's sync work runs on a
+        # per-request executor thread that asgiref destroys when the request
+        # finishes; a positive CONN_MAX_AGE leaves the thread-local connection
+        # open on a dead thread, leaking PostgreSQL backends and 500ing later
+        # requests with "connection already closed" (2026-08-31). Long-lived
+        # processes (celery workers, management commands) can opt back into
+        # persistent connections via DB_CONN_MAX_AGE.
+        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 0),
+        # Re-verify persistent connections so they survive database restarts
+        # (only applies when DB_CONN_MAX_AGE is positive).
         'CONN_HEALTH_CHECKS': True,
     }
 }

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -228,6 +228,10 @@ COMMON_CONTEXT_PROCESSORS = [
 
 MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
+    # Must run on the same executor thread as the views: under ASGI the
+    # request_finished signal fires on the event loop thread, so Django's
+    # own close_old_connections never closes the thread-local connection.
+    'date.middleware.CloseConnectionsMiddleware',
     'date.middleware.ServerTimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'date.middleware.LanguageStateMiddleware',
@@ -286,13 +290,14 @@ DATABASES = {
         'HOST': env('DB_HOST', str, 'db'),
         'PORT': env('DB_PORT', int, 5432),
         # Close the connection at the end of every request (0). The web tier
-        # serves ASGI (core.asgi), where each request's sync work runs on a
-        # per-request executor thread that asgiref destroys when the request
-        # finishes; a positive CONN_MAX_AGE leaves the thread-local connection
-        # open on a dead thread, leaking PostgreSQL backends and 500ing later
-        # requests with "connection already closed" (2026-08-31). Long-lived
-        # processes (celery workers, management commands) can opt back into
-        # persistent connections via DB_CONN_MAX_AGE.
+        # serves ASGI (core.asgi): sync middleware and views run on asgiref
+        # executor threads, but the request_finished signal is sent on the
+        # event loop thread, so Django's close_old_connections never runs on
+        # the thread that owns the connection. CloseConnectionsMiddleware
+        # (outermost after WhiteNoise) closes it on the executor thread
+        # instead; 0 here is the same policy for paths outside the middleware
+        # and for long-lived processes unless they opt back in via
+        # DB_CONN_MAX_AGE (2026-08-31).
         'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 0),
         # Re-verify persistent connections so they survive database restarts
         # (only applies when DB_CONN_MAX_AGE is positive).

--- a/core/tests/test_database_settings.py
+++ b/core/tests/test_database_settings.py
@@ -15,5 +15,9 @@ class DatabaseSettingsTests(SimpleTestCase):
         default_db = common.DATABASES["default"]
 
         self.assertIn("CONN_MAX_AGE", default_db)
-        self.assertGreater(default_db["CONN_MAX_AGE"], 0)
+        # The ASGI web tier runs each request on a per-request thread, so a
+        # persistent connection is left open on a thread that asgiref then
+        # destroys: it leaks PostgreSQL backends and 500s later requests.
+        # 0 closes the connection at request end on the same thread.
+        self.assertEqual(default_db["CONN_MAX_AGE"], 0)
         self.assertTrue(default_db["CONN_HEALTH_CHECKS"])

--- a/date/middleware.py
+++ b/date/middleware.py
@@ -2,13 +2,38 @@ import time
 from contextlib import ExitStack
 
 from django.conf import settings
-from django.db import connections
+from django.db import close_old_connections, connections
 from django.shortcuts import render
 from django.utils import translation
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import get_language_from_request
 
 from .language_utils import resolve_language
+
+
+class CloseConnectionsMiddleware:
+    """Close the request thread's DB connection when the request finishes.
+
+    Under Django's ASGI handler (web serves core.asgi), sync middleware and
+    views run on asgiref executor threads, while the ``request_finished``
+    signal is sent asynchronously on the event loop thread, so
+    ``close_old_connections`` never runs on the thread that owns the
+    connection. Every request therefore leaked its thread-local PostgreSQL
+    connection; once the server reaped the idle connection, the next request
+    on that thread 500ed with "connection already closed" (2026-08-31).
+    ``CONN_MAX_AGE`` cannot fix this (no cleanup ever runs on the owning
+    thread), so close unconditionally here, on the same thread as the view.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            response = self.get_response(request)
+        finally:
+            close_old_connections()
+        return response
 
 
 class LanguageStateMiddleware(MiddlewareMixin):

--- a/date/tests.py
+++ b/date/tests.py
@@ -26,6 +26,7 @@ from date.views import (
     format_calendar_events,
     get_homepage_template_name,
     get_recent_albins_angels_post,
+    handler404,
     handler500,
 )
 from events.models import Event
@@ -541,6 +542,16 @@ class LanguageSelectionTests(TestCase):
             response = handler500(request)
         self.assertEqual(response.status_code, 500)
         self.assertContains(response, "Serverfel", status_code=500)
+
+    def test_error_handlers_close_stale_connections_before_rendering(self):
+        # The ASGI error path can reuse a connection that died on a previous
+        # per-request thread; the handlers must close it before rendering so
+        # the error page itself does not 500 with "connection already closed".
+        request = self.factory.get("/")
+        with patch("date.views.close_old_connections") as close:
+            handler404(request)
+            handler500(request)
+        self.assertEqual(close.call_count, 2)
 
     @override_settings(
         ENABLE_LANGUAGE_FEATURES=False,

--- a/date/tests.py
+++ b/date/tests.py
@@ -11,15 +11,17 @@ from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db import connection
+from django.http import HttpResponse
 from django.template import Context, Template
 from django.template.loader import render_to_string
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import clear_url_caches, reverse, set_urlconf
 from django.utils import timezone, translation
 
 from core.admin import admin_site
 from date.language_utils import localize_url, strip_language_prefix
+from date.middleware import CloseConnectionsMiddleware
 from date.views import (
     _homepage_context,
     _homepage_version_key,
@@ -698,6 +700,31 @@ class LanguageSelectionTests(TestCase):
         )
         self.assertIn("https://example.com/facebook", rendered)
         self.assertNotIn('href=""', rendered)
+
+
+class CloseConnectionsMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_closes_connection_after_response(self):
+        # Django's ASGI handler sends request_finished on the event loop
+        # thread, so close_old_connections must also run on the executor
+        # thread that owns the connection, via this middleware.
+        middleware = CloseConnectionsMiddleware(lambda request: HttpResponse("ok"))
+        with patch("date.middleware.close_old_connections") as close:
+            response = middleware(self.factory.get("/"))
+        self.assertEqual(response.status_code, 200)
+        close.assert_called_once_with()
+
+    def test_closes_connection_when_view_raises(self):
+        def boom(request):
+            raise RuntimeError("boom")
+
+        middleware = CloseConnectionsMiddleware(boom)
+        with patch("date.middleware.close_old_connections") as close:
+            with self.assertRaises(RuntimeError):
+                middleware(self.factory.get("/"))
+        close.assert_called_once_with()
 
 
 class HomepageTemplateSelectionTests(TestCase):

--- a/date/views.py
+++ b/date/views.py
@@ -5,7 +5,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import connection, transaction
+from django.db import close_old_connections, connection, transaction
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -188,12 +188,17 @@ def set_language(request):
 
 
 def handler404(request, *args, **argv):
+    # The ASGI error path can reuse a connection that died on a previous
+    # per-request thread; close before rendering so the error page itself
+    # does not 500 with "connection already closed".
+    close_old_connections()
     response = render(request, 'core/404.html', {})
     response.status_code = 404
     return response
 
 
 def handler500(request, *args, **argv):
+    close_old_connections()
     response = render(request, 'core/500.html', {})
     response.status_code = 500
     return response

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,11 @@ services:
     image: ghcr.io/datateknologerna-vid-abo-akademi/date-website:${DATE_IMG_TAG}
     restart: always
     command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && exec gunicorn -k uvicorn_worker.UvicornWorker -w 3 --timeout 120 --max-requests 0 --max-requests-jitter 0 --bind=0.0.0.0 core.asgi:application"
+    environment:
+      # ASGI web: close DB connections at request end (each request runs on
+      # a per-request thread, so persistent connections leak). Takes
+      # precedence over DB_CONN_MAX_AGE from .env.
+      DB_CONN_MAX_AGE: "0"
     depends_on:
       - db
       - redis

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -330,14 +330,18 @@ Bucket requirements (one-time):
   operator values must drop their `asgi:` overrides; WebSocket traffic
   follows the normal `/` path to the web service.
 - DB connections close at the end of every request under the ASGI handler
-  (`CONN_MAX_AGE = 0`, `DB_CONN_MAX_AGE` env): each request's sync work runs
-  on a per-request executor thread that asgiref destroys when the request
-  finishes, so a positive `CONN_MAX_AGE` leaves the thread-local connection
-  open on a dead thread, leaking PostgreSQL backends and 500ing later
-  requests with `InterfaceError: connection already closed` (2026-08-31).
-  `handler404`/`handler500` call `close_old_connections()` so the error
-  path never reuses a poisoned connection. Long-lived processes (celery,
-  management commands) may opt back into persistent connections via
-  `DB_CONN_MAX_AGE`.
+  (2026-08-31). Sync middleware and views run on asgiref executor threads,
+  but Django's ASGI handler sends the `request_finished` signal on the event
+  loop thread, so `close_old_connections` never runs on the thread that owns
+  the thread-local connection. Every request leaked its PostgreSQL
+  connection; once the server reaped the idle connection, the next request
+  on that thread 500ed with `InterfaceError: connection already closed`
+  (`CONN_MAX_AGE`/`CONN_HEALTH_CHECKS` cannot fix this, the cleanup never
+  runs on the owning thread). Fix: `date.middleware.CloseConnectionsMiddleware`
+  (outermost after WhiteNoise) closes the connection on the executor thread
+  after every request, `handler404`/`handler500` close before rendering the
+  error page, and `CONN_MAX_AGE = 0` is the settings default for paths
+  outside the middleware. Long-lived processes (celery, management commands)
+  may opt back into persistent connections via `DB_CONN_MAX_AGE`.
 - Media must stay on S3-compatible storage before web replicas are ever
   scaled up; a local RWO PVC would block scaling and failover.

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -329,5 +329,15 @@ Bucket requirements (one-time):
   so the `/ws` ingress/gateway route and the asgi Service are gone. Per-site
   operator values must drop their `asgi:` overrides; WebSocket traffic
   follows the normal `/` path to the web service.
+- DB connections close at the end of every request under the ASGI handler
+  (`CONN_MAX_AGE = 0`, `DB_CONN_MAX_AGE` env): each request's sync work runs
+  on a per-request executor thread that asgiref destroys when the request
+  finishes, so a positive `CONN_MAX_AGE` leaves the thread-local connection
+  open on a dead thread, leaking PostgreSQL backends and 500ing later
+  requests with `InterfaceError: connection already closed` (2026-08-31).
+  `handler404`/`handler500` call `close_old_connections()` so the error
+  path never reuses a poisoned connection. Long-lived processes (celery,
+  management commands) may opt back into persistent connections via
+  `DB_CONN_MAX_AGE`.
 - Media must stay on S3-compatible storage before web replicas are ever
   scaled up; a local RWO PVC would block scaling and failover.


### PR DESCRIPTION
## Summary

Fixes the intermittent 500s introduced by the asgi merge (#1146) without reverting the single-pool topology.

## Root cause (two layers)

1. Under Django's ASGI handler, sync middleware and views run on asgiref executor threads (thread-local DB connections), while the `request_finished` signal is sent **asynchronously on the event loop thread** (`signals.request_finished.asend` in `handlers/asgi.py`). `close_old_connections` therefore never runs on the thread that owns the connection.
2. Every request leaks its PostgreSQL connection on the shared executor thread. When the server reaps the idle connection (`idle_session_timeout`), the next request on that thread 500s with `psycopg2.InterfaceError: connection already closed` / `server closed the connection unexpectedly`. `CONN_MAX_AGE` and `CONN_HEALTH_CHECKS` cannot fix this: no cleanup ever runs on the owning thread.

Verified in production (2026-08-31): with `CONN_MAX_AGE=0` set cluster-wide, kk still 500ed; `pg_stat_activity` showed request connections left idle on the web pod for minutes, and error log timestamps correlated with ~10-minute-old reaped connections.

## Changes

- `date/middleware.py`: new `CloseConnectionsMiddleware` — calls `close_old_connections()` in a `finally` after `get_response`, running on the same executor thread as the views. Registered outermost after WhiteNoise in `core/settings/common.py`.
- `core/settings/common.py`: `CONN_MAX_AGE` default 600 -> 0 (`DB_CONN_MAX_AGE` env override stays) as the same policy for paths outside the middleware and for long-lived processes, which can opt back in.
- `date/views.py`: `handler404` / `handler500` call `close_old_connections()` before rendering, so the error page never reuses a poisoned connection mid-render.
- `docker-compose.prod.yml`: web service pins `DB_CONN_MAX_AGE: "0"` (wins over `.env`).
- `.env.example`, `docs/dev/kubernetes.md` updated.
- Tests: middleware closes connections after success and after a raised view; error handlers close before rendering; settings guard pins the 0 default.

## Operator note

Per-site operator values currently set `extraEnv: DB_CONN_MAX_AGE: '60'`; those go to `'0'` (done, values-only, already rolled 2026-08-31). Note the values-only change does NOT fix the 500s: the middleware is the actual fix and ships with this image (auto-update rolls it to all sites).

## Testing

- `ruff check` / `ruff format --check` clean
- `manage.py check` clean
- `manage.py test date core`: 259 pass, 3 skipped