### PR TITLE
feat: enable language switcher and nested navs for Impuls

### DIFF
--- a/charts/date-website/values-impuls.example.yaml
+++ b/charts/date-website/values-impuls.example.yaml
@@ -7,6 +7,9 @@
 
 django:
   projectName: impuls
+  # Exposes Swedish and English in the language switcher; without this only
+  # Swedish is served.
+  enableLanguageFeatures: true
   allowedHosts:
     - impuls.example.org
   allowedOrigins:

--- a/docs/dev/staticpages.md
+++ b/docs/dev/staticpages.md
@@ -3,7 +3,8 @@
 ## Models
 - `StaticPageNav` stores menu categories. `use_category_url` shortcuts the category click to a custom `url`. `nav_element` defines ordering.
 - `StaticPage` is the CKEditor-backed page content. `members_only` gates access, and `slug` is unique (max 50 chars). `update()` stamps `modified_time`.
-- `StaticUrl` represents dropdown entries linked to a `StaticPageNav`. `logged_in_only` hides links from anonymous users, and `dropdown_element` controls ordering for the admin ordering widget.
+- `StaticUrl` represents dropdown entries linked to a `StaticPageNav`. `logged_in_only` hides links from anonymous users, and `dropdown_element` controls ordering for the admin ordering widget. A `parent` self-relation lets a `StaticUrl` carry nested children.
+- Nested navigation is rendered by `templates/common/core/header_nav_items.html` only when the header include passes `show_submenus=True` (pulterit, sf, impuls). Associations enabling it also need submenu styles in their header CSS, since the shared `core/css/header.css` has none.
 
 ## Views & Routing
 - `StaticPageView` (`staticpages/views.py`) is the only view. It loads the page by slug, checks `members_only`, and either renders `staticpages/staticpage.html` or redirects unauthenticated users to `/members/login`.

--- a/docs/dev/translations.md
+++ b/docs/dev/translations.md
@@ -15,8 +15,9 @@ Swedish (`sv`) is the default language. The exact non-default languages exposed 
 - Default language: `sv`
 - Shared locale catalogs in the repo: `sv`, `en`, `fi`
 - DaTe runtime languages: `sv`, `en`
+- Impuls runtime languages: `sv`, `en`
 - Some other associations still expose `fi`
-- Settings sources: `core/settings/common.py`, `core/settings/date.py`
+- Settings sources: `core/settings/common.py`, `core/settings/date.py`, `core/settings/impuls.py`
 
 Important settings:
 

--- a/static/impuls/core/css/header.css
+++ b/static/impuls/core/css/header.css
@@ -69,6 +69,42 @@ li .dropdown-menu {
     background-color: var(--navClickHighlight) !important;
 }
 
+.navbar-nav .dropdown-submenu > .dropdown-menu {
+    position: static;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background-color: transparent;
+    display: none;
+}
+
+.navbar-nav .dropdown-submenu:hover > .dropdown-menu,
+.navbar-nav .dropdown-submenu:focus-within > .dropdown-menu {
+    display: block;
+}
+
+.dropdown-submenu-toggle {
+    text-align: left;
+}
+
+.navbar-nav .dropdown-submenu > .dropdown-menu .dropdown-item {
+    padding-left: 2rem;
+    color: rgba(255, 255, 255, 0.88) !important;
+}
+
+.navbar-nav .dropdown-submenu > .dropdown-menu .dropdown-item:hover,
+.navbar-nav .dropdown-submenu > .dropdown-menu .dropdown-item:focus {
+    color: var(--textColorLight) !important;
+    background-color: var(--navHoverHighlight);
+}
+
+@media (max-width: 992px) {
+    .navbar-nav .dropdown-submenu > .dropdown-menu {
+        display: block;
+        margin-left: 0.5rem;
+    }
+}
+
 .language-dropdown-toggle {
     align-items: center;
     display: flex;

--- a/templates/impuls/core/header.html
+++ b/templates/impuls/core/header.html
@@ -9,3 +9,6 @@
          height="45">
   </a>
 {% endblock %}
+{% block header_nav_items %}
+  {% include "core/header_nav_items.html" with show_submenus=True %}
+{% endblock %}


### PR DESCRIPTION
Impuls already declared Swedish and English in its settings; this PR documents the runtime flag that exposes both in the language switcher, and enables nested (dropdown) navigation for the Impuls site.

- `templates/impuls/core/header.html`: pass `show_submenus=True` so `StaticUrl` children render as submenus, like pulterit and sf
- `static/impuls/core/css/header.css`: submenu styles (hover reveal on desktop, static blocks in the mobile offcanvas)
- `charts/date-website/values-impuls.example.yaml`: `enableLanguageFeatures: true` so the deployment exposes sv + en
- docs: note Impuls runtime languages and the `show_submenus` switch

Verified: `date-test staticpages.tests` (23 tests) passes, ruff/djlint clean, impuls settings expose sv + en with `ENABLE_LANGUAGE_FEATURES=true`.