### PR TITLE
feat: SF signup city label, membership choice, SF-only gulispass

### DIFF
--- a/core/settings/sf.py
+++ b/core/settings/sf.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from .common import *  # noqa
 
 TEMPLATES = build_templates('sf', parent_variants=('date',))
@@ -32,10 +34,12 @@ MEMBERS_SIGNUP_FIELDS = (
     'first_name',
     'last_name',
     'city',
+    'membership_type',
     'year_of_admission',
     'password',
 )
 MEMBERS_SIGNUP_DEFAULT_MEMBERSHIP_TYPE = 'Ordinarie medlem'
+MEMBERS_SIGNUP_CITY_LABEL = _('Hemort')
 MEMBERSHIP_SUBSCRIPTIONS = {
     'Ordinarie medlem': {
         'price': '15.00',

--- a/docs/admin/members.md
+++ b/docs/admin/members.md
@@ -12,14 +12,14 @@ Most people register themselves at `/members/signup/`. Those signups land in the
    - Set a temporary password. Tick **Send email** if you plan to notify the member manually (system does not send the password automatically).
 3. **Edit member**:
     - Update contact info, membership type, or group assignments as needed.
-    - On SF, tick **Gulispass utfört** after the member completes the required duty/pass. Until then, both ordinary and lifetime SF members are blocked from the picture and exam archives.
+    - On SF, tick **Gulispass utfört** after the member completes the required duty/pass. Until then, both ordinary and lifetime SF members are blocked from the picture and exam archives. The checkbox only appears on SF.
    - Use the actions menu to bulk **Activate** or **Deactivate** selected users.
    - `is_staff` is computed automatically from group membership (groups listed in `settings.STAFF_GROUPS`).
 4. **Password resets**: direct members to the "Forgot password" link on the login page, which uses the custom reset form.
 
 ## Membership Types
 - Found under **Members › Membership types**. Each type has a description and a `Behörighetsprofil` (Freshman, Ordinary, Supporting, Senior). These profiles are referenced by other apps (e.g., Polls, Archive) to enforce permissions.
-- SF signup and member administration offer **Ordinarie medlem** and **Evig SF:are**. Both use ordinary-member behavior outside the separate archive eligibility checkbox. Provisioning does not delete historical membership types that may still be attached to existing records.
+- SF signup asks applicants to choose **Ordinarie medlem** or **Evig SF:are**, and member administration offers the same two types. Both use ordinary-member behavior outside the separate archive eligibility checkbox. Provisioning does not delete historical membership types that may still be attached to existing records.
 - **Ordinarie medlem** costs 15 euro and expires after one year. **Evig SF:are** costs 40 euro and does not expire.
 
 ## SF Staff Access

--- a/docs/dev/members.md
+++ b/docs/dev/members.md
@@ -5,7 +5,7 @@
 - Fields include contact info, `membership_type` FK, `year_of_admission`, and helper props (`is_staff`, `full_name`, `active_payment`).
 - `MemberManager` (see `members/managers.py`) handles user creation.
 - `membership_type.permission_profile` ties into other apps for access control.
-- `archive_access_eligible` records completion of an association-specific duty or pass. It is only required for archive access when `ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY` is enabled.
+- `archive_access_eligible` records completion of an association-specific duty or pass. It is only required for archive access when `ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY` is enabled, and the admin forms only expose the checkbox when that setting is on (currently SF).
 
 ## Membership & Payments
 - `Subscription`: defines pricing and renewal cadence (`renewal_scale` + `renewal_period`).
@@ -17,7 +17,7 @@
 ## Forms
 - `MemberCreationForm` validates usernames via `USERNAME_VALIDATOR` (letters, underscores, hyphens). `AdminMemberUpdateForm` uses `ReadOnlyPasswordHashField` and disables password editing unless explicitly changed.
 - `SignUpForm` collects data for `/members/signup/`, including captcha validation and manual activation flow.
-- Associations can limit public signup fields with `MEMBERS_SIGNUP_FIELDS` and membership names with `MEMBERSHIP_TYPE_NAMES`. SF collects username, email, first and last name, city (`hemort`), admission year, and password; signup assigns `Ordinarie medlem` without exposing contact address, postcode, phone, country, or a membership selector.
+- Associations can limit public signup fields with `MEMBERS_SIGNUP_FIELDS` and membership names with `MEMBERSHIP_TYPE_NAMES`, and override the city field label with `MEMBERS_SIGNUP_CITY_LABEL`. SF collects username, email, first and last name, city (labeled `Hemort`), a membership type selector (`Ordinarie medlem` / `Evig SF:are`), admission year, and password; `MEMBERS_SIGNUP_DEFAULT_MEMBERSHIP_TYPE` still applies as a fallback when an association hides the selector. SF does not expose contact address, postcode, phone, or country.
 - `CustomPasswordResetForm` overrides `send_mail` to push messages through `send_email_task` (Celery-backed).
 
 ## Views
@@ -36,7 +36,7 @@
 - Admin-created members require a password of at least eight characters. Changing a payment to a non-expiring subscription clears any expiry date left by the previous subscription.
 - `UserAdmin` inherits from `auth_admin.UserAdmin` but swaps in custom forms and ordering.
 - Actions `activate_user`/`deactivate_user` bulk-toggle `is_active`.
-- SF exposes the `Gulispass utfört` archive eligibility checkbox in member add/change forms. Its post-migration provisioning creates or updates `Ordinarie medlem` and `Evig SF:are`, both with the ordinary permission profile, without deleting historical membership types. It also creates a yearly 15 euro subscription and a non-expiring 40 euro subscription, and synchronizes `styrelse`, `skattis`, `sekre`, `Inauta`, `webbansvarig`, and `admin` permissions repeatably.
+- SF exposes the `Gulispass utfört` archive eligibility checkbox in member add/change forms; other associations do not see the field because it is gated on `ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY`. Its post-migration provisioning creates or updates `Ordinarie medlem` and `Evig SF:are`, both with the ordinary permission profile, without deleting historical membership types. It also creates a yearly 15 euro subscription and a non-expiring 40 euro subscription, and synchronizes `styrelse`, `skattis`, `sekre`, `Inauta`, `webbansvarig`, and `admin` permissions repeatably.
 - SF `styrelse` receives all local app model permissions except the complete `members` app. `skattis`, `sekre`, `webbansvarig`, and `admin` receive all local app model permissions without superuser status. `Inauta` receives full permissions outside `members`, plus only view/change/delete permission for members whose type is `Evig SF:are`; it cannot access membership products or payments, create members, change membership types, or change member groups. Superusers remain unrestricted.
 - `SubscriptionPaymentAdmin` uses a custom `ModelChoiceField` to show human-readable member names.
 - Member-valued autocomplete fields on other apps (`Flag.solver`, `Event.author`, `Functionary.member`, `EventInvoice.participant`, `Post.author`, ...) work for editors who can add/change the referring object even when they lack `members.view_member`. `core.admin.ReferringObjectAutocompleteJsonView` (installed via `FixedLanguageAdminSite.autocomplete_view`) widens Django's default check, which otherwise requires view permission on the *related* model and returns an empty "no results" dropdown. `UserAdmin.get_queryset` still filters the returned rows, so `MEMBER_ADMIN_RESTRICTED_GROUP`/`MEMBER_ADMIN_RESTRICTED_MEMBERSHIP_TYPE` restrictions keep applying.

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -343,6 +343,9 @@ msgstr "Development"
 msgid "Production"
 msgstr "Production"
 
+#: core/settings/sf.py:40
+msgid "Hemort"
+msgstr "Home town"
 #: ctf/admin.py:22 events/admin.py:142 lucia/admin.py:30 news/admin.py:31
 #: polls/admin.py:54
 msgid "publicering"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -343,6 +343,9 @@ msgstr "Kehitys"
 msgid "Production"
 msgstr "Tuotanto"
 
+#: core/settings/sf.py:40
+msgid "Hemort"
+msgstr "Kotipaikka"
 #: ctf/admin.py:22 events/admin.py:142 lucia/admin.py:30 news/admin.py:31
 #: polls/admin.py:54
 msgid "publicering"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -342,6 +342,9 @@ msgstr "Utveckling"
 msgid "Production"
 msgstr "Produktion"
 
+#: core/settings/sf.py:40
+msgid "Hemort"
+msgstr "Hemort"
 #: ctf/admin.py:22 events/admin.py:142 lucia/admin.py:30 news/admin.py:31
 #: polls/admin.py:54
 msgid "publicering"

--- a/members/admin.py
+++ b/members/admin.py
@@ -85,11 +85,22 @@ else:
 
 @admin.register(Member)
 class UserAdmin(_UserAdminBase):
-    fieldsets = ((None, {'fields': AdminMemberUpdateForm.Meta.fields}),)
-    add_fieldsets = ((None, {'fields': MemberCreationForm.Meta.fields}),)
-
     form = AdminMemberUpdateForm
     add_form = MemberCreationForm
+
+    def get_fieldsets(self, request, obj=None):
+        # The archive eligibility ("Gulispass") checkbox only exists on
+        # associations that gate archive access on it; keep it out of both
+        # add and change fieldsets everywhere else, or the rendered admin
+        # form would look up a field the form no longer carries.
+        if obj is None:
+            fields = MemberCreationForm.Meta.fields
+        else:
+            fields = AdminMemberUpdateForm.Meta.fields
+        if not getattr(settings, 'ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY', False):
+            fields = tuple(name for name in fields if name != 'archive_access_eligible')
+        return ((None, {'fields': fields}),)
+
     list_display = (
         'username',
         'first_name',

--- a/members/forms.py
+++ b/members/forms.py
@@ -69,6 +69,8 @@ class MemberCreationForm(UnfoldFormMixin, forms.ModelForm):
         membership_names = getattr(settings, 'MEMBERSHIP_TYPE_NAMES', None)
         if membership_names:
             self.fields['membership_type'].queryset = MembershipType.objects.filter(name__in=membership_names)
+        if not getattr(settings, 'ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY', False):
+            self.fields.pop('archive_access_eligible', None)
 
     def save(self, commit=True):
         member = super().save(commit=False)
@@ -119,6 +121,8 @@ class AdminMemberUpdateForm(UnfoldFormMixin, forms.ModelForm):
         membership_names = getattr(settings, 'MEMBERSHIP_TYPE_NAMES', None)
         if membership_names:
             self.fields['membership_type'].queryset = MembershipType.objects.filter(name__in=membership_names)
+        if not getattr(settings, 'ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY', False):
+            self.fields.pop('archive_access_eligible', None)
 
     def save(self, commit=True):
         member = super().save(commit=False)
@@ -240,6 +244,10 @@ class SignUpForm(forms.ModelForm):
         membership_names = getattr(settings, 'MEMBERSHIP_TYPE_NAMES', None)
         if membership_names and 'membership_type' in self.fields:
             self.fields['membership_type'].queryset = MembershipType.objects.filter(name__in=membership_names)
+
+        city_label = getattr(settings, 'MEMBERS_SIGNUP_CITY_LABEL', None)
+        if city_label and 'city' in self.fields:
+            self.fields['city'].label = city_label
 
 
 class SubscriptionPaymentChoiceField(forms.ModelChoiceField):

--- a/members/tests.py
+++ b/members/tests.py
@@ -110,6 +110,32 @@ class UsernameValidatorTest(TestCase):
         self.assertNotIn('archive_access_eligible', MemberCreationForm().fields)
         self.assertNotIn('archive_access_eligible', AdminMemberUpdateForm().fields)
 
+    def test_signup_keeps_postanstalt_label_for_non_sf_associations(self):
+        self.assertEqual(str(SignUpForm().fields['city'].label), 'Postanstalt')
+
+    def test_gulispass_checkbox_is_absent_from_non_sf_admin_pages(self):
+        admin_user = Member.objects.create_superuser(
+            username='admintest',
+            email='admintest@example.com',
+            password='secret12345',
+            membership_type=self.membership_type,
+        )
+        member = Member.objects.create_user(
+            username='target',
+            email='target@example.com',
+            password='secret12345',
+            membership_type=self.membership_type,
+        )
+        self.client.force_login(admin_user, backend='members.backends.AuthBackend')
+
+        add_response = self.client.get(reverse('admin:members_member_add'))
+        self.assertEqual(add_response.status_code, 200)
+        self.assertNotContains(add_response, 'Gulispass')
+
+        change_response = self.client.get(reverse('admin:members_member_change', args=[member.pk]))
+        self.assertEqual(change_response.status_code, 200)
+        self.assertNotContains(change_response, 'Gulispass')
+
 
 class MemberCreationFormSaveTests(TestCase):
     @classmethod

--- a/members/tests.py
+++ b/members/tests.py
@@ -12,7 +12,7 @@ from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from two_factor.forms import TOTPDeviceForm
 
-from members.forms import MemberCreationForm, SignUpForm, SubscriptionPaymentForm
+from members.forms import AdminMemberUpdateForm, MemberCreationForm, SignUpForm, SubscriptionPaymentForm
 from members.models import ORDINARY_MEMBER, Member, MembershipType, Subscription, SubscriptionPayment
 from members.two_factor import (
     INFERRED_REDIRECT_SESSION_KEY,
@@ -105,6 +105,10 @@ class UsernameValidatorTest(TestCase):
         )
         self.assertFalse(form.is_valid())
         self.assertIn('username', form.errors)
+
+    def test_gulispass_checkbox_is_hidden_for_non_sf_associations(self):
+        self.assertNotIn('archive_access_eligible', MemberCreationForm().fields)
+        self.assertNotIn('archive_access_eligible', AdminMemberUpdateForm().fields)
 
 
 class MemberCreationFormSaveTests(TestCase):

--- a/members/tests_sf_access.py
+++ b/members/tests_sf_access.py
@@ -92,6 +92,62 @@ class SFSignupTests(TestCase):
         self.assertIn('archive_access_eligible', MemberCreationForm().fields)
         self.assertIn('archive_access_eligible', AdminMemberUpdateForm().fields)
 
+    def test_gulispass_checkbox_is_present_on_sf_admin_pages(self):
+        ordinary = MembershipType.objects.get(name='Ordinarie medlem')
+        admin_user = Member.objects.create_superuser(
+            username='admintest',
+            email='admintest@example.com',
+            password='secret12345',
+            membership_type=ordinary,
+        )
+        member = Member.objects.create_user(
+            username='target',
+            email='target@example.com',
+            password='secret12345',
+            membership_type=ordinary,
+        )
+        self.client.force_login(admin_user, backend='members.backends.AuthBackend')
+
+        add_response = self.client.get(reverse('admin:members_member_add'))
+        self.assertEqual(add_response.status_code, 200)
+        self.assertContains(add_response, 'Gulispass')
+
+        change_response = self.client.get(reverse('admin:members_member_change', args=[member.pk]))
+        self.assertEqual(change_response.status_code, 200)
+        self.assertContains(change_response, 'Gulispass')
+
+    @patch('members.views.validate_captcha', return_value=True)
+    def test_signup_without_membership_selector_falls_back_to_default_type(self, _validate_captcha):
+        ordinary = MembershipType.objects.get(name='Ordinarie medlem')
+        with override_settings(
+            MEMBERS_SIGNUP_FIELDS=(
+                'username',
+                'email',
+                'first_name',
+                'last_name',
+                'city',
+                'year_of_admission',
+                'password',
+            )
+        ):
+            self.assertNotIn('membership_type', SignUpForm().fields)
+            response = self.client.post(
+                reverse('members:signup'),
+                {
+                    'username': 'fallback-member',
+                    'email': 'fallback@example.com',
+                    'first_name': 'Fall',
+                    'last_name': 'Back',
+                    'city': 'Åbo',
+                    'year_of_admission': 2026,
+                    'password': 'safe-password',
+                },
+            )
+
+        self.assertEqual(response.status_code, 302)
+        member = Member.objects.get(username='fallback-member')
+        self.assertEqual(member.membership_type, ordinary)
+
     @patch('members.views.validate_captcha', return_value=True)
     def test_signup_saves_inactive_member_with_chosen_sf_type(self, _validate_captcha):
         ordinary = MembershipType.objects.get(name='Ordinarie medlem')

--- a/members/tests_sf_access.py
+++ b/members/tests_sf_access.py
@@ -18,10 +18,12 @@ SF_SETTINGS = {
         'first_name',
         'last_name',
         'city',
+        'membership_type',
         'year_of_admission',
         'password',
     ),
     'MEMBERS_SIGNUP_DEFAULT_MEMBERSHIP_TYPE': 'Ordinarie medlem',
+    'MEMBERS_SIGNUP_CITY_LABEL': 'Hemort',
     'MEMBERSHIP_SUBSCRIPTIONS': {
         'Ordinarie medlem': {
             'price': '15.00',
@@ -57,9 +59,24 @@ class SFSignupTests(TestCase):
         MembershipType.objects.update_or_create(name='Evig SF:are', defaults={'permission_profile': ORDINARY_MEMBER})
 
     def test_signup_exposes_only_sf_public_fields(self):
+        form = SignUpForm()
         self.assertEqual(
-            tuple(SignUpForm().fields),
-            ('username', 'email', 'first_name', 'last_name', 'city', 'year_of_admission', 'password'),
+            tuple(form.fields),
+            (
+                'username',
+                'email',
+                'first_name',
+                'last_name',
+                'city',
+                'membership_type',
+                'year_of_admission',
+                'password',
+            ),
+        )
+        self.assertEqual(str(form.fields['city'].label), 'Hemort')
+        self.assertEqual(
+            set(form.fields['membership_type'].queryset.values_list('name', flat=True)),
+            {'Ordinarie medlem', 'Evig SF:are'},
         )
 
     def test_admin_membership_choices_are_limited_to_sf_types(self):
@@ -71,10 +88,14 @@ class SFSignupTests(TestCase):
             set(AdminMemberUpdateForm().fields['membership_type'].queryset.values_list('name', flat=True)), expected
         )
 
+    def test_admin_forms_expose_gulispass_checkbox(self):
+        self.assertIn('archive_access_eligible', MemberCreationForm().fields)
+        self.assertIn('archive_access_eligible', AdminMemberUpdateForm().fields)
+
     @patch('members.views.validate_captcha', return_value=True)
-    def test_signup_saves_inactive_ordinary_member_with_only_sf_fields(self, _validate_captcha):
+    def test_signup_saves_inactive_member_with_chosen_sf_type(self, _validate_captcha):
         ordinary = MembershipType.objects.get(name='Ordinarie medlem')
-        MembershipType.objects.create(name='Ordinarie medlem', permission_profile=ORDINARY_MEMBER)
+        lifetime = MembershipType.objects.create(name='Evig SF:are', permission_profile=ORDINARY_MEMBER)
 
         response = self.client.post(
             reverse('members:signup'),
@@ -84,6 +105,7 @@ class SFSignupTests(TestCase):
                 'first_name': 'New',
                 'last_name': 'Member',
                 'city': 'Åbo',
+                'membership_type': lifetime.id,
                 'year_of_admission': 2026,
                 'password': 'safe-password',
             },
@@ -91,9 +113,10 @@ class SFSignupTests(TestCase):
 
         self.assertEqual(response.status_code, 302)
         member = Member.objects.get(username='new-sf-member')
-        self.assertEqual(member.membership_type, ordinary)
+        self.assertEqual(member.membership_type, lifetime)
         self.assertFalse(member.is_active)
         self.assertEqual(member.city, 'Åbo')
+        self.assertNotEqual(member.membership_type, ordinary)
 
 
 @override_settings(**SF_SETTINGS)


### PR DESCRIPTION
Three SF registration/member changes:

**City label**: SF signup now labels the city field `Hemort` instead of `Postanstalt`, via the new `MEMBERS_SIGNUP_CITY_LABEL` setting (other associations keep `Postanstalt`). New translatable string added to sv/en/fi catalogs.

**Membership type choice**: `membership_type` added to SF's `MEMBERS_SIGNUP_FIELDS`, so applicants pick `Ordinarie medlem` or `Evig SF:are` at registration. The `MEMBERS_SIGNUP_DEFAULT_MEMBERSHIP_TYPE` fallback still applies when a future association hides the selector.

**Gulispass only for SF**: `archive_access_eligible` ("Gulispass utfört") is popped from the member add/change admin forms unless `ARCHIVE_ACCESS_REQUIRES_ELIGIBILITY` is enabled, so the checkbox no longer appears for date/kk/biocum/impuls.

Docs updated (`docs/dev/members.md`, `docs/admin/members.md`). Verified: full test suite (483 tests, 4 pre-existing skips), ruff, ruff format, djlint, mypy, `validate_translations.py`, all green.