### PR TITLE
ci: reduce web startup workflow time

### DIFF
--- a/.github/workflows/web_startup.yaml
+++ b/.github/workflows/web_startup.yaml
@@ -115,16 +115,15 @@ jobs:
           done
 
           if [ "${logged_in}" -eq 1 ]; then
-            for attempt in 1 2 3; do
-              if docker pull "${CI_IMAGE}"; then
-                printf 'services:\n  init:\n    image: %s\n  web:\n    image: %s\n  celery:\n    image: %s\n' "${CI_IMAGE}" "${CI_IMAGE}" "${CI_IMAGE}" > docker-compose.ci.yml
-                echo "compose_file=docker-compose.yml:docker-compose.ci.yml" >> "${GITHUB_OUTPUT}"
-                exit 0
-              fi
-              if [ "${attempt}" -lt 3 ]; then
-                sleep $((attempt * 5))
-              fi
-            done
+            # The image for this SHA is published by the docker_build workflow,
+            # which starts at the same time and takes minutes, so a first run
+            # never finds it. Retrying with sleeps only delays the fallback
+            # build; a re-run after publication succeeds on the first attempt.
+            if docker pull "${CI_IMAGE}"; then
+              printf 'services:\n  init:\n    image: %s\n  web:\n    image: %s\n  celery:\n    image: %s\n' "${CI_IMAGE}" "${CI_IMAGE}" "${CI_IMAGE}" > docker-compose.ci.yml
+              echo "compose_file=docker-compose.yml:docker-compose.ci.yml" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
           fi
 
           echo "compose_file=docker-compose.yml" >> "${GITHUB_OUTPUT}"
@@ -150,12 +149,14 @@ jobs:
           docker-compose run --rm --no-deps -e TEST=1 ${{ matrix.extra_env }} web python /code/manage.py test
 
       - name: Build and run Docker Compose
+        if: matrix.label == 'default'
         run: |
           set -euo pipefail
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
           docker-compose up -d
 
       - name: Wait for web container
+        if: matrix.label == 'default'
         run: |
           set -euo pipefail
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"
@@ -172,10 +173,11 @@ jobs:
           exit 1
 
       - name: Check HTTP response
+        if: matrix.label == 'default'
         run: |
           set -euo pipefail
-          # The app is typically reachable ~12s after container is "running".
-          sleep 10
+          # The web container is "running" before Django serves; the retry
+          # loop below absorbs the remaining boot time.
           for attempt in $(seq 1 15); do
             if curl --retry 1 --retry-delay 1 --retry-connrefused --retry-all-errors --max-time 8 -sSf http://localhost:8000 >/dev/null 2>&1; then
               exit 0
@@ -186,7 +188,7 @@ jobs:
           exit 1
 
       - name: Print Docker diagnostics on failure
-        if: failure()
+        if: failure() && matrix.label == 'default'
         run: |
           set -euo pipefail
           export COMPOSE_FILE="${{ steps.prebuilt.outputs.compose_file }}"


### PR DESCRIPTION
## Summary

Trims duplicate and doomed work from `.github/workflows/web_startup.yaml` to shorten CI wall time and cut runner minutes. No app, admin, or template behavior changes.

### Changes

1. **Full-stack smoke test now runs once (default leg only).** The matrix's `unfold` leg ran an identical smoke test: `USE_UNFOLD` is passed only to the `manage.py test` invocation, never to `docker compose up`, so the second stack boot never exercised Unfold. Unfold-specific coverage is untouched, it lives in tests (`core/tests/test_admin_ui.py` is the only suite referencing `USE_UNFOLD`), and the unfold leg still builds the image and runs the full test suite with `USE_UNFOLD=True`.
2. **Prebuilt image is pulled once instead of three times.** `docker_build.yaml` starts at the same time as this workflow on a push and publishes the SHA tag only after a ~7.5 minute multi-arch build, so retries with 5s/10s sleeps could never succeed on a first run. A re-run after publication succeeds on the first attempt anyway.
3. **Fixed 10-second sleep removed from the HTTP check.** The curl retry loop (15 attempts, 2s apart, retry-on-refused) absorbs the remaining Django boot time after the wait step sees the container running.

### Measured context

From recent runs of this workflow (e.g. run 33685680041 on main): `test_and_ping (default)` ~4m, `(unfold)` ~3m30s, `variant_checks` ~2m40s, `lint` ~22s. After this change the unfold leg shortens to roughly its test time; the default leg is unchanged apart from the pull/sleep trims and remains the longest job.

### Considered and not done

- `manage.py test --parallel` is broken on this stack: Django's parallel runner fails to pickle `unittest.loader.ModuleSkipped` on Python 3.14 (reproduced locally with `core.settings.test`). Needs an upstream fix first.
- Sharing a GHA build cache between the three docker jobs would cut the ~50s cold builds, but the concurrent-writer and cache-scope design needs GitHub-side trials; proposed as follow-up.

CI runs on this PR will validate the gated steps.