### PR TITLE
feat: move DaTe address to Arken, Fabriksgatan 2

### DIFF
--- a/core/settings/date.py
+++ b/core/settings/date.py
@@ -46,8 +46,8 @@ CONTENT_VARIABLES = {
     "ASSOCIATION_NAME_SHORT": "DaTe",
     "EVENT_TEMPLATE_LOGO": "core/images/headerlogo.png",
     "ASSOCIATION_EMAIL": "date@abo.fi",
-    "ASSOCIATION_ADDRESS_L1": "Åbo Akademi, Agora",
-    "ASSOCIATION_ADDRESS_L2": "Vattenborgsvägen 5",
+    "ASSOCIATION_ADDRESS_L1": "Arken, B313",
+    "ASSOCIATION_ADDRESS_L2": "Fabriksgatan 2",
     "ASSOCIATION_POSTAL_CODE": "20500 Åbo",
     "SOCIAL_BUTTONS": [
         ["fa-facebook-f", "https://www.facebook.com/HerrKanin/"],


### PR DESCRIPTION
DaTe has moved to new premises. Updates the footer address in `core/settings/date.py`:

- L1: Arken, B313 (was `Åbo Akademi, Agora`)
- L2: Fabriksgatan 2 (was `Vattenborgsvägen 5`)

The full address now renders as:

```
Datateknologerna vid Åbo Akademi rf
Arken, B313
Fabriksgatan 2
20500 Åbo
```

No template changes needed; the footer reads `ASSOCIATION_ADDRESS_L1/L2` from `CONTENT_VARIABLES`. Verified with `manage.py check` and the footer shell template tests.