### PR TITLE
fix: restore DB connection reuse under ASGI (lifecycle middleware, CONN_MAX_AGE=600)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,10 @@ DATE_POSTGRESQL_VERSION=16
 DATE_DB_PASSWORD="password"
 
 # How long (seconds) a database connection is kept alive between requests.
-# 0 (default) closes it at request end: the web tier serves ASGI, where each
-# request runs on a per-request thread and persistent connections leak.
-# Long-lived processes (celery) may set a positive value.
-DB_CONN_MAX_AGE=0
+# 600 amortizes connection setup; the ASGI connection lifecycle is enforced
+# by date.middleware.ConnectionLifecycleMiddleware (signals alone cannot do
+# it under ASGI). 0 disables persistent connections.
+DB_CONN_MAX_AGE=600
 
 # [pgAdmin]
 

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -229,9 +229,10 @@ COMMON_CONTEXT_PROCESSORS = [
 MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
     # Must run on the same executor thread as the views: under ASGI the
-    # request_finished signal fires on the event loop thread, so Django's
-    # own close_old_connections never closes the thread-local connection.
-    'date.middleware.CloseConnectionsMiddleware',
+    # request_started/request_finished signals fire on the event loop
+    # thread, so Django's own close_old_connections never touches the
+    # thread-local connection. This enforces the lifecycle where it lives.
+    'date.middleware.ConnectionLifecycleMiddleware',
     'date.middleware.ServerTimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'date.middleware.LanguageStateMiddleware',
@@ -289,18 +290,18 @@ DATABASES = {
         'PASSWORD': env_alias('DATE_DB_PASSWORD', 'DB_PASSWORD', default=''),
         'HOST': env('DB_HOST', str, 'db'),
         'PORT': env('DB_PORT', int, 5432),
-        # Close the connection at the end of every request (0). The web tier
-        # serves ASGI (core.asgi): sync middleware and views run on asgiref
-        # executor threads, but the request_finished signal is sent on the
-        # event loop thread, so Django's close_old_connections never runs on
-        # the thread that owns the connection. CloseConnectionsMiddleware
-        # (outermost after WhiteNoise) closes it on the executor thread
-        # instead; 0 here is the same policy for paths outside the middleware
-        # and for long-lived processes unless they opt back in via
-        # DB_CONN_MAX_AGE (2026-08-31).
-        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 0),
-        # Re-verify persistent connections so they survive database restarts
-        # (only applies when DB_CONN_MAX_AGE is positive).
+        # Keep PostgreSQL connections alive between requests (600 s) to
+        # amortize connection setup, like the pre-ASGI WSGI behavior.
+        # Persistent connections are only safe because
+        # ConnectionLifecycleMiddleware runs close_old_connections on the
+        # executor thread that owns the connection at request start and end
+        # (under ASGI the request_started/request_finished signals fire on
+        # the event loop thread and never see it); without the middleware a
+        # positive CONN_MAX_AGE leaks backends and 500s with "connection
+        # already closed" (2026-08-31). The executor threads are long-lived
+        # and reused, so the pool stays bounded by threads, not requests.
+        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 600),
+        # Re-verify persistent connections so they survive database restarts.
         'CONN_HEALTH_CHECKS': True,
     }
 }

--- a/core/tests/test_database_settings.py
+++ b/core/tests/test_database_settings.py
@@ -15,9 +15,9 @@ class DatabaseSettingsTests(SimpleTestCase):
         default_db = common.DATABASES["default"]
 
         self.assertIn("CONN_MAX_AGE", default_db)
-        # The ASGI web tier runs each request on a per-request thread, so a
-        # persistent connection is left open on a thread that asgiref then
-        # destroys: it leaks PostgreSQL backends and 500s later requests.
-        # 0 closes the connection at request end on the same thread.
-        self.assertEqual(default_db["CONN_MAX_AGE"], 0)
+        # Persistent connections (600 s) amortize setup and are safe because
+        # ConnectionLifecycleMiddleware enforces the connection lifecycle on
+        # the executor thread that owns the connection; without it a
+        # positive CONN_MAX_AGE leaks backends under ASGI (2026-08-31).
+        self.assertEqual(default_db["CONN_MAX_AGE"], 600)
         self.assertTrue(default_db["CONN_HEALTH_CHECKS"])

--- a/date/middleware.py
+++ b/date/middleware.py
@@ -11,24 +11,30 @@ from django.utils.translation import get_language_from_request
 from .language_utils import resolve_language
 
 
-class CloseConnectionsMiddleware:
-    """Close the request thread's DB connection when the request finishes.
+class ConnectionLifecycleMiddleware:
+    """Enforce Django's DB connection lifecycle on the request's own thread.
 
-    Under Django's ASGI handler (web serves core.asgi), sync middleware and
-    views run on asgiref executor threads, while the ``request_finished``
-    signal is sent asynchronously on the event loop thread, so
-    ``close_old_connections`` never runs on the thread that owns the
-    connection. Every request therefore leaked its thread-local PostgreSQL
-    connection; once the server reaped the idle connection, the next request
-    on that thread 500ed with "connection already closed" (2026-08-31).
-    ``CONN_MAX_AGE`` cannot fix this (no cleanup ever runs on the owning
-    thread), so close unconditionally here, on the same thread as the view.
+    Under Django's ASGI handler (web serves core.asgi), the
+    ``request_started`` / ``request_finished`` signals are dispatched on the
+    event loop thread, so ``close_old_connections`` never runs on the
+    executor thread that owns the thread-local connection. Without it, a
+    connection is never closed and never health-checked: it lingers until
+    the server reaps it, then the next request on that thread 500s with
+    "connection already closed" (2026-08-31).
+
+    This middleware runs on the same thread-sensitive executor thread as
+    the sync middleware and views, and runs Django's normal lifecycle
+    there: before the request (drop obsolete/poisoned connections before
+    use) and after it (close if beyond CONN_MAX_AGE, otherwise keep for
+    reuse). Long-lived executor threads make reuse safe: the pool is
+    bounded by threads, not by requests.
     """
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
+        close_old_connections()
         try:
             response = self.get_response(request)
         finally:

--- a/date/tests.py
+++ b/date/tests.py
@@ -21,7 +21,7 @@ from django.utils import timezone, translation
 
 from core.admin import admin_site
 from date.language_utils import localize_url, strip_language_prefix
-from date.middleware import CloseConnectionsMiddleware
+from date.middleware import ConnectionLifecycleMiddleware
 from date.views import (
     _homepage_context,
     _homepage_version_key,
@@ -702,29 +702,31 @@ class LanguageSelectionTests(TestCase):
         self.assertNotIn('href=""', rendered)
 
 
-class CloseConnectionsMiddlewareTests(SimpleTestCase):
+class ConnectionLifecycleMiddlewareTests(SimpleTestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-    def test_closes_connection_after_response(self):
-        # Django's ASGI handler sends request_finished on the event loop
-        # thread, so close_old_connections must also run on the executor
-        # thread that owns the connection, via this middleware.
-        middleware = CloseConnectionsMiddleware(lambda request: HttpResponse("ok"))
+    def test_runs_lifecycle_around_response(self):
+        # Django's ASGI handler dispatches request_started/request_finished
+        # on the event loop thread, so close_old_connections must also run
+        # on the executor thread that owns the connection, via this
+        # middleware: once before the request (drop obsolete/poisoned
+        # connections) and once after (close or keep per CONN_MAX_AGE).
+        middleware = ConnectionLifecycleMiddleware(lambda request: HttpResponse("ok"))
         with patch("date.middleware.close_old_connections") as close:
             response = middleware(self.factory.get("/"))
         self.assertEqual(response.status_code, 200)
-        close.assert_called_once_with()
+        self.assertEqual(close.call_count, 2)
 
-    def test_closes_connection_when_view_raises(self):
+    def test_runs_lifecycle_when_view_raises(self):
         def boom(request):
             raise RuntimeError("boom")
 
-        middleware = CloseConnectionsMiddleware(boom)
+        middleware = ConnectionLifecycleMiddleware(boom)
         with patch("date.middleware.close_old_connections") as close:
             with self.assertRaises(RuntimeError):
                 middleware(self.factory.get("/"))
-        close.assert_called_once_with()
+        self.assertEqual(close.call_count, 2)
 
 
 class HomepageTemplateSelectionTests(TestCase):

--- a/date/views.py
+++ b/date/views.py
@@ -189,8 +189,8 @@ def set_language(request):
 
 def handler404(request, *args, **argv):
     # The ASGI error path can reuse a connection that died on a previous
-    # per-request thread; close before rendering so the error page itself
-    # does not 500 with "connection already closed".
+    # request on this thread; close obsolete/poisoned connections before
+    # rendering (healthy young connections are kept, so no extra setup).
     close_old_connections()
     response = render(request, 'core/404.html', {})
     response.status_code = 404

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,10 +19,9 @@ services:
     restart: always
     command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && exec gunicorn -k uvicorn_worker.UvicornWorker -w 3 --timeout 120 --max-requests 0 --max-requests-jitter 0 --bind=0.0.0.0 core.asgi:application"
     environment:
-      # ASGI web: close DB connections at request end (each request runs on
-      # a per-request thread, so persistent connections leak). Takes
-      # precedence over DB_CONN_MAX_AGE from .env.
-      DB_CONN_MAX_AGE: "0"
+      # Connection reuse (600 s) is safe with the ASGI lifecycle middleware;
+      # wins over DB_CONN_MAX_AGE from .env.
+      DB_CONN_MAX_AGE: "600"
     depends_on:
       - db
       - redis

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -329,19 +329,20 @@ Bucket requirements (one-time):
   so the `/ws` ingress/gateway route and the asgi Service are gone. Per-site
   operator values must drop their `asgi:` overrides; WebSocket traffic
   follows the normal `/` path to the web service.
-- DB connections close at the end of every request under the ASGI handler
-  (2026-08-31). Sync middleware and views run on asgiref executor threads,
-  but Django's ASGI handler sends the `request_finished` signal on the event
-  loop thread, so `close_old_connections` never runs on the thread that owns
-  the thread-local connection. Every request leaked its PostgreSQL
-  connection; once the server reaped the idle connection, the next request
-  on that thread 500ed with `InterfaceError: connection already closed`
-  (`CONN_MAX_AGE`/`CONN_HEALTH_CHECKS` cannot fix this, the cleanup never
-  runs on the owning thread). Fix: `date.middleware.CloseConnectionsMiddleware`
-  (outermost after WhiteNoise) closes the connection on the executor thread
-  after every request, `handler404`/`handler500` close before rendering the
-  error page, and `CONN_MAX_AGE = 0` is the settings default for paths
-  outside the middleware. Long-lived processes (celery, management commands)
-  may opt back into persistent connections via `DB_CONN_MAX_AGE`.
+- DB connections are reused between requests (CONN_MAX_AGE 600) with the
+  lifecycle enforced by `date.middleware.ConnectionLifecycleMiddleware`
+  (outermost after WhiteNoise, 2026-08-31). Under Django's ASGI handler,
+  sync middleware and views run on asgiref executor threads but the
+  `request_started` / `request_finished` signals are dispatched on the
+  event loop thread, so Django's own `close_old_connections` never runs on
+  the thread that owns the thread-local connection: without the middleware
+  a positive `CONN_MAX_AGE` leaks PostgreSQL backends and 500s with
+  `InterfaceError: connection already closed`. The middleware runs
+  `close_old_connections()` at request start and end on the owning thread,
+  so obsolete/poisoned connections are dropped before use and young ones
+  are kept for reuse (the executor threads are long-lived, so the pool is
+  bounded by threads, not requests). `handler404`/`handler500` also close
+  obsolete connections before rendering. Set `DB_CONN_MAX_AGE=0` to
+  disable persistence (per-request setup instead).
 - Media must stay on S3-compatible storage before web replicas are ever
   scaled up; a local RWO PVC would block scaling and failover.


### PR DESCRIPTION
## Summary

Restores DB connection reuse (the pre-ASGI behavior) now that the lifecycle problem is understood, eliminating the per-request connection-setup cost of #1153.

## Why this is safe now

The executor threads that run sync middleware/views under Django's ASGI handler are **long-lived and reused** (verified: a connection was reused 10 minutes after creation on the same thread). The only reason positive `CONN_MAX_AGE` leaked was that Django's `request_started`/`request_finished` signals are dispatched on the **event loop thread**, so `close_old_connections` never ran on the thread that owns the thread-local connection. Once the lifecycle runs on the owning thread, persistence is exactly the WSGI-era behavior.

## Changes

- `date/middleware.py`: `CloseConnectionsMiddleware` → `ConnectionLifecycleMiddleware`; now calls `close_old_connections()` at request **start** (drop obsolete/poisoned connections before use) and in a `finally` at request **end** (close if beyond `CONN_MAX_AGE`, else keep for reuse), both on the executor thread that owns the connection.
- `core/settings/common.py`: `CONN_MAX_AGE` default 0 → 600 (env `DB_CONN_MAX_AGE` stays), middleware entry renamed.
- `date/views.py`: `handler404`/`handler500` keep `close_old_connections()`; with 600 they keep healthy young connections, so error pages no longer churn an extra connection.
- `.env.example`, `docker-compose.prod.yml` (web pins 600), `docs/dev/kubernetes.md` updated.
- Tests: middleware runs the lifecycle twice per request (also when the view raises); settings guard pins 600.

## Safety properties (same as WSGI-era)

- Reuse within 600 s → setup cost amortized; pool bounded by executor threads (not requests) → no pool exhaustion.
- Reaped/stale connections are detected before use: Django 6 runs `close_if_health_check_failed()` (socket poll) on every first cursor of a request, and the start-of-request `close_old_connections` drops obsolete ones → no `connection already closed` 500s.
- `CONN_HEALTH_CHECKS` + `close_old_connections` behave as they did under WSGI, just dispatched by the middleware instead of the (loop-thread) signals.

## Operator note

Deploy order matters: ship this image first (site values can stay at `DB_CONN_MAX_AGE: '0'` = current behavior), then flip the values to `'600'` in a second commit. Do NOT flip values before the image is live: the old image has no lifecycle middleware and 600 would leak.

## Testing

- `ruff check` / `ruff format --check` clean; `manage.py check` clean
- `manage.py test date core`: 259 pass, 3 skipped
