### PR TITLE
fix: auto-reconnect the live attendee WebSocket

### DIFF
--- a/docs/dev/events.md
+++ b/docs/dev/events.md
@@ -46,9 +46,12 @@
 - Websocket notifications: `ws_send(slug, form, public_info)` broadcasts new
   registrations (except during tests). The slug is derived from the parent event
   if present. The client (`static/common/core/js/live-attendee-list.js`)
-  auto-reconnects with capped exponential backoff (1s doubling to 30s) after a
-  close or error, so worker recycling, deploys and network blips do not leave
-  the live list stale.
+  auto-reconnects with capped exponential backoff (1s doubling to 30s, reset
+  only after a connection has stayed open) after a close or error, so worker
+  recycling, deploys and network blips do not leave the live list stale.
+  Broadcasts received while disconnected are not replayed and the row counter
+  is local, so the list can show gaps after a longer outage until the page is
+  reloaded.
 - Billing hook: when `settings.EXPERIMENTAL_FEATURES` contains `event_billing`,
   `billing.handlers.handle_event_billing()` runs after a successful signup to
   generate invoices or send confirmations.

--- a/docs/dev/events.md
+++ b/docs/dev/events.md
@@ -45,7 +45,10 @@
   Turnstile responses in `cf-turnstile-response`.
 - Websocket notifications: `ws_send(slug, form, public_info)` broadcasts new
   registrations (except during tests). The slug is derived from the parent event
-  if present.
+  if present. The client (`static/common/core/js/live-attendee-list.js`)
+  auto-reconnects with capped exponential backoff (1s doubling to 30s) after a
+  close or error, so worker recycling, deploys and network blips do not leave
+  the live list stale.
 - Billing hook: when `settings.EXPERIMENTAL_FEATURES` contains `event_billing`,
   `billing.handlers.handle_event_billing()` runs after a successful signup to
   generate invoices or send confirmations.

--- a/static/common/core/js/live-attendee-list.js
+++ b/static/common/core/js/live-attendee-list.js
@@ -17,10 +17,10 @@ $(function() {
         ws_url = ws_scheme + '://' + window.location.host + '/ws' + window.location.pathname;
     }
 
-    // Only run where there is an attendee table to update (event pages with
-    // signup). Templates without the list markup (kk100 index pages, detail
-    // pages with sign_up off) must not open idle sockets.
-    if (!attendeeListEl && !document.getElementById('attendees')) {
+    // Only run where there is an attendee table to update. The #attendee-list
+    // wrapper also renders without a table (signup closed, list hidden for old
+    // events, kk100 index/anmalan pages), so the table itself is the gate.
+    if (!document.getElementById('attendees')) {
         return;
     }
 
@@ -30,6 +30,9 @@ $(function() {
     let closedByPage = false;
 
     function connect() {
+        if (closedByPage) {
+            return;
+        }
         if (reconnectTimer) {
             clearTimeout(reconnectTimer);
             reconnectTimer = null;
@@ -102,6 +105,10 @@ $(function() {
     // Stop retrying once the page is being left.
     window.addEventListener('beforeunload', function() {
         closedByPage = true;
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
         if (socket) {
             socket.close();
         }

--- a/static/common/core/js/live-attendee-list.js
+++ b/static/common/core/js/live-attendee-list.js
@@ -2,7 +2,7 @@
 $(function() {
 
     // for HTTPS also use WSS.
-    let ws_scheme = window.location.protocol === "https:" ? "wss" : "ws";
+    const ws_scheme = window.location.protocol === "https:" ? "wss" : "ws";
 
     let ws_url = ws_scheme + '://' + window.location.host + '/ws' + window.location.pathname;
 
@@ -10,34 +10,65 @@ $(function() {
         ws_url = ws_scheme + '://' + window.location.host + '/ws/' + document.getElementById('attendee-list').dataset.parentSlug + '/';
     }
 
-    let socket = new WebSocket(ws_url);
+    let socket = null;
+    let reconnectDelay = 1000;
+    let closedByPage = false;
 
-    socket.onmessage = function(e) {
-        const { fields, anonymous } = JSON.parse(e.data).data;
+    function connect() {
+        socket = new WebSocket(ws_url);
 
-        const list = $('#attendees tbody');
-        $('#attendees-header').css("display", "table-row");
-        $('#no-attendee').css("display", "none");
+        socket.onmessage = function(e) {
+            const { fields, anonymous } = JSON.parse(e.data).data;
 
-        if (fields) {
-            // includes header row and is thus equivalent to current amount of attendees + 1
-            const attendeeNumber = list.children().length;
-            const row = $('<tr>');
-            row.append($('<td>').text(attendeeNumber));
-            for (const [field, value] of fields) {
-                const cell = $('<td>');
-                // names of anonymous attendees use <i>
-                if (field === "user" && anonymous)
-                    cell.append($('<i>').text(value))
-                else
-                    cell.text(value);
-                row.append(cell);
+            const list = $('#attendees tbody');
+            $('#attendees-header').css("display", "table-row");
+            $('#no-attendee').css("display", "none");
+
+            if (fields) {
+                // includes header row and is thus equivalent to current amount of attendees + 1
+                const attendeeNumber = list.children().length;
+                const row = $('<tr>');
+                row.append($('<td>').text(attendeeNumber));
+                for (const [field, value] of fields) {
+                    const cell = $('<td>');
+                    // names of anonymous attendees use <i>
+                    if (field === "user" && anonymous)
+                        cell.append($('<i>').text(value))
+                    else
+                        cell.text(value);
+                    row.append(cell);
+                }
+                list.append(row);
             }
-            list.append(row);
-        }
-    };
-    socket.onclose = function(e) {
-        console.error('Event socket closed unexpectedly');
-    };
+        };
+
+        socket.onopen = function() {
+            reconnectDelay = 1000;
+        };
+
+        socket.onclose = function() {
+            if (closedByPage) {
+                return;
+            }
+            // Worker recycling, deploys and network blips close the socket;
+            // keep the live list refreshing instead of going stale silently.
+            // Retry with capped exponential backoff (1s doubling to 30s).
+            console.warn('Event socket closed; reconnecting in ' + reconnectDelay + 'ms');
+            setTimeout(connect, reconnectDelay);
+            reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+        };
+
+        socket.onerror = function() {
+            socket.close();
+        };
+    }
+
+    connect();
+
+    // Stop retrying once the page is being left.
+    window.addEventListener('beforeunload', function() {
+        closedByPage = true;
+        socket.close();
+    });
 
 });

--- a/static/common/core/js/live-attendee-list.js
+++ b/static/common/core/js/live-attendee-list.js
@@ -17,11 +17,28 @@ $(function() {
         ws_url = ws_scheme + '://' + window.location.host + '/ws' + window.location.pathname;
     }
 
+    // Only run where there is an attendee table to update (event pages with
+    // signup). Templates without the list markup (kk100 index pages, detail
+    // pages with sign_up off) must not open idle sockets.
+    if (!attendeeListEl && !document.getElementById('attendees')) {
+        return;
+    }
+
     let socket = null;
+    let reconnectTimer = null;
     let reconnectDelay = 1000;
     let closedByPage = false;
 
     function connect() {
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+        // Single-flight: never stack a second socket on an open/connecting
+        // one (a pending pageshow or retry timer can race a live socket).
+        if (socket && (socket.readyState === WebSocket.CONNECTING || socket.readyState === WebSocket.OPEN)) {
+            return;
+        }
         socket = new WebSocket(ws_url);
 
         socket.onmessage = function(e) {
@@ -50,7 +67,15 @@ $(function() {
         };
 
         socket.onopen = function() {
-            reconnectDelay = 1000;
+            const opened = socket;
+            // Reset the backoff only once the connection has proven stable: a
+            // worker that accepts and then dies (rolling deploy, crash loop)
+            // must keep backing off instead of retrying every second.
+            setTimeout(function() {
+                if (opened.readyState === WebSocket.OPEN) {
+                    reconnectDelay = 1000;
+                }
+            }, 5000);
         };
 
         socket.onclose = function() {
@@ -60,8 +85,10 @@ $(function() {
             // Worker recycling, deploys and network blips close the socket;
             // keep the live list refreshing instead of going stale silently.
             // Retry with capped exponential backoff (1s doubling to 30s).
+            // Broadcasts received while disconnected are not replayed and the
+            // local row counter is not re-based: reload the page to resync.
             console.warn('Event socket closed; reconnecting in ' + reconnectDelay + 'ms');
-            setTimeout(connect, reconnectDelay);
+            reconnectTimer = setTimeout(connect, reconnectDelay);
             reconnectDelay = Math.min(reconnectDelay * 2, 30000);
         };
 
@@ -75,7 +102,9 @@ $(function() {
     // Stop retrying once the page is being left.
     window.addEventListener('beforeunload', function() {
         closedByPage = true;
-        socket.close();
+        if (socket) {
+            socket.close();
+        }
     });
 
     // Back/forward cache restore keeps the page alive but the socket died

--- a/static/common/core/js/live-attendee-list.js
+++ b/static/common/core/js/live-attendee-list.js
@@ -4,10 +4,17 @@ $(function() {
     // for HTTPS also use WSS.
     const ws_scheme = window.location.protocol === "https:" ? "wss" : "ws";
 
-    let ws_url = ws_scheme + '://' + window.location.host + '/ws' + window.location.pathname;
+    const attendeeListEl = document.getElementById('attendee-list');
+    const parentSlug = attendeeListEl ? attendeeListEl.dataset.parentSlug : '';
 
-    if (document.getElementById('attendee-list').dataset.parentSlug) {
-        ws_url = ws_scheme + '://' + window.location.host + '/ws/' + document.getElementById('attendee-list').dataset.parentSlug + '/';
+    // Child events store their attendees on the parent and ws_send broadcasts
+    // to the parent slug's group, so both branches must hit the single
+    // ws/events/<slug>/ route (event routing only knows that path).
+    let ws_url;
+    if (parentSlug) {
+        ws_url = ws_scheme + '://' + window.location.host + '/ws/events/' + parentSlug + '/';
+    } else {
+        ws_url = ws_scheme + '://' + window.location.host + '/ws' + window.location.pathname;
     }
 
     let socket = null;
@@ -69,6 +76,17 @@ $(function() {
     window.addEventListener('beforeunload', function() {
         closedByPage = true;
         socket.close();
+    });
+
+    // Back/forward cache restore keeps the page alive but the socket died
+    // with the freeze; resume updates instead of staying permanently closed
+    // (closedByPage is still set from the beforeunload that preceded it).
+    window.addEventListener('pageshow', function() {
+        closedByPage = false;
+        if (!socket || socket.readyState === WebSocket.CLOSED) {
+            reconnectDelay = 1000;
+            connect();
+        }
     });
 
 });

--- a/templates/common/events/tomtejakt.html
+++ b/templates/common/events/tomtejakt.html
@@ -79,7 +79,9 @@
           <h2 id="sign-up">{% trans "Anmälning" %}</h2>
           {% include 'events/registration_state.html' %}
         </div>
-        <div class="content overflow-auto">
+        <div id="attendee-list"
+             class="content overflow-auto"
+             data-parent-slug="{{ event.parent.slug|default:'' }}">
           {% if event|show_attendee_list %}
             {% if event.sign_up_max_participants != 0 %}<p>{{ event.remaining_places|localized_remaining_places }}</p>{% endif %}
             <h2>{% trans "Anmälda" %}</h2>


### PR DESCRIPTION
## Summary

The event-page live attendee list opens one WebSocket and, until now, gave up permanently when it closed: `onclose` only logged an error, so the list silently went stale until a manual reload.

Sockets now close routinely: gunicorn worker recycling (being enabled in the operator deployment to bound the web pods' slow memory drift) and deploys terminate the worker holding the socket. This makes those drops self-healing.

## Changes

- reconnect with capped exponential backoff (1s doubling to 30s), reset on a successful open
- no retry stacking: one socket at a time, and no retry after the page unloads (`beforeunload` closes the socket and flags the page as leaving)
- `onerror` closes the socket so the close handler owns the retry path

## Validation

- `node --check static/common/core/js/live-attendee-list.js`
- logic unchanged on the message path (same handler body); UI behavior identical on a stable connection