### PR TITLE
fix: bound ASGI HTTP and database concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,10 @@ DATE_POSTGRESQL_VERSION=16
 # DB password
 DATE_DB_PASSWORD="password"
 
-# How long (seconds) a database connection is kept alive between requests.
-# 600 amortizes connection setup; the ASGI connection lifecycle is enforced
-# by date.middleware.ConnectionLifecycleMiddleware (signals alone cannot do
-# it under ASGI). 0 disables persistent connections.
-DB_CONN_MAX_AGE=600
+# Django 6 uses a per-request executor under ASGI, so web connections cannot
+# safely persist beyond the request. PgBouncer can amortize connection setup.
+DB_CONN_MAX_AGE=0
+ASGI_HTTP_CONCURRENCY=8
 
 # [pgAdmin]
 

--- a/.github/workflows/helm_chart.yaml
+++ b/.github/workflows/helm_chart.yaml
@@ -61,6 +61,25 @@ jobs:
             exit 1
           fi
 
+      - name: Check web concurrency bound
+        run: |
+          set -euo pipefail
+          rendered="$(helm template ci "${CHART_PATH}" \
+            --set django.secretKey=ci-secret-key \
+            --set database.password=ci-database-password \
+            --set web.asgi.maxConcurrentHttpRequestsPerWorker=12 \
+            --set-string extraEnv.ASGI_HTTP_CONCURRENCY=99 \
+            --set-string extraEnv.DB_CONN_MAX_AGE=300)"
+          grep -A1 -- '- name: ASGI_HTTP_CONCURRENCY' <<<"${rendered}" | grep -q 'value: "12"'
+          grep -A1 -- '- name: DB_CONN_MAX_AGE' <<<"${rendered}" | grep -q 'value: "0"'
+          if helm lint "${CHART_PATH}" \
+            --set django.secretKey=ci-secret-key \
+            --set database.password=ci-database-password \
+            --set web.asgi.maxConcurrentHttpRequestsPerWorker=0; then
+            echo "Chart accepted a non-positive HTTP concurrency limit."
+            exit 1
+          fi
+
       - name: Check migration Job name stays under 63 bytes
         run: |
           set -euo pipefail

--- a/charts/date-website/Chart.yaml
+++ b/charts/date-website/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: date-website
 description: Helm chart for running date-website on Kubernetes/k3s
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "prod"
 home: https://datateknologerna.org
 sources:

--- a/charts/date-website/templates/deployment-web.yaml
+++ b/charts/date-website/templates/deployment-web.yaml
@@ -91,6 +91,12 @@ spec:
                 --bind=0.0.0.0:8000 \
                 core.asgi:application
           env:
+            - name: ASGI_HTTP_CONCURRENCY
+              value: {{ .Values.web.asgi.maxConcurrentHttpRequestsPerWorker | quote }}
+            # Django 6 destroys its thread-sensitive executor after each ASGI
+            # request, so persistent thread-local connections cannot be reused.
+            - name: DB_CONN_MAX_AGE
+              value: "0"
             {{- if .Values.django.alumniSettingsSecretName }}
             - name: ALUMNI_SETTINGS
               valueFrom:

--- a/charts/date-website/values.schema.json
+++ b/charts/date-website/values.schema.json
@@ -278,6 +278,15 @@
           "type": "integer",
           "minimum": 0
         },
+        "asgi": {
+          "type": "object",
+          "properties": {
+            "maxConcurrentHttpRequestsPerWorker": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
         "terminationGracePeriodSeconds": {
           "type": "integer",
           "minimum": 1

--- a/charts/date-website/values.yaml
+++ b/charts/date-website/values.yaml
@@ -187,6 +187,11 @@ email:
   password: ''
 web:
   replicaCount: 1
+  asgi:
+    # Hard per-Gunicorn-worker bound for concurrent HTTP requests. WebSocket
+    # connections bypass this limit. Total HTTP capacity per pod is workers
+    # multiplied by this value.
+    maxConcurrentHttpRequestsPerWorker: 8
   service:
     type: ClusterIP
     port: 8000

--- a/core/asgi.py
+++ b/core/asgi.py
@@ -8,6 +8,34 @@ gunicorn (Uvicorn worker) targets this module in production, while the dev
 ``runserver`` command (daphne) uses ``ASGI_APPLICATION`` directly.
 """
 
-from core.routing import application
+import asyncio
 
-__all__ = ['application']
+from django.conf import settings
+
+from core import routing
+
+
+class HttpConcurrencyLimiter:
+    """Bound concurrent HTTP requests without consuming slots for WebSockets."""
+
+    def __init__(self, application, limit: int):
+        if limit < 1:
+            raise ValueError("ASGI_HTTP_CONCURRENCY must be at least 1")
+        self.application = application
+        self.limit = limit
+        self._semaphore = asyncio.Semaphore(limit)
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.application(scope, receive, send)
+
+        async with self._semaphore:
+            return await self.application(scope, receive, send)
+
+
+application = HttpConcurrencyLimiter(
+    routing.application,
+    settings.ASGI_HTTP_CONCURRENCY,  # type: ignore[misc]  # Custom Django setting.
+)
+
+__all__ = ['HttpConcurrencyLimiter', 'application']

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -228,10 +228,8 @@ COMMON_CONTEXT_PROCESSORS = [
 
 MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    # Must run on the same executor thread as the views: under ASGI the
-    # request_started/request_finished signals fire on the event loop
-    # thread, so Django's own close_old_connections never touches the
-    # thread-local connection. This enforces the lifecycle where it lives.
+    # Run connection cleanup on the same executor thread as the views. This
+    # remains defense-in-depth for exceptional ASGI disconnect/error paths.
     'date.middleware.ConnectionLifecycleMiddleware',
     'date.middleware.ServerTimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -251,7 +249,8 @@ SERVER_TIMING_ENABLED = DEVELOP
 
 
 WSGI_APPLICATION = 'core.wsgi.application'
-ASGI_APPLICATION = 'core.routing.application'
+ASGI_APPLICATION = 'core.asgi.application'
+ASGI_HTTP_CONCURRENCY = env('ASGI_HTTP_CONCURRENCY', int, 8)
 
 
 REDIS_SERVER = env("REDIS_SERVER", str, "redis://redis:6379")
@@ -290,17 +289,12 @@ DATABASES = {
         'PASSWORD': env_alias('DATE_DB_PASSWORD', 'DB_PASSWORD', default=''),
         'HOST': env('DB_HOST', str, 'db'),
         'PORT': env('DB_PORT', int, 5432),
-        # Keep PostgreSQL connections alive between requests (600 s) to
-        # amortize connection setup, like the pre-ASGI WSGI behavior.
-        # Persistent connections are only safe because
-        # ConnectionLifecycleMiddleware runs close_old_connections on the
-        # executor thread that owns the connection at request start and end
-        # (under ASGI the request_started/request_finished signals fire on
-        # the event loop thread and never see it); without the middleware a
-        # positive CONN_MAX_AGE leaks backends and 500s with "connection
-        # already closed" (2026-08-31). The executor threads are long-lived
-        # and reused, so the pool stays bounded by threads, not requests.
-        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 600),
+        # Django 6 creates a thread-sensitive executor per ASGI request. A
+        # persistent connection would remain attached to the destroyed thread
+        # and accumulate until PostgreSQL reaps it. Close web-safe connections
+        # at request completion; deployments may override this for non-ASGI
+        # processes that have a reusable thread lifecycle.
+        'CONN_MAX_AGE': env('DB_CONN_MAX_AGE', int, 0),
         # Re-verify persistent connections so they survive database restarts.
         'CONN_HEALTH_CHECKS': True,
     }

--- a/core/tests/test_asgi.py
+++ b/core/tests/test_asgi.py
@@ -1,13 +1,17 @@
+import asyncio
+
 from channels.testing import HttpCommunicator, WebsocketCommunicator
+from django.conf import settings
 from django.test import SimpleTestCase
 
 from core import routing
-from core.asgi import application
+from core.asgi import HttpConcurrencyLimiter, application
 
 
 class AsgiApplicationTests(SimpleTestCase):
-    def test_asgi_exposes_the_channels_application(self):
-        self.assertIs(application, routing.application)
+    def test_asgi_wraps_the_channels_application(self):
+        self.assertIs(application.application, routing.application)
+        self.assertEqual(application.limit, settings.ASGI_HTTP_CONCURRENCY)
 
     async def test_http_request_served_through_the_asgi_application(self):
         communicator = HttpCommunicator(
@@ -26,3 +30,91 @@ class AsgiApplicationTests(SimpleTestCase):
         connected, _ = await communicator.connect()
         self.assertTrue(connected)
         await communicator.disconnect()
+
+
+class HttpConcurrencyLimiterTests(SimpleTestCase):
+    async def test_bounds_concurrent_http_requests(self):
+        release = asyncio.Event()
+        two_entered = asyncio.Event()
+        active = 0
+        maximum_active = 0
+        calls = 0
+
+        async def wrapped(scope, receive, send):
+            nonlocal active, maximum_active, calls
+            calls += 1
+            active += 1
+            maximum_active = max(maximum_active, active)
+            if active == 2:
+                two_entered.set()
+            await release.wait()
+            active -= 1
+
+        limiter = HttpConcurrencyLimiter(wrapped, 2)
+        tasks = [asyncio.create_task(limiter({"type": "http"}, None, None)) for _ in range(3)]
+
+        await asyncio.wait_for(two_entered.wait(), timeout=1)
+        await asyncio.sleep(0)
+        self.assertEqual(calls, 2)
+
+        release.set()
+        await asyncio.gather(*tasks)
+        self.assertEqual(calls, 3)
+        self.assertEqual(maximum_active, 2)
+
+    async def test_releases_slot_after_exception(self):
+        calls = 0
+
+        async def wrapped(scope, receive, send):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("request failed")
+
+        limiter = HttpConcurrencyLimiter(wrapped, 1)
+        with self.assertRaises(RuntimeError):
+            await limiter({"type": "http"}, None, None)
+        await asyncio.wait_for(limiter({"type": "http"}, None, None), timeout=1)
+
+    async def test_releases_slot_after_cancellation(self):
+        entered = asyncio.Event()
+        calls = 0
+
+        async def wrapped(scope, receive, send):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                entered.set()
+                await asyncio.Event().wait()
+
+        limiter = HttpConcurrencyLimiter(wrapped, 1)
+        task = asyncio.create_task(limiter({"type": "http"}, None, None))
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        await asyncio.wait_for(limiter({"type": "http"}, None, None), timeout=1)
+
+    async def test_websocket_bypasses_http_limit(self):
+        http_entered = asyncio.Event()
+        release_http = asyncio.Event()
+        websocket_entered = asyncio.Event()
+
+        async def wrapped(scope, receive, send):
+            if scope["type"] == "http":
+                http_entered.set()
+                await release_http.wait()
+            else:
+                websocket_entered.set()
+
+        limiter = HttpConcurrencyLimiter(wrapped, 1)
+        http_task = asyncio.create_task(limiter({"type": "http"}, None, None))
+        await asyncio.wait_for(http_entered.wait(), timeout=1)
+        await asyncio.wait_for(limiter({"type": "websocket"}, None, None), timeout=1)
+        self.assertTrue(websocket_entered.is_set())
+        release_http.set()
+        await http_task
+
+    def test_rejects_non_positive_limit(self):
+        with self.assertRaisesMessage(ValueError, "ASGI_HTTP_CONCURRENCY must be at least 1"):
+            HttpConcurrencyLimiter(None, 0)

--- a/core/tests/test_database_settings.py
+++ b/core/tests/test_database_settings.py
@@ -15,9 +15,7 @@ class DatabaseSettingsTests(SimpleTestCase):
         default_db = common.DATABASES["default"]
 
         self.assertIn("CONN_MAX_AGE", default_db)
-        # Persistent connections (600 s) amortize setup and are safe because
-        # ConnectionLifecycleMiddleware enforces the connection lifecycle on
-        # the executor thread that owns the connection; without it a
-        # positive CONN_MAX_AGE leaks backends under ASGI (2026-08-31).
-        self.assertEqual(default_db["CONN_MAX_AGE"], 600)
+        # Django's ASGI handler destroys its per-request executor thread, so a
+        # persistent thread-local connection cannot be safely reused.
+        self.assertEqual(default_db["CONN_MAX_AGE"], 0)
         self.assertTrue(default_db["CONN_HEALTH_CHECKS"])

--- a/date/middleware.py
+++ b/date/middleware.py
@@ -14,20 +14,13 @@ from .language_utils import resolve_language
 class ConnectionLifecycleMiddleware:
     """Enforce Django's DB connection lifecycle on the request's own thread.
 
-    Under Django's ASGI handler (web serves core.asgi), the
-    ``request_started`` / ``request_finished`` signals are dispatched on the
-    event loop thread, so ``close_old_connections`` never runs on the
-    executor thread that owns the thread-local connection. Without it, a
-    connection is never closed and never health-checked: it lingers until
-    the server reaps it, then the next request on that thread 500s with
-    "connection already closed" (2026-08-31).
-
     This middleware runs on the same thread-sensitive executor thread as
     the sync middleware and views, and runs Django's normal lifecycle
-    there: before the request (drop obsolete/poisoned connections before
-    use) and after it (close if beyond CONN_MAX_AGE, otherwise keep for
-    reuse). Long-lived executor threads make reuse safe: the pool is
-    bounded by threads, not by requests.
+    there before and after the request. Normal Django ASGI request signals
+    also perform cleanup, but this outer layer protects exceptional
+    disconnect/error paths. Django 6 destroys the executor after each ASGI
+    request, so web deployments use CONN_MAX_AGE=0 rather than attempt to
+    persist its thread-local connection.
     """
 
     def __init__(self, get_response):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,9 +19,9 @@ services:
     restart: always
     command: /bin/bash -c "./wait-for-postgres.sh db:5432 && python /code/manage.py migrate --noinput && exec gunicorn -k uvicorn_worker.UvicornWorker -w 3 --timeout 120 --max-requests 0 --max-requests-jitter 0 --bind=0.0.0.0 core.asgi:application"
     environment:
-      # Connection reuse (600 s) is safe with the ASGI lifecycle middleware;
-      # wins over DB_CONN_MAX_AGE from .env.
-      DB_CONN_MAX_AGE: "600"
+      ASGI_HTTP_CONCURRENCY: "${ASGI_HTTP_CONCURRENCY:-8}"
+      # Wins over DB_CONN_MAX_AGE from .env for the ASGI web process.
+      DB_CONN_MAX_AGE: "0"
     depends_on:
       - db
       - redis

--- a/docs/dev/kubernetes.md
+++ b/docs/dev/kubernetes.md
@@ -350,20 +350,24 @@ Bucket requirements (one-time):
   so the `/ws` ingress/gateway route and the asgi Service are gone. Per-site
   operator values must drop their `asgi:` overrides; WebSocket traffic
   follows the normal `/` path to the web service.
-- DB connections are reused between requests (CONN_MAX_AGE 600) with the
-  lifecycle enforced by `date.middleware.ConnectionLifecycleMiddleware`
-  (outermost after WhiteNoise, 2026-08-31). Under Django's ASGI handler,
-  sync middleware and views run on asgiref executor threads but the
-  `request_started` / `request_finished` signals are dispatched on the
-  event loop thread, so Django's own `close_old_connections` never runs on
-  the thread that owns the thread-local connection: without the middleware
-  a positive `CONN_MAX_AGE` leaks PostgreSQL backends and 500s with
-  `InterfaceError: connection already closed`. The middleware runs
-  `close_old_connections()` at request start and end on the owning thread,
-  so obsolete/poisoned connections are dropped before use and young ones
-  are kept for reuse (the executor threads are long-lived, so the pool is
-  bounded by threads, not requests). `handler404`/`handler500` also close
-  obsolete connections before rendering. Set `DB_CONN_MAX_AGE=0` to
-  disable persistence (per-request setup instead).
+- Django 6 creates a thread-sensitive executor per ASGI HTTP request. The
+  chart bounds concurrent requests with
+  `web.asgi.maxConcurrentHttpRequestsPerWorker` (default 8); WebSockets do
+  not consume slots. With the default 3 Gunicorn workers, one pod therefore
+  runs at most 24 concurrent Django HTTP executor threads. Replica count and
+  rollout surge multiply that bound. A slot covers the complete ASGI HTTP
+  exchange, including request input and response streaming, so slow clients
+  consume capacity rather than bypass the memory/connection bound. Configure
+  finite ingress request and response timeouts accordingly.
+- Web deployments set `CONN_MAX_AGE=0`: a connection cannot be reused after
+  Django destroys its request executor, so keeping it open would strand the
+  thread-local backend until PostgreSQL reaps it. The outer
+  `date.middleware.ConnectionLifecycleMiddleware` runs
+  `close_old_connections()` on the owning thread at request start and end;
+  it remains defense-in-depth for exceptional disconnect/error paths beyond
+  Django's normal request-signal cleanup. Celery, migrations and
+  administrative sessions are outside the web concurrency bound. PgBouncer
+  is the recommended way to amortize PostgreSQL connection setup without
+  persistent application connections.
 - Media must stay on S3-compatible storage before web replicas are ever
   scaled up; a local RWO PVC would block scaling and failover.


### PR DESCRIPTION
## Summary

- bound concurrent HTTP requests to 8 per Gunicorn worker while allowing WebSockets to bypass the semaphore
- close web database connections at request completion so Django 6 per-request executor threads cannot strand idle PostgreSQL backends
- expose and validate the concurrency limit in chart 0.4.2 and Docker Compose
- correct the ASGI connection-lifecycle documentation and add deployment regression checks

With the default 3 Gunicorn workers, this caps one web pod at 24 concurrent Django HTTP request executors and approximately 24 request-owned database connections. Rolling updates can temporarily double that site-level allowance. This follows PR #1151, which reduces signup request cost but does not bound executor or connection growth.

The limit covers the complete HTTP exchange, including request input and response streaming. Slow clients therefore consume a slot instead of bypassing the resource bound. PgBouncer remains the recommended follow-up for amortizing PostgreSQL handshakes without persistent application connections.

## Validation

- `uv run python manage.py test --settings=core.settings.test` (643 passed, 7 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run djlint --check templates/`
- `helm lint charts/date-website`
- rendered chart verifies explicit web env overrides conflicting ConfigMap values
- chart schema rejects concurrency values below 1